### PR TITLE
PR-02 (#35-A): catalog-v3 schema, migration, and capacity-evidence primitives

### DIFF
--- a/modelark/capacity_evidence.py
+++ b/modelark/capacity_evidence.py
@@ -1,0 +1,136 @@
+"""Pure capacity-evidence primitives for catalog v3 (RFC-002 / DEC-049, issue #35-A).
+
+Functional core only: fingerprint, typed evidence records, and the fail-closed precedence rule are
+pure (no SQLite, filesystem, mount, ``df``, fence, clock, or network). The one catalog reader here,
+:func:`shadow_by_drive`, is a read-only diagnostic accessor — it derives evidence from persisted
+facts alongside the legacy ``drives.free_bytes`` and never becomes admission authority in this phase.
+
+Admission cutover, the live observation/fencing shell, and generation/anchor writes are #35-B/#35-C.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+
+# Diagnostic-only floor for the shadow accessor. Migrated drives derive `unknown` (zero executable
+# and, with no current-epoch filesystem capacity, no optimistic maximum), so this value never affects
+# a decision in this phase; the versioned admission floor arrives with the #35-C authority cutover.
+_DIAGNOSTIC_SAFETY_FLOOR = 0
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """A typed admission-evidence verdict for one drive. `unknown` contributes zero executable
+    capacity; `legacy_free_bytes` is diagnostic only and never executable; `optimistic_usable_max` is
+    a non-executable sensitivity bound (post-safety-floor filesystem capacity, or None when the
+    current-epoch filesystem capacity is unknown)."""
+    kind: str                       # "live" | "anchor" | "unknown"
+    executable: bool
+    admissible_free: int
+    code: str | None = None
+    optimistic_usable_max: int | None = None
+    legacy_free_bytes: int | None = None
+
+
+def identity_fingerprint_v1(*, fs_uuid, annex_uuid, serial, filesystem_capacity_bytes) -> str:
+    """Version-1 identity fingerprint: lowercase SHA-256 over canonical UTF-8 JSON with sorted keys
+    and explicit nulls. At least one of fs_uuid / annex_uuid must be proven."""
+    if not fs_uuid and not annex_uuid:
+        raise ValueError("identity fingerprint requires at least one of fs_uuid or annex_uuid")
+    payload = {
+        "annex_uuid": annex_uuid,
+        "filesystem_capacity_bytes": filesystem_capacity_bytes,
+        "fs_uuid": fs_uuid,
+        "serial": serial,
+        "v": 1,
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _optimistic_usable_max(filesystem_capacity_bytes, safety_floor_bytes):
+    if filesystem_capacity_bytes is None:
+        return None
+    return max(0, filesystem_capacity_bytes - safety_floor_bytes)
+
+
+def derive(*, mounted, identity_proven, fence_held, write_authority, current_epoch,
+           filesystem_capacity_bytes, current_fingerprint, live_free_bytes, dirty,
+           anchor_free_bytes, anchor_epoch, anchor_fingerprint, anchor_filesystem_capacity,
+           safety_floor_bytes) -> Evidence:
+    """Fail-closed evidence precedence over one drive's synthetic observation (contract rule):
+
+    1. mounted + identity-proven + dedicated-local + fenced → live `df`, authoritative even while dirty;
+    2. offline + clean + exact identity/capacity epoch under dedicated-local control → latest anchor;
+    3. anything else → `unknown` (zero executable), with the binding distinction preserved.
+
+    The safety floor is subtracted exactly once when deriving admissible free.
+    """
+    optimistic = _optimistic_usable_max(filesystem_capacity_bytes, safety_floor_bytes)
+
+    def unknown(code: str) -> Evidence:
+        return Evidence(kind="unknown", executable=False, admissible_free=0, code=code,
+                        optimistic_usable_max=optimistic)
+
+    if mounted:
+        if not identity_proven:
+            return unknown("DRIVE_IDENTITY_UNPROVEN")
+        if write_authority != "dedicated_local":
+            return unknown("UNSUPPORTED_SHARED_WRITER")
+        if not fence_held:
+            return unknown("DRIVE_FENCE_UNAVAILABLE")
+        if live_free_bytes is None:
+            return unknown("CAPACITY_EVIDENCE_UNKNOWN")
+        return Evidence(kind="live", executable=True,
+                        admissible_free=max(0, live_free_bytes - safety_floor_bytes),
+                        code=None, optimistic_usable_max=optimistic)
+
+    # offline
+    if dirty:
+        return unknown("DRIVE_RECONCILIATION_REQUIRED")
+    if anchor_free_bytes is None:
+        return unknown("CAPACITY_EVIDENCE_UNKNOWN")
+    if write_authority != "dedicated_local":
+        return unknown("UNSUPPORTED_SHARED_WRITER")
+    if (anchor_epoch != current_epoch or anchor_fingerprint != current_fingerprint
+            or anchor_filesystem_capacity != filesystem_capacity_bytes):
+        return unknown("DRIVE_RECONCILIATION_REQUIRED")
+    if filesystem_capacity_bytes is None or not (0 <= anchor_free_bytes <= filesystem_capacity_bytes):
+        return unknown("ANCHOR_OUT_OF_RANGE")
+    return Evidence(kind="anchor", executable=True,
+                    admissible_free=max(0, anchor_free_bytes - safety_floor_bytes),
+                    code=None, optimistic_usable_max=optimistic)
+
+
+def shadow_by_drive(con) -> dict[str, Evidence]:
+    """Internal diagnostic accessor: derive evidence for every drive from persisted catalog facts,
+    with the legacy ``free_bytes`` attached as a diagnostic. Read-only — no mounts, ``df``, fencing,
+    or writes — and never admission authority. In this phase (no observation shell, migration creates
+    no anchors) every drive derives ``unknown`` with zero executable capacity."""
+    drives = con.execute(
+        "SELECT drive_label, identity_epoch, write_generation, write_authority, "
+        "filesystem_capacity_bytes, identity_fingerprint, free_bytes FROM drives ORDER BY drive_label"
+    ).fetchall()
+    out: dict[str, Evidence] = {}
+    for label, epoch, generation, authority, fs_capacity, fingerprint, free in drives:
+        anchor = con.execute(
+            "SELECT generation, anchor_free_bytes, identity_epoch, identity_fingerprint, "
+            "filesystem_capacity_bytes FROM drive_clean_anchors WHERE drive_label=? "
+            "ORDER BY generation DESC LIMIT 1", [label]).fetchone()
+        anchor_generation = anchor[0] if anchor else None
+        # A current generation is clean only when a matching anchor exists; otherwise it is dirty.
+        # A never-written drive (generation 0, no anchor) is simply unproven, not dirty.
+        dirty = generation > 0 and anchor_generation != generation
+        evidence = derive(
+            mounted=False, identity_proven=False, fence_held=False, write_authority=authority,
+            current_epoch=epoch, filesystem_capacity_bytes=fs_capacity,
+            current_fingerprint=fingerprint, live_free_bytes=None, dirty=dirty,
+            anchor_free_bytes=(anchor[1] if anchor else None),
+            anchor_epoch=(anchor[2] if anchor else None),
+            anchor_fingerprint=(anchor[3] if anchor else None),
+            anchor_filesystem_capacity=(anchor[4] if anchor else None),
+            safety_floor_bytes=_DIAGNOSTIC_SAFETY_FLOOR,
+        )
+        out[label] = replace(evidence, legacy_free_bytes=free)
+    return out

--- a/modelark/capacity_evidence.py
+++ b/modelark/capacity_evidence.py
@@ -22,13 +22,15 @@ _DIAGNOSTIC_SAFETY_FLOOR = 0
 @dataclass(frozen=True)
 class Evidence:
     """A typed admission-evidence verdict for one drive. `unknown` contributes zero executable
-    capacity; `legacy_free_bytes` is diagnostic only and never executable; `optimistic_usable_max` is
-    a non-executable sensitivity bound (post-safety-floor filesystem capacity, or None when the
-    current-epoch filesystem capacity is unknown)."""
+    capacity; `observed_free` is the raw live/anchor observation BEFORE the safety floor (None when
+    unknown), so exactly-once subtraction is auditable against `admissible_free`; `legacy_free_bytes`
+    is diagnostic only and never executable; `optimistic_usable_max` is a non-executable sensitivity
+    bound (post-safety-floor filesystem capacity, or None when the current-epoch capacity is unknown)."""
     kind: str                       # "live" | "anchor" | "unknown"
     executable: bool
     admissible_free: int
     code: str | None = None
+    observed_free: int | None = None
     optimistic_usable_max: int | None = None
     legacy_free_bytes: int | None = None
 
@@ -84,7 +86,7 @@ def derive(*, mounted, identity_proven, fence_held, write_authority, current_epo
             return unknown("CAPACITY_EVIDENCE_UNKNOWN")
         return Evidence(kind="live", executable=True,
                         admissible_free=max(0, live_free_bytes - safety_floor_bytes),
-                        code=None, optimistic_usable_max=optimistic)
+                        code=None, observed_free=live_free_bytes, optimistic_usable_max=optimistic)
 
     # offline
     if dirty:
@@ -100,7 +102,7 @@ def derive(*, mounted, identity_proven, fence_held, write_authority, current_epo
         return unknown("ANCHOR_OUT_OF_RANGE")
     return Evidence(kind="anchor", executable=True,
                     admissible_free=max(0, anchor_free_bytes - safety_floor_bytes),
-                    code=None, optimistic_usable_max=optimistic)
+                    code=None, observed_free=anchor_free_bytes, optimistic_usable_max=optimistic)
 
 
 def shadow_by_drive(con) -> dict[str, Evidence]:
@@ -114,22 +116,23 @@ def shadow_by_drive(con) -> dict[str, Evidence]:
     ).fetchall()
     out: dict[str, Evidence] = {}
     for label, epoch, generation, authority, fs_capacity, fingerprint, free in drives:
