### PR TITLE
Address Phase 3 Greptile findings

### DIFF
--- a/modelark/capacity.py
+++ b/modelark/capacity.py
@@ -46,6 +46,7 @@ class FreeEvidence(str, Enum):
 class FailureCode(str, Enum):
     CAPACITY_DURABLE_SHORT = "CAPACITY_DURABLE_SHORT"
     CAPACITY_WORKSPACE_SHORT = "CAPACITY_WORKSPACE_SHORT"
+    TARGET_DRIVE_CHANGED = "TARGET_DRIVE_CHANGED"
     TARGET_TIER_MISSING = "TARGET_TIER_MISSING"
     GRAPH_INVARIANT = "GRAPH_INVARIANT"
 
@@ -493,6 +494,31 @@ def preflight_file(
         shortfall_bytes=required - drive.usable_now,
         evidence=drive.free_evidence,
         actions=("free_target_space", "add_eligible_drive", "replan"),
+    )
+
+
+def target_drive_changed_failure(
+    task: AssignedTask,
+    mode: CapacityMode,
+) -> CapacityFailure:
+    """Typed stale-snapshot evidence when a task target leaves its Plan before execution."""
+    durable = task.budget.durable_for(mode)
+    workspace = task.budget.workspace_for(mode)
+    required = durable + workspace
+    return CapacityFailure(
+        code=FailureCode.TARGET_DRIVE_CHANGED,
+        capacity_mode=mode,
+        requirement_id=task.requirement_id,
+        task_ids=(task.task_id,),
+        target_tier=("replica" if task.kind == TaskKind.REPLICATE else "primary"),
+        eligible_drives=(task.target_drive,),
+        required_bytes=required,
+        available_bytes=0,
+        safety_floor_bytes=0,
+        workspace_bytes=workspace,
+        shortfall_bytes=required,
+        evidence=None,
+        actions=("reconcile_plan", "restore_target_drive_to_plan"),
     )
 
 

--- a/modelark/fill.py
+++ b/modelark/fill.py
@@ -220,6 +220,7 @@ def _stop_terminal() -> dict:
 
 def _file_guard(ctx, plan_id: str, provisioning: str, task: capacity.AssignedTask):
     budgets = {item.rfilename: item for item in task.budget.file_budgets}
+    mode = capacity.mode_from_legacy(provisioning)
 
     def before_file(repo_id, item):
         with ctx.lock:
@@ -231,19 +232,27 @@ def _file_guard(ctx, plan_id: str, provisioning: str, task: capacity.AssignedTas
             path = register.archive_path(ctx.con, task.target_drive)
         if path is None:
             with ctx.lock:
-                drive = next(entry for entry in capacity.inspect_drives(ctx.con, plan_id)
-                             if entry.drive_label == task.target_drive)
+                drive = next((
+                    entry for entry in capacity.inspect_drives(ctx.con, plan_id)
+                    if entry.drive_label == task.target_drive
+                ), None)
         else:
             try:
                 free = shutil.disk_usage(path).free
             except OSError:
                 free = 0
             with ctx.lock:
-                drive = next(entry for entry in capacity.inspect_drives(
-                    ctx.con, plan_id, live_free_by_drive={task.target_drive: free}
-                ) if entry.drive_label == task.target_drive)
+                drive = next((
+                    entry for entry in capacity.inspect_drives(
+                        ctx.con, plan_id, live_free_by_drive={task.target_drive: free}
+                    ) if entry.drive_label == task.target_drive
+                ), None)
+        if drive is None:
+            raise fetch.CapacityPreflightError(
+                capacity.target_drive_changed_failure(task, mode)
+            )
         failure = capacity.preflight_file(
-            drive, budgets[item.rfilename], capacity.mode_from_legacy(provisioning),
+            drive, budgets[item.rfilename], mode,
             requirement_id=task.requirement_id,
             task_id=task.task_id,
         )

--- a/tests/test_replan.py
+++ b/tests/test_replan.py
@@ -197,6 +197,30 @@ def test_reconcile_uses_and_closes_dedicated_read_connection():
     assert read_con.closed
 
 
+def test_file_guard_types_a_target_removed_after_reconciliation(tmp_path):
+    con, _, _, _ = _executor_harness()
+    ctx = fetch.RunCtx(con=con)
+    snapshot = fill._reconcile(ctx, "ark", "uncompressed", None)
+    task = next(item for item in snapshot.ledger.tasks if item.kind == reconcile.TaskKind.FETCH)
+    manifest_item = next(
+        item for item in snapshot.graph.manifests[task.repo_id]
+        if item.rfilename in task.budget.missing_files
+    )
+    guard = fill._file_guard(ctx, "ark", "uncompressed", task)
+
+    for archive_path in (None, tmp_path):
+        with mock.patch.object(fill.register, "archive_path", return_value=archive_path), \
+             mock.patch.object(fill.capacity, "inspect_drives", return_value=()):
+            try:
+                guard(task.repo_id, manifest_item)
+                raise AssertionError("a stale target must be a typed re-plan boundary")
+            except fetch.CapacityPreflightError as exc:
+                failure = exc.failure
+        assert failure.code == capacity.FailureCode.TARGET_DRIVE_CHANGED
+        assert failure.requirement_id == task.requirement_id
+        assert failure.actions == ("reconcile_plan", "restore_target_drive_to_plan")
+
+
 def test_reconciled_executor_bounds_failed_task_retries():
     con, calls, fake_run, fake_replica = _executor_harness(failed={"b"})
     with mock.patch.object(fill.fetch, "run", side_effect=fake_run), \

--- a/tests/test_web_xss.py
+++ b/tests/test_web_xss.py
@@ -96,7 +96,8 @@ def test_fill_poll_uses_shared_terminal_classifier_and_modal() -> None:
     assert '"plan-capacity-stop": "🟠 capacity changed"' in app
     assert "window.MA.showFillTerminal = show" in app
     assert "MA.isFillTerminal(s.status)" in fill
-    assert fill.count("announceTerminal(s)") >= 3, "load, poll, and refresh must announce terminals"
+    call_sites = [line.strip() for line in fill.splitlines() if line.strip() == "announceTerminal(s);"]
+    assert len(call_sites) == 2, "both poll and refresh/load must announce terminals"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- classify a task target removed between reconciliation and file execution as a typed TARGET_DRIVE_CHANGED preflight result
- re-enter reconciliation immediately with explicit restore/re-plan actions instead of spending generic fetch retries on StopIteration
- make the Fill terminal regression count only real announceTerminal call lines

## Root cause

The per-file guard assumed its stale assigned target still appeared in the active Plan. A concurrent plan edit could violate that assumption after snapshot placement. The frontend assertion also counted the function declaration, weakening its protection against a removed call site.

## Verification

- 190 pytest tests passed
- standalone executor test passed
- Ruff passed
- direct regression covers both mounted/live-free and offline/snapshot target-removal branches