### PR TITLE
Disambiguate legacy catalog migration

### DIFF
--- a/docs/legacy-cutover.md
+++ b/docs/legacy-cutover.md
@@ -66,7 +66,9 @@ From the canonical checkout, first run inspection mode with the agreed paths:
 
 Review the detected engine, source catalog, table counts, runtime config list, and destination. If
 both SQLite and DuckDB are present, stop and determine which one the service actually opened; the tool
-refuses to guess. DuckDB input requires `.[migration]`.
+refuses to guess. After proving the active engine from the stopped process inventory, rerun inspection
+with `--source-kind sqlite` or `--source-kind duckdb`; that explicit selection is recorded in both
+manifests. DuckDB input requires `.[migration]`.
 
 After review, execute against the stopped source:
 
@@ -75,6 +77,7 @@ After review, execute against the stopped source:
   --source-data-dir <LEGACY_DATA_DIR> \
   --destination-data-dir <NEW_DATA_DIR> \
   --backup-root <BACKUP_ROOT> \
+  --source-kind <sqlite-or-duckdb> \
   --execute --confirm-stopped MODELARK-STOPPED
 ```
 

--- a/scripts/migrate_legacy_runtime.py
+++ b/scripts/migrate_legacy_runtime.py
@@ -69,12 +69,19 @@ def _paths(source: Path, destination: Path, backup_root: Path) -> tuple[Path, Pa
     return source, destination, backup_root
 
 
-def _source_kind(source_dir: Path) -> tuple[str, Path]:
+def _source_kind(source_dir: Path, requested_kind: str | None = None) -> tuple[str, Path]:
     sqlite_path = source_dir / "catalog.sqlite"
     duckdb_path = source_dir / "catalog.duckdb"
     found = [("sqlite", sqlite_path)] if sqlite_path.is_file() else []
     if duckdb_path.is_file():
         found.append(("duckdb", duckdb_path))
+    if requested_kind is not None:
+        requested = dict(found).get(requested_kind)
+        if requested is None:
+            raise RuntimeError(
+                f"explicit {requested_kind} source requested, but its catalog does not exist in "
+                f"{source_dir}")
+        return requested_kind, requested
     if not found:
         raise RuntimeError(
             f"no catalog.sqlite or catalog.duckdb found in source data directory {source_dir}")
@@ -124,13 +131,15 @@ def _duckdb_inventory(path: Path) -> dict:
         con.close()
 
 
-def inspect(source_data_dir: Path, destination_data_dir: Path, backup_root: Path) -> dict:
+def inspect(source_data_dir: Path, destination_data_dir: Path, backup_root: Path,
+            source_kind: str | None = None) -> dict:
     source, destination, backups = _paths(source_data_dir, destination_data_dir, backup_root)
-    kind, catalog = _source_kind(source)
+    kind, catalog = _source_kind(source, source_kind)
     inventory = _sqlite_inventory(catalog) if kind == "sqlite" else _duckdb_inventory(catalog)
     return {
         "mode": "inspection-only",
         "source_kind": kind,
+        "source_selection": "explicit" if source_kind else "automatic",
         "source_catalog": str(catalog),
         "destination_data_dir": str(destination),
         "backup_root": str(backups),
@@ -249,12 +258,13 @@ def _publish_current_catalog(source_kind: str, backup_catalog: Path, stage: Path
 
 
 def execute(source_data_dir: Path, destination_data_dir: Path, backup_root: Path,
-            confirmation: str, run_id: str | None = None) -> dict:
+            confirmation: str, run_id: str | None = None,
+            source_kind: str | None = None) -> dict:
     if confirmation != _CONFIRMATION:
         raise RuntimeError(
             f"execution requires --confirm-stopped {_CONFIRMATION} after every ModelArk writer is stopped")
     source, destination, backups = _paths(source_data_dir, destination_data_dir, backup_root)
-    kind, catalog = _source_kind(source)
+    kind, catalog = _source_kind(source, source_kind)
     if destination.exists():
         raise RuntimeError(f"destination already exists; refusing to overwrite {destination}")
     run_id = run_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -272,6 +282,7 @@ def execute(source_data_dir: Path, destination_data_dir: Path, backup_root: Path
         "status": "started", "run_id": run_id,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "source_kind": kind, "source_catalog": str(catalog),
+        "source_selection": "explicit" if source_kind else "automatic",
         "destination_data_dir": str(destination), "backup_dir": str(run_backup),
     }
     guard = None
@@ -338,6 +349,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--source-data-dir", type=Path, required=True)
     parser.add_argument("--destination-data-dir", type=Path, required=True)
     parser.add_argument("--backup-root", type=Path, required=True)
+    parser.add_argument(
+        "--source-kind", choices=("sqlite", "duckdb"),
+        help="explicit active catalog engine; required to disambiguate when both catalogs exist",
+    )
     parser.add_argument("--execute", action="store_true",
                         help="create backup and publish a new migrated destination (default: inspect only)")
     parser.add_argument("--confirm-stopped", metavar="TEXT",
@@ -347,11 +362,12 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.execute:
             result = execute(args.source_data_dir, args.destination_data_dir, args.backup_root,
-                             args.confirm_stopped or "", args.run_id)
+                             args.confirm_stopped or "", args.run_id, args.source_kind)
         else:
             if args.confirm_stopped or args.run_id:
                 parser.error("--confirm-stopped/--run-id are valid only with --execute")
-            result = inspect(args.source_data_dir, args.destination_data_dir, args.backup_root)
+            result = inspect(args.source_data_dir, args.destination_data_dir, args.backup_root,
+                             args.source_kind)
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0
     except RuntimeError as exc:

--- a/scripts/migrate_legacy_runtime.py
+++ b/scripts/migrate_legacy_runtime.py
@@ -38,6 +38,7 @@ from modelark.core import db
 _CONFIRMATION = "MODELARK-STOPPED"
 _RUNTIME_CONFIGS = ("library.json",)
 _RUN_ID = re.compile(r"^[A-Za-z0-9_.-]+$")
+_SOURCE_KINDS = ("sqlite", "duckdb")
 
 
 def _sha256(path: Path) -> str:
@@ -76,6 +77,9 @@ def _source_kind(source_dir: Path, requested_kind: str | None = None) -> tuple[s
     if duckdb_path.is_file():
         found.append(("duckdb", duckdb_path))
     if requested_kind is not None:
+        if requested_kind not in _SOURCE_KINDS:
+            raise RuntimeError(
+                f"unknown source kind {requested_kind!r}; must be 'sqlite' or 'duckdb'")
         requested = dict(found).get(requested_kind)
         if requested is None:
             raise RuntimeError(
@@ -350,7 +354,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--destination-data-dir", type=Path, required=True)
     parser.add_argument("--backup-root", type=Path, required=True)
     parser.add_argument(
-        "--source-kind", choices=("sqlite", "duckdb"),
+        "--source-kind", choices=_SOURCE_KINDS,
         help="explicit active catalog engine; required to disambiguate when both catalogs exist",
     )
     parser.add_argument("--execute", action="store_true",

--- a/tests/test_legacy_runtime_migration.py
+++ b/tests/test_legacy_runtime_migration.py
@@ -72,6 +72,36 @@ def test_default_inspection_creates_nothing(tmp_path):
     assert not destination.exists() and not backups.exists()
 
 
+def test_multiple_catalogs_require_an_explicit_source_kind(tmp_path):
+    source = _source(tmp_path)
+    stale_duckdb = source / "catalog.duckdb"
+    stale_duckdb.write_bytes(b"obsolete catalog sentinel")
+    destination, backups = tmp_path / "new-data", tmp_path / "backups"
+
+    try:
+        MIGRATION.inspect(source, destination, backups)
+        raise AssertionError("ambiguous catalogs must be refused")
+    except RuntimeError as exc:
+        assert "both catalog.sqlite and catalog.duckdb exist" in str(exc)
+
+    report = MIGRATION.inspect(source, destination, backups, source_kind="sqlite")
+    assert report["source_kind"] == "sqlite"
+    assert report["source_selection"] == "explicit"
+    assert report["source_catalog"] == str(source / "catalog.sqlite")
+    assert stale_duckdb.read_bytes() == b"obsolete catalog sentinel"
+    assert not destination.exists() and not backups.exists()
+
+
+def test_explicit_source_kind_must_exist(tmp_path):
+    source = _source(tmp_path)
+    try:
+        MIGRATION.inspect(
+            source, tmp_path / "new-data", tmp_path / "backups", source_kind="duckdb")
+        raise AssertionError("a missing explicitly selected catalog must be refused")
+    except RuntimeError as exc:
+        assert "explicit duckdb source requested" in str(exc)
+
+
 def test_execute_backs_up_migrates_validates_and_publishes(tmp_path):
     source = _source(tmp_path)
     destination, backups = tmp_path / "new-data", tmp_path / "backups"
@@ -96,6 +126,25 @@ def test_execute_backs_up_migrates_validates_and_publishes(tmp_path):
     assert (run / "catalog.sqlite.snapshot").is_file()
     assert (run / "raw-source" / "catalog.sqlite").is_file()
     assert (destination / "migration-manifest.json").is_file()
+
+
+def test_execute_records_explicit_source_selection_without_touching_other_catalog(tmp_path):
+    source = _source(tmp_path)
+    stale_duckdb = source / "catalog.duckdb"
+    stale_duckdb.write_bytes(b"obsolete catalog sentinel")
+    destination, backups = tmp_path / "new-data", tmp_path / "backups"
+
+    report = MIGRATION.execute(
+        source, destination, backups, "MODELARK-STOPPED", "explicit-sqlite",
+        source_kind="sqlite",
+    )
+    assert report["status"] == "published"
+    assert report["source_kind"] == "sqlite"
+    assert report["source_selection"] == "explicit"
+    assert stale_duckdb.read_bytes() == b"obsolete catalog sentinel"
+    manifest = json.loads(
+        (backups / "modelark-migration-explicit-sqlite" / "manifest.json").read_text())
+    assert manifest["source_selection"] == "explicit"
 
 
 def test_execution_refuses_confirmation_busy_source_and_existing_destination(tmp_path):

--- a/tests/test_legacy_runtime_migration.py
+++ b/tests/test_legacy_runtime_migration.py
@@ -67,6 +67,7 @@ def test_default_inspection_creates_nothing(tmp_path):
     destination, backups = tmp_path / "new-data", tmp_path / "backups"
     report = MIGRATION.inspect(source, destination, backups)
     assert report["mode"] == "inspection-only" and report["source_kind"] == "sqlite"
+    assert report["source_selection"] == "automatic"
     assert report["source"]["integrity_check"] == "ok"
     assert report["source"]["tables"]["archived"] == 1
     assert not destination.exists() and not backups.exists()
@@ -100,6 +101,13 @@ def test_explicit_source_kind_must_exist(tmp_path):
         raise AssertionError("a missing explicitly selected catalog must be refused")
     except RuntimeError as exc:
         assert "explicit duckdb source requested" in str(exc)
+
+    try:
+        MIGRATION.inspect(
+            source, tmp_path / "new-data", tmp_path / "backups", source_kind="sqlite3")
+        raise AssertionError("an unknown source kind must be refused")
+    except RuntimeError as exc:
+        assert "unknown source kind 'sqlite3'" in str(exc)
 
 
 def test_execute_backs_up_migrates_validates_and_publishes(tmp_path):


### PR DESCRIPTION
## What changed

- add an explicit `--source-kind sqlite|duckdb` selector for legacy migrations
- retain refusal-by-default when both legacy catalogs exist
- record whether catalog selection was automatic or explicit in inspection and migration manifests
- document the dual-catalog cutover flow and cover it with SQLite/DuckDB regression tests

## Why

The operator's legacy checkout contains both an active SQLite catalog and an obsolete DuckDB catalog. Process-descriptor evidence proves SQLite is active, but the backup-first migration tool had no safe way to express that decision without renaming files or building an ad hoc staging directory.

## Validation

- `ruff check scripts/migrate_legacy_runtime.py tests/test_legacy_runtime_migration.py`
- `pytest -q tests/test_legacy_runtime_migration.py` (8 passed)
- read-only inspection of the legacy directory with `--source-kind sqlite` reports integrity `ok` and leaves the absent destination untouched