+        # Select the anchor for the drive's EXACT current (identity_epoch, write_generation): a stale
+        # anchor from an old epoch at a higher generation must not shadow the current-epoch one.
         anchor = con.execute(
-            "SELECT generation, anchor_free_bytes, identity_epoch, identity_fingerprint, "
-            "filesystem_capacity_bytes FROM drive_clean_anchors WHERE drive_label=? "
-            "ORDER BY generation DESC LIMIT 1", [label]).fetchone()
-        anchor_generation = anchor[0] if anchor else None
-        # A current generation is clean only when a matching anchor exists; otherwise it is dirty.
-        # A never-written drive (generation 0, no anchor) is simply unproven, not dirty.
-        dirty = generation > 0 and anchor_generation != generation
+            "SELECT anchor_free_bytes, identity_epoch, identity_fingerprint, filesystem_capacity_bytes "
+            "FROM drive_clean_anchors WHERE drive_label=? AND identity_epoch=? AND generation=?",
+            [label, epoch, generation]).fetchone()
+        # The current generation is clean iff its matching anchor exists; a never-written drive
+        # (generation 0, no anchor) is simply unproven, not dirty.
+        dirty = generation > 0 and anchor is None
         evidence = derive(
             mounted=False, identity_proven=False, fence_held=False, write_authority=authority,
             current_epoch=epoch, filesystem_capacity_bytes=fs_capacity,
             current_fingerprint=fingerprint, live_free_bytes=None, dirty=dirty,
-            anchor_free_bytes=(anchor[1] if anchor else None),
-            anchor_epoch=(anchor[2] if anchor else None),
-            anchor_fingerprint=(anchor[3] if anchor else None),
-            anchor_filesystem_capacity=(anchor[4] if anchor else None),
+            anchor_free_bytes=(anchor[0] if anchor else None),
+            anchor_epoch=(anchor[1] if anchor else None),
+            anchor_fingerprint=(anchor[2] if anchor else None),
+            anchor_filesystem_capacity=(anchor[3] if anchor else None),
             safety_floor_bytes=_DIAGNOSTIC_SAFETY_FLOOR,
         )
         out[label] = replace(evidence, legacy_free_bytes=free)

--- a/modelark/core/db.py
+++ b/modelark/core/db.py
@@ -89,6 +89,10 @@ def _statements(sql: str) -> Iterable[str]:
 # Catalog-v3 (#35-A) append-only evidence tables. The v2->v3 migration creates these transactionally
 # after its backup, so the pre-migration tables-only pass must NOT create them first on a v2 catalog.
 _V3_EVIDENCE_TABLES = ("drive_dirty_generations", "drive_clean_anchors")
+# The v3 drives columns. The v0->v1 integrity rebuild excludes them so a legacy catalog keeps its
+# pre-v3 drive shape until the actual v3 transaction takes its own backup.
+_V3_DRIVE_COLUMN_NAMES = ("identity_epoch", "write_generation", "filesystem_capacity_bytes",
+                          "identity_fingerprint", "write_authority")
 
 
 def _apply_schema(con: sqlite3.Connection, tables_only: bool = False) -> None:
@@ -200,8 +204,33 @@ def _validate_catalog_version(version: int, *, read_only: bool = False) -> None:
         )
 
 
