### PR TITLE
Address release engineering review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,migration]"
+          pip install -e ".[dev]"
 
       - name: Run test suite (excluding E2E)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,migration]"
 
       - name: Run test suite (excluding E2E)
         run: |
@@ -52,7 +52,7 @@ jobs:
           pip install --no-deps /tmp/modelark-wheel/modelark-*.whl
           cd /tmp
           python -c "import tempfile; from pathlib import Path; from modelark import wishlist; from modelark.core import db; from modelark.web import server; d=tempfile.mkdtemp(); db.configure(d); c=db.connect(_bootstrapping=True); c.close(); assert wishlist.download()['max_24h_gb']==1000; assert (server.STATIC/'index.html').is_file(); assert db.DB_PATH.is_file() and Path(d) in db.DB_PATH.parents"
-          python -c "from importlib.metadata import metadata, requires; m=metadata('modelark'); r=requires('modelark') or []; assert m['License-Expression']=='Apache-2.0'; assert m['Project-URL']; assert not any(x.lower().startswith(('duckdb','hf-transfer')) and 'extra ==' not in x for x in r)"
+          python -c "import re; from importlib.metadata import metadata, requires; m=metadata('modelark'); r=requires('modelark') or []; name=lambda x: re.match(r'[A-Za-z0-9._-]+', x).group(0); canon=lambda x: re.sub(r'[-_.]+','-',name(x).lower()); assert m['License-Expression']=='Apache-2.0'; assert m['Project-URL']; assert not any(canon(x) in {'duckdb','hf-transfer'} and 'extra ==' not in x for x in r)"
 
   # Browser E2E — boots the portal on a seeded catalog and drives it headless with Playwright.
   # Separate job so the core suite stays zero-dep and fast; this one pays for a browser install.

--- a/modelark/core/db.py
+++ b/modelark/core/db.py
@@ -117,9 +117,6 @@ def connect(read_only: bool = False, _bootstrapping: bool = False) -> sqlite3.Co
         _migrate(con)
         _apply_schema(con)
         con.execute("PRAGMA foreign_keys=ON")
-        violations = con.execute("PRAGMA foreign_key_check").fetchall()
-        if violations:
-            raise RuntimeError(f"Catalog foreign-key check failed after startup: {violations[:8]}")
     except Exception:
         con.close()
         raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ zstd = [
 ]
 dev = [
     "build>=1.2",
+    "duckdb>=1.4",  # exercises the optional legacy-catalog migration in the full test suite
     "playwright>=1.52",
     "pytest>=8.3",
     "ruff>=0.11",

--- a/scripts/migrate_duckdb_to_sqlite.py
+++ b/scripts/migrate_duckdb_to_sqlite.py
@@ -46,43 +46,72 @@ def migrate(src_path: Path, dst_path: Path) -> dict:
             "DuckDB migration support is optional; install it with "
             "`pip install 'modelark[migration]'`."
         ) from exc
-    src = duckdb.connect(str(src_path))                     # read-write on the COPY → replays any .wal
-    db.CATALOG_DIR = dst_path.parent
-    db.DB_PATH = dst_path
-    dst_path.unlink(missing_ok=True)
-    Path(str(dst_path) + "-wal").unlink(missing_ok=True)
-    Path(str(dst_path) + "-shm").unlink(missing_ok=True)
-    dst = db.connect(_bootstrapping=True)                   # bootstraps the SQLite schema (skips the not-migrated guard)
-    sqlite_cols = {t: {r[1] for r in dst.execute(f"PRAGMA table_info({t})").fetchall()} for t in TABLES}
+    src = dst = None
+    destination_started = completed = False
+    sidecars = (dst_path, Path(str(dst_path) + "-wal"), Path(str(dst_path) + "-shm"))
+    try:
+        src = duckdb.connect(str(src_path))                 # read-write on the COPY → replays any .wal
+        db.CATALOG_DIR = dst_path.parent
+        db.DB_PATH = dst_path
+        for path in sidecars:
+            path.unlink(missing_ok=True)
+        destination_started = True
+        dst = db.connect(_bootstrapping=True)               # creates the constrained SQLite schema
+        sqlite_cols = {
+            t: {r[1] for r in dst.execute(f"PRAGMA table_info({t})").fetchall()}
+            for t in TABLES
+        }
 
