### PR TITLE
Test runtime paths from installed wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           pip install --no-deps /tmp/modelark-wheel/modelark-*.whl
           cd /tmp
           python -c "import tempfile; from pathlib import Path; from importlib.metadata import distribution; import scripts; from modelark import wishlist; from modelark.core import db; from modelark.web import server; d=tempfile.mkdtemp(); db.configure(d); c=db.connect(_bootstrapping=True); c.close(); assert wishlist.download()['max_24h_gb']==1000; assert (server.STATIC/'index.html').is_file(); assert db.DB_PATH.is_file() and Path(d) in db.DB_PATH.parents; assert scripts.__file__; names={e.name for e in distribution('modelark').entry_points}; assert {'modelark-migrate','modelark-deploy'} <= names"
+          python "$GITHUB_WORKSPACE/tests/test_runtime_paths.py"
           python -m scripts.phase4_wheel_migration_smoke
           python -c "import re; from importlib.metadata import metadata, requires; m=metadata('modelark'); r=requires('modelark') or []; name=lambda x: re.match(r'[A-Za-z0-9._-]+', x).group(0); canon=lambda x: re.sub(r'[-_.]+','-',name(x).lower()); assert m['License-Expression']=='Apache-2.0'; assert m['Project-URL']; assert not any(canon(x) in {'duckdb','hf-transfer'} and 'extra ==' not in x for x in r)"
           modelark-migrate --help

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -61,7 +61,10 @@ def test_packaged_default_works_without_source_checkout(tmp_path):
 
 @_isolated_runtime
 def test_packaged_default_matches_source_policy(tmp_path):
-    source = db.REPO_ROOT / "wishlist.yaml"
+    # This is a source-fixture comparison, not a runtime path lookup. Under a non-editable wheel
+    # install db.REPO_ROOT correctly lives in site-packages, while this test still runs from the
+    # checkout and must name the checked-in operator policy explicitly.
+    source = Path(__file__).resolve().parents[1] / "wishlist.yaml"
     source_policy = yaml.safe_load(source.read_text())
     with mock.patch.object(db, "REPO_ROOT", tmp_path), \
             mock.patch.object(wishlist, "_user_config_path", return_value=tmp_path / "missing.yaml"):


### PR DESCRIPTION
## What changed

- make the source-policy fixture in `test_runtime_paths.py` resolve from the checked-out test file instead of the installed package location
- run the runtime-path suite after CI replaces the editable install with the built wheel

## Why

The hidden acceptance run executes the repository's direct-file suite against a normal non-editable wheel install. That exposed a test-only path assumption: `db.REPO_ROOT` correctly points into site-packages for a wheel, so it cannot also locate the checkout-only `wishlist.yaml` fixture.

The runtime behavior and packaged default were correct. The test now names its source fixture explicitly, and CI exercises it in both editable and wheel-installed modes.

## Validation

- wheel-installed runtime-path suite passed from `/tmp`
- editable direct-file runtime-path suite passed
- Ruff passed
- full suite: 212 passed

No runtime code, catalog, portal, or fill behavior changes.