-def _canonical_table_sql(table: str, replacement: str) -> str:
-    """Return one canonical CREATE TABLE statement under a temporary table name."""
+def _drop_columns_from_ddl(ddl: str, exclude: tuple[str, ...]) -> str:
+    """Remove the named column definitions from a CREATE TABLE statement, splitting the column list on
+    depth-0 commas so CHECK(...) parens and quoted commas are respected."""
+    open_i = ddl.index("(")
+    close_i = ddl.rindex(")")
+    body = ddl[open_i + 1:close_i]
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in body:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        if char == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current))
+    kept = [p for p in parts if p.strip().split()[0].strip('"') not in exclude]
+    return ddl[:open_i + 1] + ",".join(kept) + ddl[close_i:]
+
+
+def _canonical_table_sql(table: str, replacement: str, exclude: tuple[str, ...] = ()) -> str:
+    """Return one canonical CREATE TABLE statement under a temporary table name, optionally excluding
+    named columns (used so the integrity rebuild does not pull future-version columns backward)."""
     prefix = re.compile(
         rf"^CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\s+{re.escape(table)}\b",
         re.IGNORECASE,
@@ -209,7 +238,8 @@ def _canonical_table_sql(table: str, replacement: str) -> str:
     for stmt in _statements(SCHEMA_PATH.read_text()):
         clean = stmt.strip()
         if prefix.match(clean):
-            return prefix.sub(f"CREATE TABLE {replacement}", clean, count=1)
+            ddl = prefix.sub(f"CREATE TABLE {replacement}", clean, count=1)
+            return _drop_columns_from_ddl(ddl, exclude) if exclude else ddl
     raise RuntimeError(f"Packaged schema has no CREATE TABLE statement for {table}")
 
 
@@ -249,7 +279,10 @@ def _rebuild_integrity_tables(con: sqlite3.Connection) -> None:
             current = table
             new = f"{table}__integrity_new"
             con.execute(f'DROP TABLE IF EXISTS "{new}"')
-            con.execute(_canonical_table_sql(table, new))
+            # Preserve the pre-v3 drive shape: a v0/v1 rebuild must not introduce the catalog-v3
+            # columns, so the later v2->v3 transaction takes a genuine pre-v3 backup.
+            exclude = _V3_DRIVE_COLUMN_NAMES if table == "drives" else ()
+            con.execute(_canonical_table_sql(table, new, exclude=exclude))
             old_cols = {r[1] for r in con.execute(f'PRAGMA table_info("{table}")').fetchall()}
             new_cols = [r[1] for r in con.execute(f'PRAGMA table_info("{new}")').fetchall()]
             cols = [c for c in new_cols if c in old_cols]
@@ -398,6 +431,10 @@ def _migrate_capacity_evidence_v3(con, *, backup_existing: bool) -> None:
                 con.execute(ddl)
         for stmt in _v3_object_ddl():
             con.execute(stmt)
+        violations = con.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise RuntimeError(
+                f"Capacity-evidence migration produced foreign-key violations: {violations[:12]}")
         con.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
         con.execute("COMMIT")
     except Exception as exc:

--- a/modelark/core/db.py
+++ b/modelark/core/db.py
@@ -64,12 +64,31 @@ sqlite3.register_adapter(datetime, lambda d: d.isoformat(sep=" ", timespec="seco
 
 
 def _statements(sql: str) -> Iterable[str]:
-    """Yield executable statements, stripping `--` line comments first so a ';'
-    inside a comment is not mistaken for a statement boundary."""
+    """Yield executable statements, stripping `--` line comments first so a ';' inside a comment is
+    not mistaken for a statement boundary. A `CREATE TRIGGER … BEGIN … END;` body contains its own
+    `;` separators, so re-join split fragments while inside a BEGIN…END block (tracked by keyword
+    depth) and emit the whole compound statement as one."""
     no_comments = "\n".join(line.split("--", 1)[0] for line in sql.splitlines())
+    buffer: list[str] = []
+    depth = 0
     for chunk in no_comments.split(";"):
-        if chunk.strip():
-            yield chunk
+        buffer.append(chunk)
+        depth += len(re.findall(r"\bBEGIN\b", chunk, re.IGNORECASE))
+        depth -= len(re.findall(r"\bEND\b", chunk, re.IGNORECASE))
+        if depth <= 0:
+            statement = ";".join(buffer)         # restore the internal separators of a trigger body
+            if statement.strip():
+                yield statement
+            buffer = []
+            depth = 0
+    tail = ";".join(buffer)                       # a final statement with no trailing ';'
+    if tail.strip():
+        yield tail
+
+
+# Catalog-v3 (#35-A) append-only evidence tables. The v2->v3 migration creates these transactionally
+# after its backup, so the pre-migration tables-only pass must NOT create them first on a v2 catalog.
+_V3_EVIDENCE_TABLES = ("drive_dirty_generations", "drive_clean_anchors")
 
 
 def _apply_schema(con: sqlite3.Connection, tables_only: bool = False) -> None:
@@ -77,6 +96,10 @@ def _apply_schema(con: sqlite3.Connection, tables_only: bool = False) -> None:
     rebuilt before unique indexes and views are installed; the final pass installs everything."""
     for stmt in _statements(SCHEMA_PATH.read_text()):
         if tables_only and not stmt.lstrip().upper().startswith("CREATE TABLE"):
+            continue
+        # Never create a v3 evidence table before the v2->v3 migration takes its backup: the migration
+        # owns them transactionally, and the final (non-tables-only) pass creates them idempotently.
+        if tables_only and any(t in stmt for t in _V3_EVIDENCE_TABLES):
             continue
         con.execute(stmt)
 
@@ -160,7 +183,8 @@ _INTEGRITY_TABLES = (
 )
 _VIEW_NAMES = ("v_ui", "v_model_summary", "v_storage_by_drive")
 _INTEGRITY_SCHEMA_VERSION = 1
-_SCHEMA_VERSION = 2
+_CAPACITY_MODE_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = 3
 
 
 def _validate_catalog_version(version: int, *, read_only: bool = False) -> None:
@@ -311,13 +335,76 @@ def _migrate_capacity_mode_v2(con: sqlite3.Connection, *, backup_existing: bool)
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_plans_one_active "
             "ON plans(is_active) WHERE is_active = 1"
         )
-        con.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
+        con.execute(f"PRAGMA user_version={_CAPACITY_MODE_SCHEMA_VERSION}")
         con.execute("COMMIT")
     except Exception as exc:
         con.execute("ROLLBACK")
         if isinstance(exc, RuntimeError):
             raise
         raise RuntimeError(f"Cannot migrate plans to schema v2 capacity modes ({exc})") from exc
+
+
+# Catalog-v3 (#35-A) drives-column additions. Introspected ALTER TABLE ADD COLUMN (no drives rebuild);
+# each column is defaulted/nullable so existing rows migrate without fabricated evidence.
+_V3_DRIVE_COLUMNS = (
+    ("identity_epoch",
+     "ALTER TABLE drives ADD COLUMN identity_epoch INTEGER NOT NULL DEFAULT 1 "
+     "CHECK (identity_epoch >= 1)"),
+    ("write_generation",
+     "ALTER TABLE drives ADD COLUMN write_generation INTEGER NOT NULL DEFAULT 0 "
+     "CHECK (write_generation >= 0)"),
+    ("filesystem_capacity_bytes",
+     "ALTER TABLE drives ADD COLUMN filesystem_capacity_bytes BIGINT "
+     "CHECK (filesystem_capacity_bytes IS NULL OR filesystem_capacity_bytes >= 0)"),
+    ("identity_fingerprint",
+     "ALTER TABLE drives ADD COLUMN identity_fingerprint VARCHAR "
+     "CHECK (identity_fingerprint IS NULL OR length(identity_fingerprint) = 64)"),
+    ("write_authority",
+     "ALTER TABLE drives ADD COLUMN write_authority VARCHAR NOT NULL DEFAULT 'unknown' "
+     "CHECK (write_authority IN ('unknown','dedicated_local'))"),
+)
+
+
+def _v3_object_ddl() -> list[str]:
+    """The catalog-v3 evidence tables, indexes, and triggers taken verbatim (single-sourced) from the
+    packaged schema, so the migration and a fresh bootstrap create identical objects in FK order."""
+    wanted = []
+    for stmt in _statements(SCHEMA_PATH.read_text()):
+        head = stmt.strip().upper()
+        if (head.startswith(("CREATE TABLE", "CREATE INDEX", "CREATE TRIGGER"))
+                and any(table in stmt for table in _V3_EVIDENCE_TABLES)):
+            wanted.append(stmt)
+    return wanted
+
+
+def _migrate_capacity_evidence_v3(con, *, backup_existing: bool) -> None:
+    """Backup-first, transactional, additive v2->v3 migration: add the capacity-evidence columns, the
+    two append-only evidence tables, their indexes, and triggers. Create no evidence rows and leave
+    every drive unknown (epoch 1 is only a namespace for migrated rows). No v3 object is created
+    before the backup, and all v3 DDL plus user_version commit in one transaction, so an injected
+    failure leaves a pristine v2 catalog."""
+    columns = {row[1] for row in con.execute('PRAGMA table_info("drives")').fetchall()}
+    if "identity_epoch" in columns:
+        con.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")   # fresh/canonical drives already v3-shaped
+        return
+    if con.execute("PRAGMA foreign_keys").fetchone()[0]:
+        raise RuntimeError("Capacity-evidence migration requires foreign_keys=OFF")
+    if backup_existing:
+        _backup_before_migration(con, "pre-evidence-v3")        # strictly before any v3 object
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        for name, ddl in _V3_DRIVE_COLUMNS:
+            if name not in columns:                             # introspected add
+                con.execute(ddl)
+        for stmt in _v3_object_ddl():
+            con.execute(stmt)
+        con.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
+        con.execute("COMMIT")
+    except Exception as exc:
+        con.execute("ROLLBACK")
+        if isinstance(exc, RuntimeError):
+            raise
+        raise RuntimeError(f"Cannot migrate catalog to v3 capacity evidence ({exc})") from exc
 
 
 def _migrate(con, version: int, *, backup_existing: bool) -> None:
@@ -327,8 +414,11 @@ def _migrate(con, version: int, *, backup_existing: bool) -> None:
         _migrate_legacy_columns(con)
         _rebuild_integrity_tables(con)
         version = _INTEGRITY_SCHEMA_VERSION
-    if version < _SCHEMA_VERSION:
+    if version < _CAPACITY_MODE_SCHEMA_VERSION:
         _migrate_capacity_mode_v2(con, backup_existing=backup_existing)
+        version = _CAPACITY_MODE_SCHEMA_VERSION
+    if version < _SCHEMA_VERSION:
+        _migrate_capacity_evidence_v3(con, backup_existing=backup_existing)
         version = _SCHEMA_VERSION
     if version != _SCHEMA_VERSION:
         raise RuntimeError(f"Catalog migration stopped at v{version}, expected v{_SCHEMA_VERSION}")

--- a/modelark/core/schema.sql
+++ b/modelark/core/schema.sql
@@ -67,7 +67,22 @@ CREATE TABLE IF NOT EXISTS drives (
     raid_backed        BOOLEAN NOT NULL DEFAULT false CHECK (raid_backed IN (0, 1)),
     health             VARCHAR,
     last_seen          TIMESTAMP,
-    notes              VARCHAR
+    notes              VARCHAR,
+    -- Catalog v3 (#35-A) capacity-evidence identity. `capacity_bytes` stays nominal device capacity;
+    -- `filesystem_capacity_bytes` is the identity-proven filesystem total for the current epoch and
+    -- the only epoch maximum Gate B may use. `free_bytes` is compatibility/diagnostic, never authority.
+    identity_epoch            INTEGER NOT NULL DEFAULT 1
+                              CHECK (identity_epoch >= 1),
+    write_generation          INTEGER NOT NULL DEFAULT 0
+                              CHECK (write_generation >= 0),
+    filesystem_capacity_bytes BIGINT
+                              CHECK (filesystem_capacity_bytes IS NULL
+                                     OR filesystem_capacity_bytes >= 0),
+    identity_fingerprint      VARCHAR
+                              CHECK (identity_fingerprint IS NULL
+                                     OR length(identity_fingerprint) = 64),
+    write_authority           VARCHAR NOT NULL DEFAULT 'unknown'
+                              CHECK (write_authority IN ('unknown','dedicated_local'))
 );
 
 -- Which file lives on which drive (mirror of `git annex whereis`).
@@ -177,6 +192,62 @@ CREATE TABLE IF NOT EXISTS plan_drives (
     FOREIGN KEY (plan_id) REFERENCES plans(plan_id) ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (drive_label) REFERENCES drives(drive_label) ON UPDATE CASCADE ON DELETE CASCADE
 );
+
+-- Catalog v3 (#35-A) append-only capacity evidence. A repair never edits an old row; it opens a new
+-- generation and publishes a new anchor. #35 callers leave both owner fields null; #39 populates them.
+CREATE TABLE IF NOT EXISTS drive_dirty_generations (
+    drive_label         VARCHAR NOT NULL,
+    identity_epoch      INTEGER NOT NULL CHECK (identity_epoch >= 1),
+    generation          INTEGER NOT NULL CHECK (generation >= 1),
+    operation_code      VARCHAR NOT NULL CHECK (length(trim(operation_code)) > 0),
+    owner_session_id    VARCHAR,
+    owner_fencing_token INTEGER CHECK (owner_fencing_token IS NULL
+                                       OR owner_fencing_token >= 1),
+    started_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (drive_label, identity_epoch, generation),
+    FOREIGN KEY (drive_label) REFERENCES drives(drive_label)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CHECK ((owner_session_id IS NULL) = (owner_fencing_token IS NULL))
+);
+
+CREATE TABLE IF NOT EXISTS drive_clean_anchors (
+    anchor_id                  INTEGER PRIMARY KEY,
+    drive_label               VARCHAR NOT NULL,
+    identity_epoch            INTEGER NOT NULL CHECK (identity_epoch >= 1),
+    generation                INTEGER NOT NULL CHECK (generation >= 1),
+    anchor_free_bytes         BIGINT NOT NULL CHECK (anchor_free_bytes >= 0),
+    filesystem_capacity_bytes BIGINT NOT NULL CHECK (filesystem_capacity_bytes >= 0),
+    identity_fingerprint      VARCHAR NOT NULL CHECK (length(identity_fingerprint) = 64),
+    write_authority           VARCHAR NOT NULL CHECK (write_authority = 'dedicated_local'),
+    identity_proof            TEXT NOT NULL CHECK (length(identity_proof) > 0),
+    fence_proof               TEXT NOT NULL CHECK (length(fence_proof) > 0),
+    observed_at               TIMESTAMP NOT NULL,
+    created_at                TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (drive_label, identity_epoch, generation),
+    FOREIGN KEY (drive_label, identity_epoch, generation)
+        REFERENCES drive_dirty_generations(drive_label, identity_epoch, generation)
+        ON UPDATE RESTRICT ON DELETE RESTRICT,
+    CHECK (anchor_free_bytes <= filesystem_capacity_bytes)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dirty_generation_owner
+    ON drive_dirty_generations(owner_session_id, owner_fencing_token)
+    WHERE owner_session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_clean_anchor_latest
+    ON drive_clean_anchors(drive_label, identity_epoch, generation DESC);
+
+CREATE TRIGGER IF NOT EXISTS drive_dirty_generations_no_update
+BEFORE UPDATE ON drive_dirty_generations
+BEGIN SELECT RAISE(ABORT, 'drive_dirty_generations is append-only'); END;
+CREATE TRIGGER IF NOT EXISTS drive_dirty_generations_no_delete
+BEFORE DELETE ON drive_dirty_generations
+BEGIN SELECT RAISE(ABORT, 'drive_dirty_generations is append-only'); END;
+CREATE TRIGGER IF NOT EXISTS drive_clean_anchors_no_update
+BEFORE UPDATE ON drive_clean_anchors
+BEGIN SELECT RAISE(ABORT, 'drive_clean_anchors is append-only'); END;
+CREATE TRIGGER IF NOT EXISTS drive_clean_anchors_no_delete
+BEFORE DELETE ON drive_clean_anchors
+BEGIN SELECT RAISE(ABORT, 'drive_clean_anchors is append-only'); END;
 
 -- Foreign-key child indexes keep parent updates/deletes and integrity checks bounded.
 CREATE INDEX IF NOT EXISTS idx_files_repo ON files(repo_id);

--- a/scripts/phase4_wheel_migration_smoke.py
+++ b/scripts/phase4_wheel_migration_smoke.py
@@ -1,4 +1,6 @@
-"""Installed-wheel smoke for the schema-v1 to schema-v2 capacity-mode migration."""
+"""Installed-wheel smoke for the chained schema v1 -> v2 (capacity mode) -> v3 (#35-A capacity
+evidence) migration. Downgrades a freshly bootstrapped catalog to a genuine pre-v2/pre-v3 shape so the
+capacity-mode rebuild and the additive, backup-first evidence migration both actually run."""
 from __future__ import annotations
 
 import sqlite3
@@ -7,9 +9,14 @@ from pathlib import Path
 
 from modelark.core import db
 
+# Frozen v2 `drives` shape (no catalog-v3 columns), so the v2->v3 migration performs a real
+# ADD COLUMN + evidence-table creation rather than short-circuiting on an already-v3 table.
+_V2_DRIVE_COLS = ("drive_label,fs_uuid,annex_uuid,capacity_bytes,free_bytes,hw_model,serial,"
+                  "physical_location,role,raid_backed,health,last_seen,notes")
+
 
 def main() -> int:
-    root = Path(tempfile.mkdtemp(prefix="modelark-wheel-v2-"))
+    root = Path(tempfile.mkdtemp(prefix="modelark-wheel-v3-"))
     db.configure(root, root / "state")
     con = db.connect(_bootstrapping=True)
     con.execute("PRAGMA foreign_keys=OFF")
@@ -29,24 +36,58 @@ def main() -> int:
     con.execute("DROP TABLE plans")
     con.execute("ALTER TABLE plans__v1 RENAME TO plans")
     con.execute("CREATE UNIQUE INDEX idx_plans_one_active ON plans(is_active) WHERE is_active=1")
+    # A drive carrying a legacy free_bytes scalar, to prove preservation + no fabricated evidence.
+    con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) VALUES('drive-00',1000,500)")
+    # Downgrade drives to a genuine v2 shape (frozen DDL keeps the PRIMARY KEY so the replicas/archived
+    # FKs still resolve) and drop the v3 evidence objects, so the v2->v3 migration genuinely runs.
+    con.execute("PRAGMA legacy_alter_table=ON")      # rename must not rewrite FK targets in other tables
+    con.execute("DROP TABLE IF EXISTS drive_clean_anchors")
+    con.execute("DROP TABLE IF EXISTS drive_dirty_generations")
+    con.execute(
+        "CREATE TABLE drives__v2 ("
+        "drive_label VARCHAR PRIMARY KEY NOT NULL CHECK (length(trim(drive_label)) > 0),"
+        "fs_uuid VARCHAR,annex_uuid VARCHAR,"
+        "capacity_bytes BIGINT CHECK (capacity_bytes IS NULL OR capacity_bytes >= 0),"
+        "free_bytes BIGINT CHECK (free_bytes IS NULL OR free_bytes >= 0),"
+        "hw_model VARCHAR,serial VARCHAR,physical_location VARCHAR,"
+        "role VARCHAR NOT NULL DEFAULT 'primary' CHECK (role IN ('primary','replica')),"
+        "raid_backed BOOLEAN NOT NULL DEFAULT false CHECK (raid_backed IN (0,1)),"
+        "health VARCHAR,last_seen TIMESTAMP,notes VARCHAR)"
+    )
+    con.execute(f"INSERT INTO drives__v2({_V2_DRIVE_COLS}) SELECT {_V2_DRIVE_COLS} FROM drives")
+    con.execute("DROP TABLE drives")
+    con.execute("ALTER TABLE drives__v2 RENAME TO drives")
     con.execute("PRAGMA user_version=1")
     con.close()
 
     migrated = db.connect()
     try:
-        assert migrated.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert migrated.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION
         assert migrated.execute(
             "SELECT plan_id,capacity_mode FROM plans ORDER BY plan_id"
         ).fetchall() == [("aware", "compression_aware"), ("safe", "guaranteed")]
         assert migrated.execute("PRAGMA foreign_key_check").fetchall() == []
-        columns = {row[1] for row in migrated.execute("PRAGMA table_info(plans)").fetchall()}
-        assert "capacity_mode" in columns and "provisioning" not in columns
+        plan_cols = {row[1] for row in migrated.execute("PRAGMA table_info(plans)").fetchall()}
+        assert "capacity_mode" in plan_cols and "provisioning" not in plan_cols
+        # v3 columns present with migration defaults; legacy scalar preserved; no fabricated evidence.
+        row = migrated.execute(
+            "SELECT identity_epoch,write_generation,write_authority,filesystem_capacity_bytes,"
+            "identity_fingerprint,free_bytes FROM drives WHERE drive_label='drive-00'").fetchone()
+        assert row == (1, 0, "unknown", None, None, 500), row
+        tables = {r[0] for r in migrated.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+        assert {"drive_dirty_generations", "drive_clean_anchors"} <= tables
+        assert migrated.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
+        assert migrated.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
     finally:
         migrated.close()
 
-    backup = db.DB_PATH.with_name(f"{db.DB_PATH.name}.pre-capacity-v2.bak")
-    assert backup.is_file()
-    legacy = sqlite3.connect(str(backup))
+    # Both migration backups exist and each retains its prior schema version.
+    v2_backup = db.DB_PATH.with_name(f"{db.DB_PATH.name}.pre-capacity-v2.bak")
+    assert v2_backup.is_file()
+    v3_backup = db.DB_PATH.with_name(f"{db.DB_PATH.name}.pre-evidence-v3.bak")
+    assert v3_backup.is_file()
+    legacy = sqlite3.connect(str(v2_backup))
     try:
         assert legacy.execute("PRAGMA user_version").fetchone()[0] == 1
         assert legacy.execute(
@@ -54,6 +95,13 @@ def main() -> int:
         ).fetchall() == [("compressed",), ("uncompressed",)]
     finally:
         legacy.close()
+    pre_v3 = sqlite3.connect(str(v3_backup))
+    try:
+        assert pre_v3.execute("PRAGMA user_version").fetchone()[0] == 2
+        drive_cols = {r[1] for r in pre_v3.execute("PRAGMA table_info(drives)").fetchall()}
+        assert "identity_epoch" not in drive_cols, "the pre-v3 backup must remain a v2 catalog"
+    finally:
+        pre_v3.close()
     return 0
 
 

--- a/tests/test_capacity_evidence.py
+++ b/tests/test_capacity_evidence.py
@@ -66,14 +66,16 @@ def test_live_evidence_is_authoritative_even_while_dirty():
     ev = _derive(mounted=True, identity_proven=True, fence_held=True,
                  write_authority="dedicated_local", live_free_bytes=1000, dirty=True)
     assert ev.kind == "live" and ev.executable
-    assert ev.admissible_free == 900 and ev.code is None      # floor subtracted exactly once
+    # observed_free is the raw observation; admissible subtracts the floor exactly once
+    assert ev.observed_free == 1000 and ev.admissible_free == 900 and ev.code is None
 
 
 def test_offline_clean_anchor_is_authoritative_for_the_matching_epoch():
     _require()
     ev = _derive(write_authority="dedicated_local", anchor_free_bytes=800, anchor_epoch=1,
                  current_epoch=1, filesystem_capacity_bytes=1000)
-    assert ev.kind == "anchor" and ev.executable and ev.admissible_free == 700
+    assert ev.kind == "anchor" and ev.executable
+    assert ev.observed_free == 800 and ev.admissible_free == 700
 
 
 def test_unknown_tiers_preserve_binding_distinctions():
@@ -108,6 +110,7 @@ def test_unknown_tiers_preserve_binding_distinctions():
     for name, (over, code) in cases.items():
         ev = _derive(**over)
         assert ev.kind == "unknown" and not ev.executable and ev.admissible_free == 0, name
+        assert ev.observed_free is None, name       # no admissible observation for unknown evidence
         assert ev.code == code, (name, ev.code)
 
 
@@ -133,10 +136,45 @@ def test_safety_floor_subtracted_once_and_clamped_at_zero():
     _require()
     exact = _derive(mounted=True, identity_proven=True, fence_held=True,
                     write_authority="dedicated_local", live_free_bytes=250, safety_floor_bytes=100)
-    assert exact.admissible_free == 150
+    assert exact.observed_free == 250 and exact.admissible_free == 150   # 250 - 100, exactly once
     clamped = _derive(mounted=True, identity_proven=True, fence_held=True,
                       write_authority="dedicated_local", live_free_bytes=50, safety_floor_bytes=100)
-    assert clamped.kind == "live" and clamped.admissible_free == 0    # never negative
+    assert clamped.kind == "live" and clamped.observed_free == 50 and clamped.admissible_free == 0
+
+
+def test_shadow_selects_current_epoch_anchor_not_a_higher_old_epoch_generation(tmp_path):
+    """A stale old-epoch anchor at a higher generation must not shadow the valid current-epoch anchor.
+    The reader selects the anchor matching the drive's exact current (identity_epoch, write_generation)."""
+    _require()
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fresh catalog must be v3 (Gate-1 red)"
+    fp = "a" * 64
+    con.execute(
+        "INSERT INTO drives(drive_label,capacity_bytes,free_bytes,identity_epoch,write_generation,"
+        "filesystem_capacity_bytes,identity_fingerprint,write_authority) "
+        "VALUES('drive-00',1000,500,2,1,1000,?,'dedicated_local')", [fp])
+    # current epoch 2, generation 1: the valid clean anchor
+    con.execute("INSERT INTO drive_dirty_generations(drive_label,identity_epoch,generation,operation_code) "
+                "VALUES('drive-00',2,1,'x')")
+    con.execute(
+        "INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
+        "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
+        "observed_at) VALUES('drive-00',2,1,500,1000,?,'dedicated_local','p','p','2026-01-01')", [fp])
+    # stale OLD epoch 1 at a much HIGHER generation 100: must be ignored
+    con.execute("INSERT INTO drive_dirty_generations(drive_label,identity_epoch,generation,operation_code) "
+                "VALUES('drive-00',1,100,'x')")
+    con.execute(
+        "INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
+        "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
+        "observed_at) VALUES('drive-00',1,100,900,1000,?,'dedicated_local','p','p','2026-01-01')", [fp])
+
+    shadow = ce.shadow_by_drive(con)
+    ev = shadow["drive-00"]
+    assert ev.kind == "anchor" and ev.executable, ev          # not DRIVE_RECONCILIATION_REQUIRED
+    assert ev.observed_free == 500, ev                        # the current-epoch anchor, not the old 900
+    con.close()
 
 
 def test_shadow_read_is_side_effect_free_and_all_unknown(tmp_path):

--- a/tests/test_capacity_evidence.py
+++ b/tests/test_capacity_evidence.py
@@ -25,11 +25,17 @@ def _require():
 
 
 def _derive(**over):
-    """Derive evidence from a synthetic per-drive observation; override only the relevant fields."""
+    """Derive evidence from a synthetic per-drive observation; override only the relevant fields.
+
+    `current_*` describe the drive's current identity/capacity; `anchor_*` describe what a latest
+    clean anchor recorded. An anchor is authoritative only when its epoch, fingerprint, and
+    filesystem capacity all equal the current drive's."""
     base = dict(
         mounted=False, identity_proven=False, fence_held=False, write_authority="unknown",
-        current_epoch=1, filesystem_capacity_bytes=1000, live_free_bytes=None, dirty=False,
-        anchor_free_bytes=None, anchor_epoch=None, safety_floor_bytes=100,
+        current_epoch=1, filesystem_capacity_bytes=1000, current_fingerprint="fp",
+        live_free_bytes=None, dirty=False,
+        anchor_free_bytes=None, anchor_epoch=None, anchor_fingerprint="fp",
+        anchor_filesystem_capacity=1000, safety_floor_bytes=100,
     )
     base.update(over)
     return ce.derive(**base)
@@ -70,33 +76,57 @@ def test_offline_clean_anchor_is_authoritative_for_the_matching_epoch():
     assert ev.kind == "anchor" and ev.executable and ev.admissible_free == 700
 
 
-def test_unknown_tiers_are_zero_executable():
+def test_unknown_tiers_preserve_binding_distinctions():
     _require()
+    # Each case is single-fault so its typed code is unambiguous; the binding distinctions are
+    # preserved rather than collapsed to a generic unknown.
     cases = {
-        "offline_dirty": dict(write_authority="dedicated_local", anchor_free_bytes=800,
-                              anchor_epoch=1, dirty=True),
-        "offline_anchorless": dict(write_authority="dedicated_local"),
-        "anchor_epoch_mismatch": dict(write_authority="dedicated_local", anchor_free_bytes=800,
-                                      anchor_epoch=2, current_epoch=1),
-        "mounted_unfenced": dict(mounted=True, identity_proven=True, fence_held=False,
-                                 write_authority="dedicated_local", live_free_bytes=1000),
-        "shared_authority": dict(mounted=True, identity_proven=True, fence_held=True,
-                                 write_authority="unknown", live_free_bytes=1000),
-        "identity_unproven": dict(mounted=True, identity_proven=False, fence_held=True,
-                                  write_authority="dedicated_local", live_free_bytes=1000),
+        "identity_unproven": (dict(mounted=True, identity_proven=False, fence_held=True,
+                                   write_authority="dedicated_local", live_free_bytes=1000),
+                              "DRIVE_IDENTITY_UNPROVEN"),
+        "fence_unavailable": (dict(mounted=True, identity_proven=True, fence_held=False,
+                                   write_authority="dedicated_local", live_free_bytes=1000),
+                              "DRIVE_FENCE_UNAVAILABLE"),
+        "shared_writer": (dict(mounted=True, identity_proven=True, fence_held=True,
+                               write_authority="unknown", live_free_bytes=1000),
+                          "UNSUPPORTED_SHARED_WRITER"),
+        "offline_dirty": (dict(write_authority="dedicated_local", anchor_free_bytes=800,
+                               anchor_epoch=1, dirty=True), "DRIVE_RECONCILIATION_REQUIRED"),
+        "anchor_epoch_mismatch": (dict(write_authority="dedicated_local", anchor_free_bytes=800,
+                                       anchor_epoch=2, current_epoch=1),
+                                  "DRIVE_RECONCILIATION_REQUIRED"),
+        "anchor_fingerprint_mismatch": (dict(write_authority="dedicated_local", anchor_free_bytes=800,
+                                             anchor_epoch=1, anchor_fingerprint="stale",
+                                             current_fingerprint="fp"),
+                                        "DRIVE_RECONCILIATION_REQUIRED"),
+        "anchor_capacity_mismatch": (dict(write_authority="dedicated_local", anchor_free_bytes=800,
+                                          anchor_epoch=1, anchor_filesystem_capacity=999,
+                                          filesystem_capacity_bytes=1000),
+                                     "DRIVE_RECONCILIATION_REQUIRED"),
+        "offline_anchorless": (dict(write_authority="dedicated_local"), "CAPACITY_EVIDENCE_UNKNOWN"),
     }
-    for name, over in cases.items():
+    for name, (over, code) in cases.items():
         ev = _derive(**over)
         assert ev.kind == "unknown" and not ev.executable and ev.admissible_free == 0, name
-        assert ev.code == "CAPACITY_EVIDENCE_UNKNOWN", name
+        assert ev.code == code, (name, ev.code)
 
 
 def test_out_of_range_anchor_is_typed_unknown():
     _require()
     ev = _derive(write_authority="dedicated_local", anchor_free_bytes=2000, anchor_epoch=1,
-                 current_epoch=1, filesystem_capacity_bytes=1000)
+                 current_epoch=1, filesystem_capacity_bytes=1000, anchor_filesystem_capacity=1000)
     assert ev.kind == "unknown" and not ev.executable and ev.admissible_free == 0
     assert ev.code == "ANCHOR_OUT_OF_RANGE"
+
+
+def test_unknown_optimistic_usable_max_is_post_floor_or_none():
+    _require()
+    known = _derive(write_authority="dedicated_local", filesystem_capacity_bytes=1000,
+                    safety_floor_bytes=100)
+    assert known.kind == "unknown" and known.optimistic_usable_max == 900   # post-floor, diagnostic only
+    assert not known.executable and known.admissible_free == 0              # never authorizes bytes
+    unknown_cap = _derive(write_authority="dedicated_local", filesystem_capacity_bytes=None)
+    assert unknown_cap.kind == "unknown" and unknown_cap.optimistic_usable_max is None
 
 
 def test_safety_floor_subtracted_once_and_clamped_at_zero():
@@ -113,20 +143,22 @@ def test_shadow_read_is_side_effect_free_and_all_unknown(tmp_path):
     _require()
     db.CATALOG_DIR = tmp_path
     db.DB_PATH = tmp_path / "catalog.sqlite"
-    con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 2
+    con = db.connect()                                   # fresh catalog is v3 directly (no migration here)
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
+        "fresh catalog must be v3 (expected Gate-1 red)"
     con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) VALUES('drive-00',1000,500)")
     con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) VALUES('drive-01',1000,900)")