-    report = {}
-    for t in TABLES:
-        src_cols = [c[0] for c in src.execute(f"SELECT * FROM {t} LIMIT 0").description]
-        use = [c for c in src_cols if c in sqlite_cols[t]]  # only columns present in BOTH schemas
-        dropped = [c for c in src_cols if c not in sqlite_cols[t]]
-        rows = src.execute(f"SELECT {', '.join(use)} FROM {t}").fetchall()
-        ph = ", ".join(["?"] * len(use))
-        dst.execute("BEGIN")
-        for r in rows:
-            values = [_cell(use[i], r[i]) for i in range(len(use))]
-            # Pre-DEC-039 Tier A used this model status for remote-header evidence. The constrained
-            # SQLite schema intentionally has no `verified` model state; preserve the row while
-            # narrowing the claim exactly as the in-place SQLite migration does.
-            if t == "models" and "status" in use:
-                status = use.index("status")
-                if values[status] == "verified":
-                    values[status] = "inspected"
-            dst.execute(f"INSERT INTO {t} ({', '.join(use)}) VALUES ({ph})", values)
-        dst.execute("COMMIT")
-        got = dst.execute(f"SELECT count(*) FROM {t}").fetchone()[0]
-        report[t] = {"src": len(rows), "dst": got, "dropped_cols": dropped}
-    # The destination schema is bootstrapped before source rows exist. Run row-level backfills once
-    # more after import (notably nested archived stored_relpath recovery); constraint migration is
-    # already complete and this call is idempotent.
-    db._migrate(dst)
-    src.close()
-    dst.close()
-    return report
+        report = {}
+        for t in TABLES:
+            src_cols = [c[0] for c in src.execute(f"SELECT * FROM {t} LIMIT 0").description]
+            use = [c for c in src_cols if c in sqlite_cols[t]]  # columns present in BOTH schemas
+            dropped = [c for c in src_cols if c not in sqlite_cols[t]]
+            rows = src.execute(f"SELECT {', '.join(use)} FROM {t}").fetchall()
+            ph = ", ".join(["?"] * len(use))
+            row_no, row_key = 0, "before first row"
+            try:
+                dst.execute("BEGIN")
+                for row_no, row in enumerate(rows, 1):
+                    values = [_cell(use[i], row[i]) for i in range(len(use))]
+                    row_key = f"{use[0]}={values[0]!r}" if use else "no shared columns"
+                    # Pre-DEC-039 Tier A mislabeled remote-header evidence as `verified`.
+                    if t == "models" and "status" in use:
+                        status = use.index("status")
+                        if values[status] == "verified":
+                            values[status] = "inspected"
+                    dst.execute(f"INSERT INTO {t} ({', '.join(use)}) VALUES ({ph})", values)
+                dst.execute("COMMIT")
+            except Exception as exc:
+                if dst.in_transaction:
+                    dst.execute("ROLLBACK")
+                raise RuntimeError(
+                    f"DuckDB migration failed in table {t!r} at source row {row_no} "
+                    f"({row_key[:160]}): {exc}. The partial SQLite destination was removed; "
+                    "the DuckDB source is unchanged."
+                ) from exc
+            got = dst.execute(f"SELECT count(*) FROM {t}").fetchone()[0]
+            report[t] = {"src": len(rows), "dst": got, "dropped_cols": dropped}
+        # The destination schema is bootstrapped before source rows exist. Run row-level backfills
+        # once more after import (notably nested archived stored_relpath recovery).
+        db._migrate(dst)
+        completed = True
+        return report
+    finally:
+        if dst is not None:
+            try:
+                if dst.in_transaction:
+                    dst.execute("ROLLBACK")
+            finally:
+                dst.close()
+        if src is not None:
+            src.close()
+        if destination_started and not completed:
+            for path in sidecars:
+                try:
+                    path.unlink(missing_ok=True)
+                except OSError:
+                    pass  # preserve the original migration diagnostic
 
 
 def main(argv: list[str]) -> int:

--- a/tests/test_db_sqlite.py
+++ b/tests/test_db_sqlite.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from unittest import mock
 
 from modelark.core import db
 
@@ -44,6 +45,28 @@ def test_schema_and_views(tmp_path):
     assert con.execute("PRAGMA foreign_keys").fetchone()[0] == 1
     assert con.execute("PRAGMA foreign_key_list(archived)").fetchall()
     con.close()
+
+
+def test_normal_connect_does_not_scan_every_foreign_key_row(tmp_path):
+    statements = []
+    real_connect = sqlite3.connect
+
+    class TracedConnection:
+        def __init__(self, con):
+            self._con = con
+
+        def execute(self, sql, *args):
+            statements.append(sql.strip().lower())
+            return self._con.execute(sql, *args)
+
+        def __getattr__(self, name):
+            return getattr(self._con, name)
+
+    with mock.patch.object(db.sqlite3, "connect", side_effect=lambda *a, **kw:
+                           TracedConnection(real_connect(*a, **kw))):
+        con = _fresh(tmp_path)
+        con.close()
+    assert "pragma foreign_key_check" not in statements, statements
 
 
 def test_upsert_touch_and_v_ui(tmp_path):

