### PR TITLE
Declare the 0.1.0 Public Alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) wh
 
 ## Unreleased
 
+## 0.1.0 - 2026-07-16
+
 ### Added
 
 - First-class staged restore with replica fallback, original-path reconstruction, final hash checks,
@@ -37,7 +39,3 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) wh
 
 - The loopback portal enforces Host, Origin, content type, request size, per-process CSRF, output
   escaping, and a restrictive Content Security Policy.
-
-## 0.1.0 - 2026-07-11
-
-- Initial sanitized release-candidate snapshot; subsequent work remains under **Unreleased**.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # ModelArk
 
-> 🚧 **Building in public.** ModelArk is an alpha: the archive pipeline, reconciled capacity
-> engine, and verified restore command are implemented, and StreamZNN's write-time restore proof has
-> been validated on real archive data. The first operator-attended restore from the migrated archive
-> is still a release-acceptance gate. See [Status](#status) for the exact boundary.
+> 🚧 **ModelArk 0.1.0 — Public Alpha.** The archive pipeline, reconciled capacity engine, and
+> verified restore command are implemented and extensively tested, and StreamZNN's write-time restore
+> proof has been validated on real archive data. "Alpha" reflects pre-1.0 interface stability and the
+> remaining operator-attended migrated-archive acceptance—not a prototype implementation. See
+> [Status](#status) for the exact boundary.
 
 An ark for open model weights: catalog every open model worth
 knowing about, archive the ones worth keeping across an offline drive library —
@@ -43,8 +44,8 @@ auxiliary files, and explicit pickle opt-ins are stored as inert raw bytes. On t
 - **Tiered storage** — mark keepers *must-have* (kept redundantly) vs bulk that's cheap to re-fetch.
 - **1/2-copy redundancy** — required copy counts are enforced from a durable record, not guessed.
 
-…and there's plenty more in the [decision log](docs/decision_log.md). The product is **early**,
-put out deliberately in a build-in-public stance — [contributions welcome](contributing/contributions.md).
+…and there's plenty more in the [decision log](docs/decision_log.md). The product is **pre-1.0** and
+released deliberately in a build-in-public stance — [contributions welcome](contributing/contributions.md).
 
 ## Honest callouts
 
@@ -362,7 +363,7 @@ restore; file-level crash recovery; first-class Plans; on-demand physical re-ver
 portal's six operator views. `DIS-002` is production evidence for StreamZNN blobs, not a claim that
 the complete restore workflow has already passed the migrated-runtime acceptance.
 
-The current release candidate has passed clean-install, installed-wheel, schema migration,
+The current 0.1.0 public-alpha build has passed clean-install, installed-wheel, schema migration,
 standalone, Playwright, hostile-web, read-only migrated-catalog, and capacity-ledger checks. The
 operator-attended migrated-runtime checklist has passed Phases A–F. Phase G still requires installing
 the reviewed hash-repair build, auditing and (if approved) repairing legacy Git-tracked hash evidence,

--- a/modelark/cli.py
+++ b/modelark/cli.py
@@ -6,10 +6,8 @@ import json
 import sys
 from pathlib import Path
 
-from modelark import __version__
-
+from modelark import __version__, discover, verify, wishlist
 from modelark.core import db
-from modelark import discover, verify, wishlist
 
 EXPORT_TABLES = ["models", "files", "verifications", "drives", "replicas"]
 

--- a/modelark/cli.py
+++ b/modelark/cli.py
@@ -6,6 +6,8 @@ import json
 import sys
 from pathlib import Path
 
+from modelark import __version__
+
 from modelark.core import db
 from modelark import discover, verify, wishlist
 
@@ -453,6 +455,7 @@ def cmd_drive_list(args):
 
 def main(argv=None):
     p = argparse.ArgumentParser(prog="modelark", description="Catalog & verify open model weights.")
+    p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     p.add_argument("--data-dir", type=Path,
                    help="writable catalog/runtime-data directory (default: platform user-data dir)")
     p.add_argument("--state-dir", type=Path,

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,12 @@
+import pytest
+
+from modelark import __version__
+from modelark import cli
+
+
+def test_cli_reports_package_version(capsys):
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["--version"])
+
+    assert exc.value.code == 0
+    assert capsys.readouterr().out == f"modelark {__version__}\n"


### PR DESCRIPTION
## Summary

- designate the existing package version as ModelArk 0.1.0 — Public Alpha
- explain that alpha reflects pre-1.0 interfaces and remaining attended acceptance, not prototype maturity
- expose the package version through modelark --version
- place the reviewed release work under the 0.1.0 changelog heading

## Validation

- modelark --version reports modelark 0.1.0
- focused CLI/version tests: 3 passed
- Ruff: passed
- git diff --check

No catalog, archive, service, restore, or Fill operations.