-    con.close()
-
-    con = db.connect()                                   # migrate to v3
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "v3 not reached (expected Gate-1 red)"
     before_free = con.execute("SELECT drive_label, free_bytes FROM drives ORDER BY 1").fetchall()
 
     shadow = ce.shadow_by_drive(con)                     # internal diagnostic accessor only
     assert set(shadow) == {"drive-00", "drive-01"}
-    assert all(e.kind == "unknown" and not e.executable and e.admissible_free == 0
-               for e in shadow.values()), shadow
+    for e in shadow.values():
+        # a migrated/unproven drive: unknown, zero executable, no admission authority
+        assert e.kind == "unknown" and not e.executable and e.admissible_free == 0, shadow
+        # current-epoch filesystem capacity is unknown post-migration -> optimistic max is None
+        assert e.optimistic_usable_max is None
+    # legacy free_bytes is exposed ONLY as a diagnostic, never as executable/admissible free
+    assert shadow["drive-00"].legacy_free_bytes == 500 and shadow["drive-01"].legacy_free_bytes == 900
     # diagnostic read: no admission input mutated, no evidence fabricated
     assert con.execute("PRAGMA user_version").fetchone()[0] == 3
     assert con.execute("SELECT drive_label, free_bytes FROM drives ORDER BY 1").fetchall() == before_free