--- a/tests/test_duckdb_migration.py
+++ b/tests/test_duckdb_migration.py
@@ -1,0 +1,97 @@
+"""The optional DuckDB importer closes and cleans up on both success and constraint failure."""
+from __future__ import annotations
+
+import sqlite3
+import importlib.util
+from pathlib import Path
+
+import duckdb
+
+from modelark.core import db
+
+_SPEC = importlib.util.spec_from_file_location(
+    "migrate_duckdb_to_sqlite", Path(__file__).parents[1] / "scripts" / "migrate_duckdb_to_sqlite.py")
+assert _SPEC and _SPEC.loader
+_MIGRATOR = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MIGRATOR)
+migrate = _MIGRATOR.migrate
+
+
+_TABLES = (
+    "CREATE TABLE models(repo_id VARCHAR, status VARCHAR)",
+    "CREATE TABLE files(repo_id VARCHAR, rfilename VARCHAR, size_bytes BIGINT, format VARCHAR)",
+    "CREATE TABLE drives(drive_label VARCHAR, role VARCHAR, raid_backed BOOLEAN)",
+    "CREATE TABLE replicas(repo_id VARCHAR, rfilename VARCHAR, drive_label VARCHAR)",
+    "CREATE TABLE verifications(repo_id VARCHAR)",
+    "CREATE TABLE selection(repo_id VARCHAR)",
+    "CREATE TABLE archived(repo_id VARCHAR, rfilename VARCHAR, stored_name VARCHAR, "
+    "drive_label VARCHAR, compressed BOOLEAN)",
+    "CREATE TABLE fetch_events(repo_id VARCHAR, outcome VARCHAR)",
+)
+
+
+def _legacy(path: Path):
+    con = duckdb.connect(str(path))
+    for statement in _TABLES:
+        con.execute(statement)
+    return con
+
+
+def test_valid_duckdb_migration_applies_backfills_and_constraints(tmp_path):
+    src, dst = tmp_path / "legacy.duckdb", tmp_path / "catalog.sqlite"
+    old_data, old_db = db.CATALOG_DIR, db.DB_PATH
+    con = _legacy(src)
+    con.execute("INSERT INTO models VALUES ('org/model','verified')")
+    con.execute("INSERT INTO files VALUES "
+                "('org/model','weights/model.safetensors',10,'safetensors')")
+    con.execute("INSERT INTO drives VALUES ('drive-01','primary',false)")
+    con.execute("INSERT INTO archived VALUES "
+                "('org/model','weights/model.safetensors','model.safetensors.znn','drive-01',true)")
+    con.close()
+    try:
+        report = migrate(src, dst)
+        out = sqlite3.connect(str(dst))
+        assert out.execute("SELECT status,numcopies FROM models").fetchone() == ("inspected", 1)
+        assert out.execute("SELECT stored_relpath FROM archived").fetchone()[0] == \
+            "weights/model.safetensors.znn"
+        assert out.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert all(row["src"] == row["dst"] for row in report.values())
+        out.close()
+    finally:
+        db.CATALOG_DIR, db.DB_PATH = old_data, old_db
+
+
+def test_orphaned_duckdb_row_rolls_back_closes_and_removes_partial_destination(tmp_path):
+    src, dst = tmp_path / "orphan.duckdb", tmp_path / "catalog.sqlite"
+    old_data, old_db = db.CATALOG_DIR, db.DB_PATH
+    con = _legacy(src)
+    con.execute("INSERT INTO selection VALUES ('missing/model')")
+    con.close()
+    try:
+        try:
+            migrate(src, dst)
+            raise AssertionError("an orphaned selection must fail migration")
+        except RuntimeError as exc:
+            message = str(exc)
+            assert "table 'selection'" in message and "source row 1" in message, message
+            assert "repo_id='missing/model'" in message and "source is unchanged" in message, message
+        assert not dst.exists(), "a partial constrained catalog must not survive a failed import"
+        # Both connections are closed: the source can be reopened and the destination recreated.
+        reopened = duckdb.connect(str(src), read_only=True)
+        assert reopened.execute("SELECT repo_id FROM selection").fetchone()[0] == "missing/model"
+        reopened.close()
+        probe = sqlite3.connect(str(dst), timeout=0.1)
+        probe.execute("BEGIN IMMEDIATE")
+        probe.execute("ROLLBACK")
+        probe.close()
+    finally:
+        db.CATALOG_DIR, db.DB_PATH = old_data, old_db
+
+
+if __name__ == "__main__":
+    import tempfile
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn(Path(tempfile.mkdtemp()))
+            print(f"ok  {name}")
+    print("all passed")


### PR DESCRIPTION
## Summary

- make DuckDB-to-SQLite imports transactional per table and remove partial destinations on failure
- report the failing source table, row, and primary identifier while preserving the source database
- stop running a full-catalog foreign-key scan on every writable database connection
- canonicalize dependency names in the wheel metadata guard and exercise the optional migration dependency in CI
- add real DuckDB migration coverage for successful backfills and orphan-row cleanup

## Why

This follows up on three actionable Greptile findings from merged PR #5. The importer previously left failure cleanup implicit, normal startup performed an O(child rows) integrity scan, and the metadata guard did not account for PEP 503-equivalent dependency spellings such as `hf_transfer`.

## Validation

- complete standalone test suite, including HTTP security tests
- Playwright portal end-to-end test
- `ruff check modelark scripts tests`
- Python compilation for `modelark`, `scripts`, and `tests`
- `git diff --check`