--- a/tests/test_capacity_evidence.py
+++ b/tests/test_capacity_evidence.py
@@ -1,0 +1,162 @@
+"""PR-02 / #35-A pure capacity-evidence primitives (tests-first, RFC-002 / DEC-049).
+
+Gate 1: pins the pure, I/O-free evidence contract BEFORE production. No mounts, df, fencing, or writes
+— every observation is supplied synthetically. RED until `modelark.capacity_evidence` exists; the lazy
+import + `_require()` guard makes each test fail cleanly for missing v3 behavior, not a fixture cascade.
+
+Fail-closed rules (contract): unknown -> zero executable capacity; legacy free_bytes is diagnostic
+only; the safety floor is subtracted exactly once; an out-of-range/mismatched anchor is typed unknown.
+"""
+from __future__ import annotations
+
+from modelark.core import db
+
+try:
+    from modelark import capacity_evidence as ce
+    _HAS = True
+except Exception:                                # noqa: BLE001 — module is the thing under construction
+    ce = None
+    _HAS = False
+
+
+def _require():
+    if not _HAS:
+        raise AssertionError("modelark.capacity_evidence not implemented yet (expected Gate-1 red)")
+
+
+def _derive(**over):
+    """Derive evidence from a synthetic per-drive observation; override only the relevant fields."""
+    base = dict(
+        mounted=False, identity_proven=False, fence_held=False, write_authority="unknown",
+        current_epoch=1, filesystem_capacity_bytes=1000, live_free_bytes=None, dirty=False,
+        anchor_free_bytes=None, anchor_epoch=None, safety_floor_bytes=100,
+    )
+    base.update(over)
+    return ce.derive(**base)
+
+
+def test_identity_fingerprint_v1_golden_vector():
+    _require()
+    assert ce.identity_fingerprint_v1(
+        fs_uuid="filesystem-uuid", annex_uuid="annex-uuid", serial="device-serial",
+        filesystem_capacity_bytes=1999844147200,
+    ) == "0eabbd90a47a23c1f02866f29dd0d0a55c853fb0fad61de32f56d54df07f2651"
+    # explicit nulls are part of the canonical form (fs_uuid/serial absent, annex proven)
+    assert ce.identity_fingerprint_v1(
+        fs_uuid=None, annex_uuid="annex-uuid", serial=None,
+        filesystem_capacity_bytes=1999844147200,
+    ) == "adeac55523d3bb3648ffd47053f4324742847ba80f4267d66868c52be677bc50"
+    # at least one of fs_uuid / annex_uuid must be proven before a fingerprint can be computed
+    try:
+        ce.identity_fingerprint_v1(fs_uuid=None, annex_uuid=None, serial="s",
+                                   filesystem_capacity_bytes=1)
+        raise AssertionError("must refuse a fingerprint with neither fs_uuid nor annex_uuid")
+    except ValueError:
+        pass
+
+
+def test_live_evidence_is_authoritative_even_while_dirty():
+    _require()
+    ev = _derive(mounted=True, identity_proven=True, fence_held=True,
+                 write_authority="dedicated_local", live_free_bytes=1000, dirty=True)
+    assert ev.kind == "live" and ev.executable
+    assert ev.admissible_free == 900 and ev.code is None      # floor subtracted exactly once
+
+
+def test_offline_clean_anchor_is_authoritative_for_the_matching_epoch():
+    _require()
+    ev = _derive(write_authority="dedicated_local", anchor_free_bytes=800, anchor_epoch=1,
+                 current_epoch=1, filesystem_capacity_bytes=1000)
+    assert ev.kind == "anchor" and ev.executable and ev.admissible_free == 700
+
+
+def test_unknown_tiers_are_zero_executable():
+    _require()
+    cases = {
+        "offline_dirty": dict(write_authority="dedicated_local", anchor_free_bytes=800,
+                              anchor_epoch=1, dirty=True),
+        "offline_anchorless": dict(write_authority="dedicated_local"),
+        "anchor_epoch_mismatch": dict(write_authority="dedicated_local", anchor_free_bytes=800,
+                                      anchor_epoch=2, current_epoch=1),
+        "mounted_unfenced": dict(mounted=True, identity_proven=True, fence_held=False,
+                                 write_authority="dedicated_local", live_free_bytes=1000),
+        "shared_authority": dict(mounted=True, identity_proven=True, fence_held=True,
+                                 write_authority="unknown", live_free_bytes=1000),
+        "identity_unproven": dict(mounted=True, identity_proven=False, fence_held=True,
+                                  write_authority="dedicated_local", live_free_bytes=1000),
+    }
+    for name, over in cases.items():
+        ev = _derive(**over)
+        assert ev.kind == "unknown" and not ev.executable and ev.admissible_free == 0, name
+        assert ev.code == "CAPACITY_EVIDENCE_UNKNOWN", name
+
+
+def test_out_of_range_anchor_is_typed_unknown():
+    _require()
+    ev = _derive(write_authority="dedicated_local", anchor_free_bytes=2000, anchor_epoch=1,
+                 current_epoch=1, filesystem_capacity_bytes=1000)
+    assert ev.kind == "unknown" and not ev.executable and ev.admissible_free == 0
+    assert ev.code == "ANCHOR_OUT_OF_RANGE"
+
+
+def test_safety_floor_subtracted_once_and_clamped_at_zero():
+    _require()
+    exact = _derive(mounted=True, identity_proven=True, fence_held=True,
+                    write_authority="dedicated_local", live_free_bytes=250, safety_floor_bytes=100)
+    assert exact.admissible_free == 150
+    clamped = _derive(mounted=True, identity_proven=True, fence_held=True,
+                      write_authority="dedicated_local", live_free_bytes=50, safety_floor_bytes=100)
+    assert clamped.kind == "live" and clamped.admissible_free == 0    # never negative
+
+
+def test_shadow_read_is_side_effect_free_and_all_unknown(tmp_path):
+    _require()
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 2
+    con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) VALUES('drive-00',1000,500)")
+    con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) VALUES('drive-01',1000,900)")
+    con.close()
+
+    con = db.connect()                                   # migrate to v3
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "v3 not reached (expected Gate-1 red)"
+    before_free = con.execute("SELECT drive_label, free_bytes FROM drives ORDER BY 1").fetchall()
+
+    shadow = ce.shadow_by_drive(con)                     # internal diagnostic accessor only
+    assert set(shadow) == {"drive-00", "drive-01"}
+    assert all(e.kind == "unknown" and not e.executable and e.admissible_free == 0
+               for e in shadow.values()), shadow
+    # diagnostic read: no admission input mutated, no evidence fabricated
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3
+    assert con.execute("SELECT drive_label, free_bytes FROM drives ORDER BY 1").fetchall() == before_free
+    assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
+    assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+    con.close()
+
+
+def main():
+    import inspect
+    import tempfile
+    from pathlib import Path
+    tests = sorted((n, f) for n, f in globals().items()
+                   if n.startswith("test_") and callable(f))
+    passed, failed = [], []
+    for name, fn in tests:
+        try:
+            if "tmp_path" in inspect.signature(fn).parameters:
+                fn(Path(tempfile.mkdtemp(prefix="mark-ev-")))
+            else:
+                fn()
+            passed.append(name)
+            print(f"PASS  {name}")
+        except Exception as exc:                 # noqa: BLE001 — Gate-1 wants the full red/green map
+            failed.append(name)
+            print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
+    print(f"\n{len(passed)} passed, {len(failed)} failed")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_catalog_v3_migration.py
+++ b/tests/test_catalog_v3_migration.py
@@ -131,46 +131,57 @@ def test_v3_schema_constraint_matrix(tmp_path):
     assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
         "v3 schema not created (expected Gate-1 red)"
 
-    def rejects(sql, params=()):
+    def rejected(sql, exc_types, contains=None):
+        """A negative case: the statement must raise the SPECIFIC constraint error, so an unrelated
+        OperationalError (missing/misspelled column in a malformed schema) is NOT mistaken for a
+        working constraint (Greptile #1)."""
         try:
-            con.execute(sql, list(params))
-            return False
-        except sqlite3.Error:
-            return True
+            con.execute(sql)
+        except exc_types as exc:
+            return contains is None or contains.lower() in str(exc).lower()
+        return False
 
-    # A valid dirty generation (both owner fields null, pre-#39) is accepted...
-    assert not rejects(
-        "INSERT INTO drive_dirty_generations(drive_label,identity_epoch,generation,operation_code) "
-        "VALUES('drive-00',1,1,'test')")
-    # ...append-only triggers reject UPDATE and DELETE on both evidence tables
-    assert rejects("UPDATE drive_dirty_generations SET operation_code='x' WHERE generation=1")
-    assert rejects("DELETE FROM drive_dirty_generations WHERE generation=1")
-    # both-present owner pair is allowed; exactly-one is refused by the paired CHECK
-    assert not rejects(
-        "INSERT INTO drive_dirty_generations"
-        "(drive_label,identity_epoch,generation,operation_code,owner_session_id,owner_fencing_token) "
-        "VALUES('drive-00',1,2,'test','sess',7)")
-    assert rejects(
+    fp = "a" * 64
+    anchor = ("INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
+              "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
+              "observed_at) VALUES('drive-00',1,{gen},{free},1000,'{fp}','{auth}','p','p','now')")
+
+    # Positive controls: valid rows insert cleanly. If the schema is malformed these raise and the
+    # test fails here rather than letting negative cases pass by accident.
+    con.execute("INSERT INTO drive_dirty_generations"
+                "(drive_label,identity_epoch,generation,operation_code) VALUES('drive-00',1,1,'test')")
+    con.execute("INSERT INTO drive_dirty_generations"
+                "(drive_label,identity_epoch,generation,operation_code,owner_session_id,owner_fencing_token)"
+                " VALUES('drive-00',1,2,'test','sess',7)")
+    con.execute(anchor.format(gen=1, free=500, fp=fp, auth="dedicated_local"))   # valid clean anchor
+
+    # Paired dirty-owner CHECK: exactly one of the pair is refused.
+    assert rejected(
         "INSERT INTO drive_dirty_generations"
         "(drive_label,identity_epoch,generation,operation_code,owner_session_id) "
-        "VALUES('drive-00',1,3,'test','sess')")
-    # anchor free bytes must not exceed filesystem capacity, fingerprint must be 64 chars,
-    # write_authority is constrained, and the anchor references an existing dirty generation
-    fp = "a" * 64
-    assert rejects(
-        "INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
-        "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
-        f"observed_at) VALUES('drive-00',1,1,2000,1000,'{fp}','dedicated_local','p','p','now')")
-    assert rejects(
-        "INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
-        "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
-        "observed_at) VALUES('drive-00',1,1,500,1000,'short','dedicated_local','p','p','now')")
-    assert rejects(
-        "INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
-        "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
-        f"observed_at) VALUES('drive-00',1,1,500,1000,'{fp}','shared','p','p','now')")
-    # write_authority on drives is constrained to the two accepted values
-    assert rejects("UPDATE drives SET write_authority='bogus' WHERE drive_label='drive-00'")
+        "VALUES('drive-00',1,3,'test','sess')", sqlite3.IntegrityError)
+
+    # Append-only triggers reject UPDATE and DELETE on BOTH evidence tables (Greptile #2). Triggers
+    # RAISE(ABORT, '... append-only'), so assert the trigger error specifically, not any error.
+    for table in ("drive_dirty_generations", "drive_clean_anchors"):
+        assert rejected(f"UPDATE {table} SET identity_epoch=9 WHERE generation=1",
+                        sqlite3.OperationalError, "append-only"), table
+        assert rejected(f"DELETE FROM {table} WHERE generation=1",
+                        sqlite3.OperationalError, "append-only"), table
+
+    # Anchor free bytes must not exceed filesystem capacity; fingerprint must be 64 chars;
+    # write_authority is constrained — each on the existing, still-unanchored generation 2.
+    assert rejected(anchor.format(gen=2, free=2000, fp=fp, auth="dedicated_local"), sqlite3.IntegrityError)
+    assert rejected(anchor.format(gen=2, free=500, fp="short", auth="dedicated_local"), sqlite3.IntegrityError)
+    assert rejected(anchor.format(gen=2, free=500, fp=fp, auth="shared"), sqlite3.IntegrityError)
+
+    # Anchor -> dirty-generation FK is exercised independently (Greptile #3): a structurally valid
+    # anchor referencing a nonexistent generation must be rejected by the foreign key, not a CHECK.
+    assert rejected(anchor.format(gen=999, free=500, fp=fp, auth="dedicated_local"), sqlite3.IntegrityError)
+
+    # drives.write_authority is constrained to the two accepted values.
+    assert rejected("UPDATE drives SET write_authority='bogus' WHERE drive_label='drive-00'",
+                    sqlite3.IntegrityError)
     con.close()
 
 

--- a/tests/test_catalog_v3_migration.py
+++ b/tests/test_catalog_v3_migration.py
@@ -154,7 +154,7 @@ def test_injected_failure_rolls_back_to_v2(tmp_path):
     try:
         db._migrate_capacity_evidence_v3(proxy, backup_existing=True)
         raise AssertionError("migration should have raised")
-    except sqlite3.OperationalError:
+    except RuntimeError:                                # migration wraps a mid-DDL failure, like v1->v2
         pass
     con.close()
 

--- a/tests/test_catalog_v3_migration.py
+++ b/tests/test_catalog_v3_migration.py
@@ -34,12 +34,38 @@ class _FailOn:
         return getattr(self._con, name)
 
 
+# Frozen v2 `drives` definition — deliberately independent of the packaged schema so this fixture
+# keeps producing a genuine v2 catalog after Gate 2 adds the v3 columns/tables and bumps
+# _SCHEMA_VERSION to 3. Kept byte-for-byte equal to the schema-v2 drives shape.
+_V2_DRIVES_COLS = ("drive_label,fs_uuid,annex_uuid,capacity_bytes,free_bytes,hw_model,serial,"
+                   "physical_location,role,raid_backed,health,last_seen,notes")
+_V2_DRIVES_DDL = """
+CREATE TABLE {name} (
+    drive_label        VARCHAR PRIMARY KEY NOT NULL CHECK (length(trim(drive_label)) > 0),
+    fs_uuid            VARCHAR,
+    annex_uuid         VARCHAR,
+    capacity_bytes     BIGINT CHECK (capacity_bytes IS NULL OR capacity_bytes >= 0),
+    free_bytes         BIGINT CHECK (free_bytes IS NULL OR free_bytes >= 0),
+    hw_model           VARCHAR,
+    serial             VARCHAR,
+    physical_location  VARCHAR,
+    role               VARCHAR NOT NULL DEFAULT 'primary' CHECK (role IN ('primary','replica')),
+    raid_backed        BOOLEAN NOT NULL DEFAULT false CHECK (raid_backed IN (0, 1)),
+    health             VARCHAR,
+    last_seen          TIMESTAMP,
+    notes              VARCHAR
+)
+"""
+
+
 def _seed_v2(tmp_path):
-    """Build a real v2 catalog (current build) with a drive carrying identity + legacy scalars."""
+    """Build a genuine v2 catalog INDEPENDENT of the build's current _SCHEMA_VERSION: bootstrap the
+    packaged schema, seed data, then transactionally strip any v3-only objects/columns using the
+    frozen v2 drives definition and stamp user_version=2. This stays a real v2 fixture even after
+    Gate 2 raises the packaged schema to v3."""
     db.CATALOG_DIR = tmp_path
     db.DB_PATH = tmp_path / "catalog.sqlite"
     con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 2, "fixture must start at schema v2"
     con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
     con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
                 "VALUES('org/m','model.safetensors',100,'safetensors','bf16')")
@@ -47,7 +73,25 @@ def _seed_v2(tmp_path):
                 "VALUES('drive-00',1000,500,'fs-uuid-00','annex-uuid-00','serial-00')")
     con.execute("INSERT INTO archived(repo_id,rfilename,drive_label,compressed) "
                 "VALUES('org/m','model.safetensors','drive-00',0)")
+    con.execute("PRAGMA foreign_keys=OFF")
+    con.execute("PRAGMA legacy_alter_table=ON")         # renames must not rewrite archived's FK target
+    con.execute("BEGIN")
+    con.execute("DROP TABLE IF EXISTS drive_clean_anchors")     # also drops its indexes + triggers
+    con.execute("DROP TABLE IF EXISTS drive_dirty_generations")
+    con.execute(_V2_DRIVES_DDL.format(name="drives__v2"))       # frozen v2 shape under a temp name
+    con.execute(f"INSERT INTO drives__v2({_V2_DRIVES_COLS}) SELECT {_V2_DRIVES_COLS} FROM drives")
+    con.execute("DROP TABLE drives")
+    con.execute("ALTER TABLE drives__v2 RENAME TO drives")
+    con.execute("PRAGMA user_version=2")
+    con.execute("COMMIT")
     con.close()
+    # sanity: the fixture really is v2 regardless of the build's packaged schema version
+    check = _reopen_raw()
+    assert check.execute("PRAGMA user_version").fetchone()[0] == 2, "fixture must be a v2 catalog"
+    tables = {r[0] for r in check.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    assert "drive_clean_anchors" not in tables and "drive_dirty_generations" not in tables
+    assert "identity_epoch" not in {r[1] for r in check.execute("PRAGMA table_info(drives)").fetchall()}
+    check.close()
 
 
 def _reopen_raw():
@@ -161,13 +205,14 @@ def test_v3_schema_constraint_matrix(tmp_path):
         "(drive_label,identity_epoch,generation,operation_code,owner_session_id) "
         "VALUES('drive-00',1,3,'test','sess')", sqlite3.IntegrityError)
 
-    # Append-only triggers reject UPDATE and DELETE on BOTH evidence tables (Greptile #2). Triggers
-    # RAISE(ABORT, '... append-only'), so assert the trigger error specifically, not any error.
+    # Append-only triggers reject UPDATE and DELETE on BOTH evidence tables (Greptile #2). SQLite
+    # RAISE(ABORT, '... append-only') surfaces as sqlite3.IntegrityError (verified), so assert that
+    # specific error + message, not a bare error.
     for table in ("drive_dirty_generations", "drive_clean_anchors"):
         assert rejected(f"UPDATE {table} SET identity_epoch=9 WHERE generation=1",
-                        sqlite3.OperationalError, "append-only"), table
+                        sqlite3.IntegrityError, "append-only"), table
         assert rejected(f"DELETE FROM {table} WHERE generation=1",
-                        sqlite3.OperationalError, "append-only"), table
+                        sqlite3.IntegrityError, "append-only"), table
 
     # Anchor free bytes must not exceed filesystem capacity; fingerprint must be 64 chars;
     # write_authority is constrained — each on the existing, still-unanchored generation 2.

--- a/tests/test_catalog_v3_migration.py
+++ b/tests/test_catalog_v3_migration.py
@@ -169,6 +169,30 @@ def test_injected_failure_rolls_back_to_v2(tmp_path):
     assert db.DB_PATH.with_name(db.DB_PATH.name + ".pre-evidence-v3.bak").is_file()
 
 
+def test_migration_aborts_on_foreign_key_violation(tmp_path):
+    """The v3 migration runs PRAGMA foreign_key_check inside its transaction and refuses to stamp v3
+    over a catalog with foreign-key violations, rolling back to a pristine v2."""
+    assert hasattr(db, "_migrate_capacity_evidence_v3"), \
+        "v3 migration not implemented yet (expected Gate-1 red)"
+    _seed_v2(tmp_path)
+    con = _reopen_raw()
+    con.execute("PRAGMA foreign_keys=OFF")
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
+                "VALUES('org/m','ghost.safetensors',1,'safetensors','bf16')")
+    con.execute("INSERT INTO archived(repo_id,rfilename,drive_label,compressed) "    # orphan: no such drive
+                "VALUES('org/m','ghost.safetensors','ghost-drive',0)")
+    try:
+        db._migrate_capacity_evidence_v3(con, backup_existing=True)
+        raise AssertionError("migration must abort on a foreign-key violation")
+    except RuntimeError as exc:
+        assert "foreign" in str(exc).lower(), exc
+    con.close()
+    raw = _reopen_raw()
+    assert raw.execute("PRAGMA user_version").fetchone()[0] == 2, "must roll back to v2"
+    assert "identity_epoch" not in {r[1] for r in raw.execute("PRAGMA table_info(drives)").fetchall()}
+    raw.close()
+
+
 def test_v3_schema_constraint_matrix(tmp_path):
     _seed_v2(tmp_path)
     con = db.connect()

--- a/tests/test_catalog_v3_migration.py
+++ b/tests/test_catalog_v3_migration.py
@@ -1,0 +1,201 @@
+"""PR-02 / #35-A catalog-v3 migration contract (tests-first, RFC-002 / DEC-049).
+
+Gate 1: expresses the v2->v3 migration + schema contract BEFORE production. Change-contract tests are
+RED until the v3 migration and DDL exist, and fail for the reviewed reason (missing v3 behavior), not
+a broken fixture — each builds a genuine v2 catalog with the current build, then asserts the v3 result.
+
+Scope (per Gate 0): schema additions + backup-first, transactional, additive migration only. No
+fencing, mounts, df, drive writes, recovery, or admission cutover (those are #35-B/#35-C).
+
+The pre-existing generic "a newer schema is rejected" test in test_db_sqlite.py is retained and will be
+re-pointed to v4 alongside the implementation; it is not duplicated here.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from modelark.core import db
+
+
+class _FailOn:
+    """A connection proxy that raises when a chosen marker appears in a statement, to inject a
+    mid-migration failure while delegating everything else (including con.backup) to the real con."""
+
+    def __init__(self, con, marker):
+        self._con = con
+        self._marker = marker
+
+    def execute(self, sql, *args):
+        if self._marker in sql:
+            raise sqlite3.OperationalError(f"injected failure at: {self._marker}")
+        return self._con.execute(sql, *args)
+
+    def __getattr__(self, name):
+        return getattr(self._con, name)
+
+
+def _seed_v2(tmp_path):
+    """Build a real v2 catalog (current build) with a drive carrying identity + legacy scalars."""
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 2, "fixture must start at schema v2"
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
+                "VALUES('org/m','model.safetensors',100,'safetensors','bf16')")
+    con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes,fs_uuid,annex_uuid,serial) "
+                "VALUES('drive-00',1000,500,'fs-uuid-00','annex-uuid-00','serial-00')")
+    con.execute("INSERT INTO archived(repo_id,rfilename,drive_label,compressed) "
+                "VALUES('org/m','model.safetensors','drive-00',0)")
+    con.close()
+
+
+def _reopen_raw():
+    return sqlite3.connect(str(db.DB_PATH), isolation_level=None)
+
+
+def test_migrate_v2_to_v3_adds_schema_and_preserves_rows(tmp_path):
+    _seed_v2(tmp_path)
+    con = db.connect()                                  # triggers the v2->v3 migration
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
+        "v2->v3 migration not implemented (expected Gate-1 red)"
+
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    assert {"identity_epoch", "write_generation", "filesystem_capacity_bytes",
+            "identity_fingerprint", "write_authority"} <= dcols
+    row = con.execute(
+        "SELECT identity_epoch, write_generation, write_authority, filesystem_capacity_bytes, "
+        "identity_fingerprint, free_bytes, capacity_bytes, fs_uuid, annex_uuid, serial "
+        "FROM drives WHERE drive_label='drive-00'").fetchone()
+    # defaults on the migrated row + no fabricated evidence; legacy scalars/identity preserved exactly
+    assert row == (1, 0, "unknown", None, None, 500, 1000, "fs-uuid-00", "annex-uuid-00", "serial-00")
+
+    tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    assert {"drive_dirty_generations", "drive_clean_anchors"} <= tables
+    assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
+    assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+    assert con.execute("SELECT count(*) FROM models").fetchone()[0] == 1
+    assert con.execute("SELECT count(*) FROM archived").fetchone()[0] == 1
+
+    bak = db.DB_PATH.with_name(db.DB_PATH.name + ".pre-evidence-v3.bak")
+    assert bak.is_file(), "non-overwriting v2 backup must exist"
+    b = sqlite3.connect(str(bak))
+    assert b.execute("PRAGMA user_version").fetchone()[0] == 2, "backup must remain a v2 catalog"
+    btables = {r[0] for r in b.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    assert "drive_clean_anchors" not in btables
+    b.close()
+    con.close()
+
+
+def test_migration_is_idempotent(tmp_path):
+    _seed_v2(tmp_path)
+    db.connect().close()
+    con = db.connect()                                  # second open must be a stable no-op
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
+        "v2->v3 migration not implemented (expected Gate-1 red)"
+    assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
+    assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+    dcols = [r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()]
+    assert len(dcols) == len(set(dcols)), "no duplicate columns from a second migration"
+    con.close()
+
+
+def test_injected_failure_rolls_back_to_v2(tmp_path):
+    assert hasattr(db, "_migrate_capacity_evidence_v3"), \
+        "v3 migration not implemented yet (expected Gate-1 red)"
+    _seed_v2(tmp_path)
+    con = _reopen_raw()
+    con.execute("PRAGMA foreign_keys=OFF")
+    proxy = _FailOn(con, "drive_clean_anchors")         # fail mid-DDL, after the backup
+    try:
+        db._migrate_capacity_evidence_v3(proxy, backup_existing=True)
+        raise AssertionError("migration should have raised")
+    except sqlite3.OperationalError:
+        pass
+    con.close()
+
+    raw = _reopen_raw()
+    assert raw.execute("PRAGMA user_version").fetchone()[0] == 2, "failed migration must leave v2"
+    tables = {r[0] for r in raw.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    assert "drive_dirty_generations" not in tables and "drive_clean_anchors" not in tables
+    dcols = {r[1] for r in raw.execute("PRAGMA table_info(drives)").fetchall()}
+    assert "identity_epoch" not in dcols, "no v3 column may survive a rolled-back migration"
+    assert raw.execute("SELECT count(*) FROM drives").fetchone()[0] == 1, "data preserved"
+    raw.close()
+    assert db.DB_PATH.with_name(db.DB_PATH.name + ".pre-evidence-v3.bak").is_file()
+
+
+def test_v3_schema_constraint_matrix(tmp_path):
+    _seed_v2(tmp_path)
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
+        "v3 schema not created (expected Gate-1 red)"
+
+    def rejects(sql, params=()):
+        try:
+            con.execute(sql, list(params))
+            return False
+        except sqlite3.Error:
+            return True
+
+    # A valid dirty generation (both owner fields null, pre-#39) is accepted...
+    assert not rejects(
+        "INSERT INTO drive_dirty_generations(drive_label,identity_epoch,generation,operation_code) "
+        "VALUES('drive-00',1,1,'test')")
+    # ...append-only triggers reject UPDATE and DELETE on both evidence tables
+    assert rejects("UPDATE drive_dirty_generations SET operation_code='x' WHERE generation=1")
+    assert rejects("DELETE FROM drive_dirty_generations WHERE generation=1")
+    # both-present owner pair is allowed; exactly-one is refused by the paired CHECK
+    assert not rejects(
+        "INSERT INTO drive_dirty_generations"
+        "(drive_label,identity_epoch,generation,operation_code,owner_session_id,owner_fencing_token) "
+        "VALUES('drive-00',1,2,'test','sess',7)")
+    assert rejects(
+        "INSERT INTO drive_dirty_generations"
+        "(drive_label,identity_epoch,generation,operation_code,owner_session_id) "
+        "VALUES('drive-00',1,3,'test','sess')")
+    # anchor free bytes must not exceed filesystem capacity, fingerprint must be 64 chars,
+    # write_authority is constrained, and the anchor references an existing dirty generation
+    fp = "a" * 64
+    assert rejects(
+        "INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
+        "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
+        f"observed_at) VALUES('drive-00',1,1,2000,1000,'{fp}','dedicated_local','p','p','now')")
+    assert rejects(
+        "INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
+        "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
+        "observed_at) VALUES('drive-00',1,1,500,1000,'short','dedicated_local','p','p','now')")
+    assert rejects(
+        "INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
+        "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
+        f"observed_at) VALUES('drive-00',1,1,500,1000,'{fp}','shared','p','p','now')")
+    # write_authority on drives is constrained to the two accepted values
+    assert rejects("UPDATE drives SET write_authority='bogus' WHERE drive_label='drive-00'")
+    con.close()
+
+
+def main():
+    import inspect
+    import tempfile
+    from pathlib import Path
+    tests = sorted((n, f) for n, f in globals().items()
+                   if n.startswith("test_") and callable(f))
+    passed, failed = [], []
+    for name, fn in tests:
+        try:
+            if "tmp_path" in inspect.signature(fn).parameters:
+                fn(Path(tempfile.mkdtemp(prefix="mark-v3-")))
+            else:
+                fn()
+            passed.append(name)
+            print(f"PASS  {name}")
+        except Exception as exc:                 # noqa: BLE001 — Gate-1 wants the full red/green map
+            failed.append(name)
+            print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
+    print(f"\n{len(passed)} passed, {len(failed)} failed")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_db_sqlite.py
+++ b/tests/test_db_sqlite.py
@@ -30,6 +30,15 @@ def _legacy_without_constraints(tmp_path):
         con.execute(f'DROP TABLE "{table}"')
     for table in db._INTEGRITY_TABLES:
         con.execute(f'ALTER TABLE "{table}__legacy" RENAME TO "{table}"')
+    # Represent a genuine pre-v3 catalog: strip the catalog-v3 evidence objects/columns a real legacy
+    # database never had, so the rebuild exercises the v0->v3 path from scratch (not a hybrid shape).
+    con.execute("DROP TABLE IF EXISTS drive_clean_anchors")
+    con.execute("DROP TABLE IF EXISTS drive_dirty_generations")
+    pre_v3 = ("drive_label,fs_uuid,annex_uuid,capacity_bytes,free_bytes,hw_model,serial,"
+              "physical_location,role,raid_backed,health,last_seen,notes")
+    con.execute(f"CREATE TABLE drives__pre3 AS SELECT {pre_v3} FROM drives")
+    con.execute("DROP TABLE drives")
+    con.execute("ALTER TABLE drives__pre3 RENAME TO drives")
     con.execute("PRAGMA user_version=0")
     con.close()
     return sqlite3.connect(str(db.DB_PATH), isolation_level=None)
@@ -72,7 +81,11 @@ def test_schema_and_views(tmp_path):
     assert con.execute("PRAGMA foreign_key_list(archived)").fetchall()
     plan_columns = {row[1] for row in con.execute("PRAGMA table_info(plans)").fetchall()}
     assert "capacity_mode" in plan_columns and "provisioning" not in plan_columns
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION
+    # v3 (#35-A) evidence objects are bootstrapped for a fresh catalog too
+    drive_columns = {row[1] for row in con.execute("PRAGMA table_info(drives)").fetchall()}
+    assert {"identity_epoch", "write_generation", "write_authority"} <= drive_columns
+    assert {"drive_dirty_generations", "drive_clean_anchors"} <= tables
     con.close()
 
 
@@ -250,7 +263,7 @@ def test_v1_capacity_modes_map_transactionally_and_idempotently(tmp_path):
     ).fetchall() == [("aware", "compression_aware"), ("safe", "guaranteed")]
     columns = {row[1] for row in con.execute("PRAGMA table_info(plans)").fetchall()}
     assert "capacity_mode" in columns and "provisioning" not in columns
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION
     assert con.execute("PRAGMA foreign_key_check").fetchall() == []
     assert con.execute("SELECT plan_id,drive_label FROM plan_drives").fetchone() == (
         "safe", "drive-01"
@@ -305,7 +318,7 @@ def test_v2_capacity_mode_migration_rolls_back_invalid_legacy_value(tmp_path):
 
 def test_newer_catalog_is_rejected_without_stamping_down(tmp_path):
     con = _fresh(tmp_path)
-    con.execute("PRAGMA user_version=3")
+    con.execute("PRAGMA user_version=4")             # a schema newer than this build (_SCHEMA_VERSION=3)
     con.close()
     before = db.DB_PATH.read_bytes()
     sidecars_before = {
@@ -318,7 +331,7 @@ def test_newer_catalog_is_rejected_without_stamping_down(tmp_path):
     except RuntimeError as exc:
         assert "newer than this ModelArk build" in str(exc), exc
     raw = sqlite3.connect(str(db.DB_PATH))
-    assert raw.execute("PRAGMA user_version").fetchone()[0] == 3
+    assert raw.execute("PRAGMA user_version").fetchone()[0] == 4
     raw.close()
     assert db.DB_PATH.read_bytes() == before
     assert {

--- a/tests/test_db_sqlite.py
+++ b/tests/test_db_sqlite.py
@@ -229,6 +229,32 @@ def test_legacy_catalog_rebuild_preserves_rows_and_applies_migrations(tmp_path):
     v2_backup.close()
 
 
+def test_v0_to_v3_migration_backs_up_a_genuine_v2_before_evidence(tmp_path):
+    """A v0 catalog migrating all the way to v3 must still take the evidence backup, and that backup
+    must be a genuine v2 (no v3 columns/tables): the integrity rebuild must not pull the v3 drive
+    columns backward and let the v3 step short-circuit past its own backup."""
+    con = _legacy_without_constraints(tmp_path)
+    con.execute("INSERT INTO drives(drive_label,free_bytes,role,raid_backed) "
+                "VALUES('drive-01',500,'primary',0)")
+    con.close()
+
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION
+    drive_columns = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    assert {"identity_epoch", "write_authority"} <= drive_columns
+    assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0   # no fabricated evidence
+    con.close()
+
+    v3_backup = db.DB_PATH.with_name(f"{db.DB_PATH.name}.pre-evidence-v3.bak")
+    assert v3_backup.is_file(), "v0->v3 must still take the evidence backup"
+    backup = sqlite3.connect(str(v3_backup))
+    assert backup.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert "identity_epoch" not in {r[1] for r in backup.execute("PRAGMA table_info(drives)").fetchall()}
+    tables = {r[0] for r in backup.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    assert "drive_clean_anchors" not in tables and "drive_dirty_generations" not in tables
+    backup.close()
+
+
 def test_legacy_orphans_abort_and_roll_back_integrity_rebuild(tmp_path):
     con = _legacy_without_constraints(tmp_path)
     con.execute("INSERT INTO selection(repo_id) VALUES('missing/model')")

--- a/tests/test_legacy_runtime_migration.py
+++ b/tests/test_legacy_runtime_migration.py
@@ -125,7 +125,7 @@ def test_execute_backs_up_migrates_validates_and_publishes(tmp_path):
         "nested/model.safetensors.znn"
     assert con.execute("SELECT plan_id,is_active FROM plans").fetchone() == ("ark", 1)
     assert con.execute("SELECT capacity_mode FROM plans").fetchone()[0] == "compression_aware"
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION
     assert con.execute("SELECT drive_label FROM plan_drives").fetchone()[0] == "drive-01"
     con.close()
     run = backups / "modelark-migration-fixture"


### PR DESCRIPTION
## PR-02 / #35-A — catalog-v3 schema, migration, evidence primitives: test contract (tests-only, Gate 1)

Tests-first slice for **RFC-002 / DEC-049, issue #35 slice A**. **No production code** — this is the reviewable test contract to confirm before implementation. Targets `fix/placement-capacity-hardening` (frozen-lineage series; not `main`). Base = integration tip `c3cc308`.

### Scope (approved Gate 0 shape)
Narrow catalog-migration + pure-logic slice. **No archive-disk interaction** (no mounts, `df`, drive writes, fencing, recovery, interruption handling, or live-runtime changes). Fencing/observation/reconciliation/recovery is **#35-B**; admission-authority cutover and `free_bytes`/`SUM(stored)` removal is **#35-C**.

### The contract these tests pin
- **`tests/test_catalog_v3_migration.py`** — v2→v3 adds the five `drives` columns + the two append-only evidence tables and **preserves every row and legacy scalar with no fabricated evidence** (all drives left `unknown` at epoch 1); idempotent replay; a **non-overwriting v2 backup that remains v2**; an **injected mid-migration failure rolls back to a pristine v2** (no v3 object survives); a compact **schema-constraint matrix** (append-only UPDATE/DELETE triggers, paired dirty-owner CHECK, `anchor_free_bytes ≤ filesystem_capacity`, 64-char fingerprint, `write_authority` domain).
- **`tests/test_capacity_evidence.py`** — identity-fingerprint v1 **golden vectors** (incl. explicit-null form and the ≥1-of-`fs_uuid`/`annex_uuid` rule); the **fail-closed precedence matrix** (live authoritative while dirty; offline clean anchor for the matching epoch; every unknown tier zero-executable; out-of-range anchor typed `unknown`; safety floor subtracted once and clamped at zero); and an **internal shadow accessor** that returns `unknown` for every migrated drive with **no side effects** (proxy for "no admission change").

### Expected status (tests-first — RED is intended)
11 tests red for the reviewed reason: the v2→v3 migration/schema and the `modelark.capacity_evidence` module are absent. Fixtures build a genuine v2 catalog and their v2 assertions pass; the existing suite is unaffected. CI on this draft is therefore expected red; implementation (Gate 2) turns it green.

### Deferred to Gate 2 (with implementation)
The generic newer-schema rejection test (`test_db_sqlite.py`) is re-pointed to v4, and the installed-wheel migration smoke is updated to v3 — both ride with the version bump rather than as gratuitously-red edits here.

### Out of scope (unchanged)
Observation/fencing/recovery/registration/lifecycle (#35-B); admission cutover + legacy-free removal (#35-C); session/proposal tables + owner-field population (#39); shared-NAS fencing; drive lifecycle ops; placement; provider pinning. No `main` sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
