### PR TITLE
PR-03b (#35-B): wire Fill/replica transport through the catalog-v3 mutation envelope

### DIFF
--- a/modelark/drive_mutation.py
+++ b/modelark/drive_mutation.py
@@ -16,7 +16,7 @@ durable sessions/fencing tokens = #39).
 """
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 
 from modelark import drive_fence
@@ -46,10 +46,12 @@ class DriveMutationRefused(Exception):
 
 class _Writer:
     """Records the exact paths and annex keys a mutation touched per drive, for generation-scoped
-    reconciliation (no full-drive inventory)."""
+    reconciliation (no full-drive inventory), and exposes the held drive-fence FDs so monitored children
+    can inherit them (parent death cannot then release the fence while a child still writes)."""
 
-    def __init__(self):
+    def __init__(self, child_fence_fds=()):
         self._touched = {}
+        self.child_fence_fds = tuple(child_fence_fds)
 
     def record_touched(self, drive_label, *, paths=(), keys=()):
         entry = self._touched.setdefault(drive_label, ([], []))
@@ -154,15 +156,20 @@ def drive_mutation(con, drive_labels, operation_code, *, observe, reconcile, now
     label, paths, keys)`` reconciles the generation's touched set. Yields a writer with
     ``record_touched(label, paths=…, keys=…)``."""
     try:
-        # Controller fence FIRST: no lifecycle change can race between reading facts and dirtying,
-        # so identity facts + drive-lock keys are captured under it (not before it).
-        with drive_fence.hold_controller(db.DB_PATH, blocking=blocking):
-            facts = {label: _drive_facts(con, label) for label in drive_labels}
-            for label, (_epoch, _gen, fingerprint, _cap, _auth) in facts.items():
-                if not fingerprint:                  # only a stable proven identity may be locked here
-                    raise DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
-            keyed = sorted((facts[label][2], facts[label][0]) for label in drive_labels)  # (fp, epoch)
-            with drive_fence.hold_drives_sorted(keyed, blocking=blocking):
+        # The sorted drive fences span the whole mutation (body -> reconcile -> anchor). The controller
+        # fence is held ONLY long enough to capture facts under it, acquire the drive fences, prove
+        # identity, and commit the dirty advance; it is then RELEASED (RFC-002 / DEC-049) so operator
+        # graph writes and recovery are not blocked for the transport body, while the drive fences stay
+        # held below.
+        with ExitStack() as drive_fences:
+            with drive_fence.hold_controller(db.DB_PATH, blocking=blocking):
+                facts = {label: _drive_facts(con, label) for label in drive_labels}
+                for label, (_epoch, _gen, fingerprint, _cap, _auth) in facts.items():
+                    if not fingerprint:              # only a stable proven identity may be locked here
+                        raise DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
+                keyed = sorted((facts[label][2], facts[label][0]) for label in drive_labels)  # (fp, epoch)
+                handles = drive_fences.enter_context(
+                    drive_fence.hold_drives_sorted(keyed, blocking=blocking))
                 # identity proven under BOTH fences before any dirtying
                 for label, (_epoch, _gen, fingerprint, capacity, _auth) in facts.items():
                     _require_identity(observe(label), fingerprint, capacity, label)
@@ -170,20 +177,21 @@ def drive_mutation(con, drive_labels, operation_code, *, observe, reconcile, now
                 captured = _immediate(con, lambda: {
                     label: _advance_one(con, label, operation_code, facts[label])
                     for label in drive_labels})
-                writer = _Writer()
-                yield writer
-                # collect ALL candidate anchors (reconcile + fresh observation per drive), then publish
-                # them in ONE transaction so a later drive's failure leaves no drive marked clean
-                candidates = {}
-                for label, (_epoch, _gen, fingerprint, capacity, _auth) in facts.items():
-                    paths, keys = writer.touched_for(label)
-                    reconcile(label, paths, keys)
-                    observation = observe(label)
-                    _require_identity(observation, fingerprint, capacity, label)
-                    candidates[label] = observation
-                _immediate(con, lambda: [
-                    _publish_anchor_locked(con, label, facts[label][0], captured[label],
-                                           candidates[label], now)
-                    for label in drive_labels])
+            # controller released here; the drive fences remain held for the body below
+            writer = _Writer([handle.fileno() for handle in handles])
+            yield writer
+            # collect ALL candidate anchors (reconcile + fresh observation per drive), then publish
+            # them in ONE transaction so a later drive's failure leaves no drive marked clean
+            candidates = {}
+            for label, (_epoch, _gen, fingerprint, capacity, _auth) in facts.items():
+                paths, keys = writer.touched_for(label)
+                reconcile(label, paths, keys)
+                observation = observe(label)
+                _require_identity(observation, fingerprint, capacity, label)
+                candidates[label] = observation
+            _immediate(con, lambda: [
+                _publish_anchor_locked(con, label, facts[label][0], captured[label],
+                                       candidates[label], now)
+                for label in drive_labels])
     except drive_fence.FenceUnavailable as exc:
         raise DriveMutationRefused("DRIVE_FENCE_UNAVAILABLE", **exc.evidence) from exc

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -1059,12 +1059,15 @@ def run(dest=None, drive_label=None, limit=None, repos=None, dry_run=False, max_
                             break
                 # DEC-006: propagate to the central map — sync the drive (commit + push the location
                 # log) then sync the map (merge the file tree into its index) so the map is both the
-                # authoritative "where" (location log) and a browsable "what". These mutating sync
-                # children inherit the held drive-fence FDs.
+                # authoritative "where" (location log) and a browsable "what". The map sync names ONLY
+                # this drive's remote (drive_label) — the same explicit-remote form registration uses —
+                # never all remotes, so it cannot reach other (possibly offline) drives; both mutating
+                # sync children inherit the held drive-fence FDs.
                 if annex:
                     s = subprocess.run(["git", "-C", str(dest), "annex", "sync"], capture_output=True,
                                        text=True, pass_fds=tuple(_writer.child_fence_fds))
-                    m = subprocess.run(["git", "-C", str(register.library_root()), "annex", "sync"],
+                    m = subprocess.run(["git", "-C", str(register.library_root()), "annex", "sync",
+                                        drive_label],
                                        capture_output=True, text=True, pass_fds=tuple(_writer.child_fence_fds))
                     if s.returncode == 0 and m.returncode == 0:
                         print("  synced drive + map (location log + index)")
@@ -1282,9 +1285,12 @@ def run_replica_tasks(tasks: Sequence[Any], ctx: RunCtx | None = None) -> dict:
                         if group_deferred:
                             break
                     if group_copied and not group_deferred:
-                        # propagate the landed copies into the central map (inside the fence; the sync
-                        # child inherits the held FDs)
-                        subprocess.run(["git", "-C", str(lib), "annex", "sync"],
+                        # Propagate the landed copies into the central map, naming ONLY this group's
+                        # source+target remotes. This is now pair-scoped and per-group — rather than one
+                        # all-remotes `annex sync` after every group — so the sync stays inside this
+                        # pair's held drive fences and never reaches unrelated (possibly offline) drive
+                        # remotes; the sync child inherits the held FDs.
+                        subprocess.run(["git", "-C", str(lib), "annex", "sync", source, target],
                                        capture_output=True, text=True, pass_fds=fds)
                     if group_deferred:
                         ctx.on_progress({

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -625,8 +625,13 @@ def _reconcile_touched(con, label: str, dest, annex: bool, paths, keys) -> None:
     if annex and keys:
         target_uuid = (con.execute(
             "SELECT annex_uuid FROM drives WHERE drive_label=?", [label]).fetchone() or [None])[0]
+        # keys the touched paths actually resolve to on this drive — a uuid-INDEPENDENT proof, so a drive
+        # whose annex_uuid is not (yet) recorded still reconciles from physical annex tracking rather than
+        # failing closed on every key (`_annex_key_on_uuid` can only match against a known target uuid).
+        path_keys = {tracked for relpath in paths
+                     if (tracked := _annex_key_for_path(dest, dest / relpath))}
         for key in keys:
-            if not _annex_key_on_uuid(dest, key, target_uuid):
+            if not (_annex_key_on_uuid(dest, key, target_uuid) or key in path_keys):
                 raise drive_mutation.DriveMutationRefused(
                     "DRIVE_RECONCILIATION_REQUIRED", drive=label, key=key)
 

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -577,7 +577,14 @@ def _live_drive_evidence(con, label: str) -> dict | None:
     path = register.archive_path(con, label)
     if path is None:
         return None
-    st = os.statvfs(path)
+    try:
+        st = os.statvfs(path)
+    except OSError:
+        # registered but not statvfs-able right now (archive dir absent / unmounted / vanished
+        # mid-probe): identity is unknown, not an error. Returning None -> unproven observation ->
+        # the envelope refuses DRIVE_IDENTITY_UNPROVEN (a typed, handled terminal), never an OSError
+        # that would escape the refusal handler and crash the caller.
+        return None
     return {
         "fs_uuid": register.probe_fs_uuid(path),
         "annex_uuid": register.probe_annex_uuid(path),

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -617,52 +617,53 @@ def _observe_drive(con, label: str) -> drive_mutation.Observation:
 
 
 def _reconcile_touched(con, label: str, dest, annex: bool, paths, keys) -> None:
-    """Generation-scoped reconciliation (never a full-drive scan): validate ONLY the recorded touched
-    paths and annex keys against durable catalog facts + physical presence, using the existing proof
-    helpers. Any gap raises a typed refusal so the generation stays dirty rather than being marked clean.
-    Touched paths are drive-relative (``repo_id`` + '/' + ``stored_relpath``)."""
+    """Generation-scoped reconciliation (never a full-drive scan) of the recorded touched set, per path:
+
+      * read the path's durable ``archived.annex_key``;
+      * a raw (non-annex) touched path requires its durable row and the physical file present;
+      * an annex touched path requires a NON-NULL durable key that AGREES with a writer-recorded key and
+        is proven the exact key present here — via the path's own ``lookupkey`` or ``whereis`` against the
+        drive's annex uuid (the worktree symlink is not proof; ``git annex copy --to`` never creates it).
+
+    A null, mismatched/unrelated, or unprovable annex key — or a missing row / absent raw file — raises
+    DRIVE_RECONCILIATION_REQUIRED so the generation stays dirty rather than being marked clean. Touched
+    paths are drive-relative (``repo_id`` + '/' + ``stored_relpath``)."""
     if not paths and not keys:
         return                              # nothing was touched on this drive -> nothing to reconcile
     if dest is None:
-        # the drive is unresolvable/unmounted at close (archive_path -> None): a TYPED refusal, never a
-        # Path(None) TypeError that would escape the DriveMutationRefused handler and crash the caller.
+        # unresolvable/unmounted at close (archive_path -> None): a TYPED refusal, never a Path(None)
+        # TypeError that would escape the DriveMutationRefused handler and crash the caller.
         raise drive_mutation.DriveMutationRefused("DRIVE_RECONCILIATION_REQUIRED", drive=label)
     dest = Path(dest)
+    recorded = set(keys)                     # the keys the writer recorded for this generation
+    target_uuid = (con.execute(
+        "SELECT annex_uuid FROM drives WHERE drive_label=?", [label]).fetchone() or [None])[0] if annex else None
     for relpath in paths:
-        durable = con.execute(
-            "SELECT 1 FROM archived WHERE drive_label=? AND repo_id || '/' || stored_relpath = ?",
+        row = con.execute(
+            "SELECT annex_key FROM archived WHERE drive_label=? AND repo_id || '/' || stored_relpath = ?",
             [label, relpath]).fetchone()
-        if durable is None:
-            raise drive_mutation.DriveMutationRefused(
+        if row is None:
+            raise drive_mutation.DriveMutationRefused(   # no durable row for a path the writer touched
                 "DRIVE_RECONCILIATION_REQUIRED", drive=label, path=relpath)
-        # A raw (non-annex) file must be physically present in the worktree. For an annex drive the
-        # worktree symlink is NOT the proof — `git annex copy --to` deposits the object without creating
-        # a working-tree link — so annex presence is proven by the key below (whereis/lookupkey), never
-        # by exists(); requiring the symlink here would false-fail every first-time replica copy.
-        if not annex and not (dest / relpath).exists():
-            raise drive_mutation.DriveMutationRefused(
-                "DRIVE_RECONCILIATION_REQUIRED", drive=label, path=relpath)
-    if annex and keys:
-        target_uuid = (con.execute(
-            "SELECT annex_uuid FROM drives WHERE drive_label=?", [label]).fetchone() or [None])[0]
-        # keys the touched paths actually resolve to on this drive — a uuid-INDEPENDENT proof, so a drive
-        # whose annex_uuid is not (yet) recorded still reconciles from physical annex tracking rather than
-        # failing closed on every key (`_annex_key_on_uuid` can only match against a known target uuid).
-        path_keys = set()
-        for relpath in paths:
-            try:
-                tracked = _annex_key_for_path(dest, dest / relpath)
-            except FetchTerminalError:
-                # a git-annex probe timeout (DownloadLocalError) leaves this path's key unproven here; it
-                # falls through to the uuid check and, failing that, the typed refusal below — never a
-                # FetchTerminalError escaping this function past run()'s DriveMutationRefused handler.
-                tracked = None
-            if tracked:
-                path_keys.add(tracked)
-        for key in keys:
-            if not (_annex_key_on_uuid(dest, key, target_uuid) or key in path_keys):
+        if not annex:
+            if not (dest / relpath).exists():            # a raw file must be physically present here
                 raise drive_mutation.DriveMutationRefused(
-                    "DRIVE_RECONCILIATION_REQUIRED", drive=label, key=key)
+                    "DRIVE_RECONCILIATION_REQUIRED", drive=label, path=relpath)
+            continue
+        durable_key = row[0]
+        if not durable_key or durable_key not in recorded:   # null durable key, or one the writer never recorded
+            raise drive_mutation.DriveMutationRefused(
+                "DRIVE_RECONCILIATION_REQUIRED", drive=label, path=relpath, key=durable_key)
+        try:
+            tracked = _annex_key_for_path(dest, dest / relpath)
+        except FetchTerminalError:
+            # a git-annex probe timeout (DownloadLocalError) leaves path-lookup unproven; the uuid check
+            # below may still prove the key, and failing that the typed refusal fires — never a
+            # FetchTerminalError escaping this function past run()'s DriveMutationRefused handler.
+            tracked = None
+        if not (_annex_key_on_uuid(dest, durable_key, target_uuid) or tracked == durable_key):
+            raise drive_mutation.DriveMutationRefused(   # the exact durable key is not provably present here
+                "DRIVE_RECONCILIATION_REQUIRED", drive=label, key=durable_key)
 
 
 def fetch_model(

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -641,8 +641,17 @@ def _reconcile_touched(con, label: str, dest, annex: bool, paths, keys) -> None:
         # keys the touched paths actually resolve to on this drive — a uuid-INDEPENDENT proof, so a drive
         # whose annex_uuid is not (yet) recorded still reconciles from physical annex tracking rather than
         # failing closed on every key (`_annex_key_on_uuid` can only match against a known target uuid).
-        path_keys = {tracked for relpath in paths
-                     if (tracked := _annex_key_for_path(dest, dest / relpath))}
+        path_keys = set()
+        for relpath in paths:
+            try:
+                tracked = _annex_key_for_path(dest, dest / relpath)
+            except FetchTerminalError:
+                # a git-annex probe timeout (DownloadLocalError) leaves this path's key unproven here; it
+                # falls through to the uuid check and, failing that, the typed refusal below — never a
+                # FetchTerminalError escaping this function past run()'s DriveMutationRefused handler.
+                tracked = None
+            if tracked:
+                path_keys.add(tracked)
         for key in keys:
             if not (_annex_key_on_uuid(dest, key, target_uuid) or key in path_keys):
                 raise drive_mutation.DriveMutationRefused(

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -31,6 +31,7 @@ import tempfile
 import time
 from contextlib import nullcontext
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
@@ -38,7 +39,7 @@ from huggingface_hub import HfApi, get_token
 from huggingface_hub.errors import GatedRepoError, HfHubHTTPError, RepositoryNotFoundError
 
 from modelark.core import db
-from modelark import archive_manifest, compress, register, wishlist
+from modelark import archive_manifest, capacity_evidence, compress, drive_mutation, register, wishlist
 
 # Download-stall resilience (INC-004 + the DEC-023 stage-2 watchdog). The built-in read timeout did
 # NOT catch a multi-hour hang (hf blocked/retried internally and never returned control; on 2026-07-09
@@ -372,18 +373,21 @@ class _HttpResp:
 
 
 def _run_monitored(cmd: list[str], progress: Callable[[], int], stall_secs: float,
-                   should_stop: Callable[[], bool]) -> dict:
+                   should_stop: Callable[[], bool], *, inherit_fds: Sequence[int] = ()) -> dict:
     """Run `cmd` as a child, watching `progress()` — a monotonically-growing byte count for the current
     operation (the `.incomplete` for a download, the `.znn` temp for a compress). KILL the child if it
     makes no progress for `stall_secs` (the hang the socket timeout can't catch) or a stop is requested.
     Returns {"outcome": "exited"|"stalled"|"stopped", "rc": int|None, "stderr": str}. The child writes
-    its real result to a file; here we only track liveness + the exit/kill disposition + a stderr tail."""
+    its real result to a file; here we only track liveness + the exit/kill disposition + a stderr tail.
+    `inherit_fds` are the held drive-fence descriptors the child inherits (pass_fds) so abrupt parent
+    death cannot release the physical fence while the child keeps writing."""
     err_fd, err_path = tempfile.mkstemp(suffix=".stderr")
     os.close(err_fd)
     outcome, rc = "exited", None
     try:
         with open(err_path, "w") as errf:
-            proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=errf)
+            proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=errf,
+                                    pass_fds=tuple(inherit_fds))
             best, last_grow = -1, time.monotonic()
             while True:
                 try:
@@ -406,7 +410,8 @@ def _run_monitored(cmd: list[str], progress: Callable[[], int], stall_secs: floa
 
 
 def _compress_isolated(local: Path, dtype: str, codec: str, threads: int,
-                       expected_sha256: str | None, should_stop: Callable[[], bool]) -> dict:
+                       expected_sha256: str | None, should_stop: Callable[[], bool],
+                       *, inherit_fds: Sequence[int] = ()) -> dict:
     """Compress + canary in a MONITORED child process (DEC-023 stage 3 + the stage-2 watchdog). A
     native compressor abort (ZipNN's double-free, INC-005) kills the child, not the portal; a HUNG
     compress is killed by the no-progress watchdog. Returns a dict whose `status` is one of:
@@ -433,7 +438,7 @@ def _compress_isolated(local: Path, dtype: str, codec: str, threads: int,
     # it to the shard size; floor at _COMPRESS_STALL_SECS for small shards. See INC-011.
     stall = max(_COMPRESS_STALL_SECS, int(local.stat().st_size / 1e9 * _COMPRESS_STALL_PER_GB))
     mon = _run_monitored([sys.executable, "-m", "modelark.compress_worker", request],
-                         progress, stall, should_stop)
+                         progress, stall, should_stop, inherit_fds=inherit_fds)
     try:
         if mon["outcome"] == "exited" and mon["rc"] == 0:
             result = json.loads(Path(res_path).read_text())
@@ -454,14 +459,16 @@ def _compress_isolated(local: Path, dtype: str, codec: str, threads: int,
         Path(res_path).unlink(missing_ok=True)
 
 
-def _annex_add(dest: Path, path: Path) -> str | None:
+def _annex_add(dest: Path, path: Path, *, inherit_fds: Sequence[int] = ()) -> str | None:
     rel = str(path.relative_to(dest))
-    subprocess.run(["git", "-C", str(dest), "annex", "add", rel], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(dest), "annex", "add", rel], check=True, capture_output=True,
+                   pass_fds=tuple(inherit_fds))                 # mutating child inherits the fence
     r = subprocess.run(["git", "-C", str(dest), "annex", "lookupkey", rel], capture_output=True, text=True)
-    return r.stdout.strip() or None
+    return r.stdout.strip() or None                            # lookupkey is read-only: no fence FD
 
 
-def _annex_metadata(dest: Path, key: str | None, repo_id: str, params, fmt: str, quant) -> None:
+def _annex_metadata(dest: Path, key: str | None, repo_id: str, params, fmt: str, quant,
+                    *, inherit_fds: Sequence[int] = ()) -> None:
     """#14: tag an archived blob's git-annex key with its model identity (model / params / format /
     quant), so the fleet is queryable (`git annex find --metadata model=…`) and a shelved drive is
     self-describing. Best-effort — a metadata failure never blocks the archive record."""
@@ -471,10 +478,11 @@ def _annex_metadata(dest: Path, key: str | None, repo_id: str, params, fmt: str,
     if params is not None:
         fields += ["-s", f"params={params}"]
     subprocess.run(["git", "-C", str(dest), "annex", "metadata", f"--key={key}", *fields],
-                   capture_output=True)
+                   capture_output=True, pass_fds=tuple(inherit_fds))   # mutating child inherits the fence
 
 
-def _download_shard(ctx: RunCtx, repo_id: str, rfilename: str, download_dir: Path, base: dict) -> Path:
+def _download_shard(ctx: RunCtx, repo_id: str, rfilename: str, download_dir: Path, base: dict,
+                    *, inherit_fds: Sequence[int] = ()) -> Path:
     """Download one file in a KILLABLE child process (DEC-023 stage-2 watchdog + INC-004). The parent
     kills the child if its `.incomplete` stops growing for _DL_STALL_SECS — the hang the socket timeout
     can't catch (the 2026-07-09 Falcon-H1 stall, blocked in poll() for hours) — then retries. Classic
@@ -512,7 +520,7 @@ def _download_shard(ctx: RunCtx, repo_id: str, rfilename: str, download_dir: Pat
                               "local_dir": str(download_dir), "result": res_path})
         try:
             mon = _run_monitored([sys.executable, "-m", "modelark.download_worker", request],
-                                 progress, _DL_STALL_SECS, ctx.should_stop)
+                                 progress, _DL_STALL_SECS, ctx.should_stop, inherit_fds=inherit_fds)
             if mon["outcome"] == "stopped":
                 raise _StopRequested()
             if mon["outcome"] == "exited" and mon["rc"] == 0:
@@ -563,6 +571,66 @@ def _download_shard(ctx: RunCtx, repo_id: str, rfilename: str, download_dir: Pat
     raise RuntimeError(last_detail)                     # exhausted retries → run() isolates the repo
 
 
+def _live_drive_evidence(con, label: str) -> dict | None:
+    """Read a drive's LIVE identity + filesystem evidence from low-level probes on the mounted volume —
+    never the catalog row. ``None`` when the drive is not mounted."""
+    path = register.archive_path(con, label)
+    if path is None:
+        return None
+    st = os.statvfs(path)
+    return {
+        "fs_uuid": register.probe_fs_uuid(path),
+        "annex_uuid": register.probe_annex_uuid(path),
+        "serial": register.probe_serial(path),
+        "filesystem_capacity_bytes": st.f_blocks * st.f_frsize,
+        "free_bytes": st.f_bavail * st.f_frsize,
+    }
+
+
+def _observe_drive(con, label: str) -> drive_mutation.Observation:
+    """Fenced observation for the mutation envelope: prove the drive's identity from LIVE evidence — the
+    fingerprint is recomputed from the current volume (fs/annex/serial + filesystem capacity), NOT read
+    from the persisted row — and read its live filesystem free/capacity. Identity is unproven when the
+    drive is absent or exposes neither an fs nor an annex UUID."""
+    ev = _live_drive_evidence(con, label)
+    if ev is None or not (ev["fs_uuid"] or ev["annex_uuid"]):
+        return drive_mutation.Observation(
+            identity_proven=False, free_bytes=None, filesystem_capacity=None,
+            fingerprint=None, identity_proof="", fence_proof="")
+    fingerprint = capacity_evidence.identity_fingerprint_v1(
+        fs_uuid=ev["fs_uuid"], annex_uuid=ev["annex_uuid"], serial=ev["serial"],
+        filesystem_capacity_bytes=ev["filesystem_capacity_bytes"])
+    proof = json.dumps(
+        {"v": 1, "fs_uuid": ev["fs_uuid"], "annex_uuid": ev["annex_uuid"], "serial": ev["serial"]},
+        sort_keys=True, separators=(",", ":"))
+    return drive_mutation.Observation(
+        identity_proven=True, free_bytes=ev["free_bytes"],
+        filesystem_capacity=ev["filesystem_capacity_bytes"], fingerprint=fingerprint,
+        identity_proof=proof, fence_proof=proof)
+
+
+def _reconcile_touched(con, label: str, dest, annex: bool, paths, keys) -> None:
+    """Generation-scoped reconciliation (never a full-drive scan): validate ONLY the recorded touched
+    paths and annex keys against durable catalog facts + physical presence, using the existing proof
+    helpers. Any gap raises a typed refusal so the generation stays dirty rather than being marked clean.
+    Touched paths are drive-relative (``repo_id`` + '/' + ``stored_relpath``)."""
+    dest = Path(dest)
+    for relpath in paths:
+        durable = con.execute(
+            "SELECT 1 FROM archived WHERE drive_label=? AND repo_id || '/' || stored_relpath = ?",
+            [label, relpath]).fetchone()
+        if durable is None or not (dest / relpath).exists():
+            raise drive_mutation.DriveMutationRefused(
+                "DRIVE_RECONCILIATION_REQUIRED", drive=label, path=relpath)
+    if annex and keys:
+        target_uuid = (con.execute(
+            "SELECT annex_uuid FROM drives WHERE drive_label=?", [label]).fetchone() or [None])[0]
+        for key in keys:
+            if not _annex_key_on_uuid(dest, key, target_uuid):
+                raise drive_mutation.DriveMutationRefused(
+                    "DRIVE_RECONCILIATION_REQUIRED", drive=label, key=key)
+
+
 def fetch_model(
     ctx: RunCtx,
     repo_id: str,
@@ -573,14 +641,20 @@ def fetch_model(
     *,
     manifest: Sequence[archive_manifest.ManifestFile] | None = None,
     before_file: Callable[[archive_manifest.ManifestFile], None] | None = None,
+    mutation_writer=None,
 ) -> dict:
     """Execute only the explicit task manifest, with a stale-work DB check per file.
 
     ``manifest=None`` retains the standalone fetch CLI behavior.  The reconciled fill always passes
     an exact missing manifest and a live-capacity guard, so the executor cannot silently broaden a
     task back to every repository file.
+
+    ``mutation_writer`` (the physical-mutation envelope's writer) supplies the held drive-fence FDs its
+    monitored/git children inherit, and records each published path + annex key for generation-scoped
+    reconciliation.  ``None`` is the pre-envelope/standalone path (no fences, no touched-set recording).
     """
     con = ctx.con
+    inherit_fds = mutation_writer.child_fence_fds if mutation_writer is not None else ()
     with ctx.lock:                                      # brief: read the plan + resume set
         task_manifest = tuple(manifest) if manifest is not None else tuple(
             archive_manifest.manifest_for_repo(con, repo_id)
@@ -622,7 +696,7 @@ def fetch_model(
             if before_file(item) is False:               # another durable writer satisfied stale work
                 continue
         ctx.on_progress({**base, "file_phase": "download"})
-        local = _download_shard(ctx, repo_id, f["rfilename"], stage_dir, base)
+        local = _download_shard(ctx, repo_id, f["rfilename"], stage_dir, base, inherit_fds=inherit_fds)
         # Every archived original needs durable restore evidence. Hugging Face does not publish a
         # sha256 for ordinary Git-tracked files such as .gitattributes, so checking only when the
         # catalog supplied one stranded those files at restore time (INC-017). Always hash the
@@ -645,7 +719,8 @@ def fetch_model(
             else:
                 ctx.on_progress({**base, "file_phase": "compress", "codec": codec})
                 dtype = compress.zipnn_dtype(f["quant"])
-                res = _compress_isolated(local, dtype, codec, compress_cfg["threads"], got, ctx.should_stop)
+                res = _compress_isolated(local, dtype, codec, compress_cfg["threads"], got,
+                                         ctx.should_stop, inherit_fds=inherit_fds)
                 if res["status"] in ("crash", "stalled", "over-cap"):
                     # INC-005: the compressor died natively (ZipNN double-free) or hung on this shard. The
                     # child absorbed it — store the shard RAW so the fill routes around it instead of
@@ -688,8 +763,9 @@ def fetch_model(
         )
         if annex:
             ctx.on_progress({**base, "file_phase": "annex"})
-            key = _annex_add(dest, stored)
-            _annex_metadata(dest, key, repo_id, params, f["fmt"], f["quant"])   # #14: self-describing key
+            key = _annex_add(dest, stored, inherit_fds=inherit_fds)
+            _annex_metadata(dest, key, repo_id, params, f["fmt"], f["quant"],   # #14: self-describing key
+                            inherit_fds=inherit_fds)
         else:
             key = None
         stored_sz = stored.stat().st_size
@@ -701,6 +777,12 @@ def fetch_model(
             "orig_bytes": f["size"], "stored_bytes": stored_sz,
             "compressed": compressed, "annex_key": key,
         }, pk=["repo_id", "rfilename", "drive_label"], touch=["verified_at"]))
+        if mutation_writer is not None:
+            # record the touched write set AFTER physical publication + the durable archived row, so
+            # generation-scoped reconciliation validates exactly what landed (dest-relative path + key)
+            mutation_writer.record_touched(
+                drive_label, paths=[stored.relative_to(dest).as_posix()],
+                keys=[key] if key else [])
         done += 1
         dl_bytes += f["size"] or 0
         st["bytes"] += f["size"] or 0
@@ -832,138 +914,171 @@ def run(dest=None, drive_label=None, limit=None, repos=None, dry_run=False, max_
                   f"not annex-tracked. (Run drive registration to enable annex.)")
         cap = (max_24h_gb or 0) * 1e9
         compress_cfg = wishlist.compression()       # DEC-022 codec gate config (loaded once per run)
-        for k, rid in enumerate(ids):
-            if ctx.should_stop():
-                break
-            with ctx.lock:
-                used = _bytes_last_24h(con) if cap else 0
-            if cap and used >= cap:
-                print(f"  throttle: {used/1e12:.2f} TB downloaded in last 24h ≥ {cap/1e12:.2f} TB cap "
-                      f"— stopping at repo boundary (resumable, re-run to continue).")
-                ctx.write(lambda c: _event(c, None, "throttled", detail=f"{used/1e9:.0f} GB in 24h"))
-                ctx.on_progress({"phase": "throttled", "say":
-                                 f"  throttle: {used/1e12:.2f} TB in 24h ≥ cap — stopping (resumable)."})
-                result["throttled"] = True
-                break
-            if fits is not None and not fits(rid):
-                # #37 per-model failsafe: this drive's LIVE free can no longer hold `rid` in the plan's
-                # capacity mode (actual > estimate, or a compression-aware forecast coming up short).
-                # Break the batch so fill.execute re-plans — it re-homes rid onto another plan drive, or
-                # (nothing fits anywhere) stops cleanly as plan-capacity-stop. Prevents an ENOSPC mid-shard.
-                print(f"  [plan-capacity] {drive_label} full for {rid} — breaking batch to re-plan.")
-                ctx.on_progress({"phase": "plan-capacity", "drive": drive_label, "repo": rid,
-                                 "say": f"  {drive_label} full for {rid} — re-planning (add a drive if nothing else fits)."})
-                break
-            ctx.on_progress({"drive": drive_label, "repo": rid, "repo_index": k + 1, "n_repos": len(ids),
-                             "used_24h": used, "cap_24h": cap})
-            try:
-                task_args = {}
-                if task_manifests is not None:
-                    task_args["manifest"] = task_manifests.get(rid)
-                if before_file is not None:
-                    task_args["before_file"] = lambda item, _rid=rid: before_file(_rid, item)
-                r = fetch_model(ctx, rid, dest, drive_label, annex, compress_cfg, **task_args)
-                tag = f"{r['files']} files" + (f" (+{r['skipped']} already had)" if r["skipped"] else "")
-                print(f"  [archived] {rid}  ({tag})")
-                ctx.write(lambda c: _event(c, rid, "archived", bytes=r["bytes"], detail=tag))
-                result["stored_repos"].append(rid)
-            except _StopRequested:
-                result["stopped"] = True
-                break                                    # clean stop requested mid-shard (INC-004)
-            except CapacityPreflightError as exc:
-                result["capacity_failure"] = exc.failure
-                ctx.on_progress({"phase": "plan-capacity", "drive": drive_label, "repo": rid,
-                                 "code": exc.failure.code.value,
-                                 "say": f"  {drive_label} lacks safe workspace for {rid} — re-planning."})
-                break
-            except FetchTerminalError as exc:
-                result["terminal_failure"] = exc.as_dict()
-                result["terminal_repo"] = rid
-                print(f"  [{exc.code.lower():8}] {rid}: {exc}")
-                event_detail = f"{exc.code}: {str(exc)[:150]}"
-                ctx.write(lambda c: _event(c, rid, "terminal", detail=event_detail))
-                ctx.on_progress({
-                    "phase": "fetch-blocked", "repo": rid, "code": exc.code,
-                    "evidence": exc.evidence, "actions": list(exc.actions),
-                    "say": f"🔴 {exc}",
-                })
-                break
-            except ArchivePolicyError as e:
-                print(f"  [policy  ] {rid}: {e}")
-                detail = str(e)[:200]
-                ctx.write(lambda c: _event(c, rid, "policy", detail=detail))
-                result["failed_repos"].append(rid)
-            except GatedRepoError:
-                print(f"  [gated   ] {rid}  — needs accepted Hugging Face repository access")
-                ctx.write(lambda c: _event(c, rid, "auth", detail="gated / needs accepted access"))
-                if on_gated is None:                    # plain fetch/CLI compatibility: no prompt broker
-                    result["failed_repos"].append(rid)
-                    continue
-                action = on_gated(rid)
-                if action == "retry":
-                    result["gated_retry"] = rid
-                    break                               # reconcile and retry this repo immediately
-                if action in {"skip", "timeout"}:
-                    detail = json.dumps({
-                        "type": "access-gated", "resolution": action,
-                        "url": f"https://huggingface.co/{rid}",
-                    }, sort_keys=True)
-                    ctx.write(lambda c: _event(c, rid, "auth", detail=detail))
-                    result["gated_repos"].append({"repo": rid, "resolution": action})
-            except HfHubHTTPError as e:
-                code = getattr(getattr(e, "response", None), "status_code", None)
-                if code == 401:
-                    failure = _hf_auth_invalid_failure()
-                    result["terminal_failure"] = failure
-                    result["terminal_repo"] = rid
-                    ctx.write(lambda c: _event(c, rid, "auth", detail="configured HF credential rejected"))
-                    ctx.on_progress({
-                        "phase": "auth-invalid", "repo": rid, "code": failure["code"],
-                        "evidence": failure["evidence"], "actions": failure["actions"],
-                        "say": f"🔴 {failure['message']}",
-                    })
-                    break
-                if code == 429:
-                    ra = _retry_after(e)
-                    print(f"  [429     ] {rid} — HF rate limit"
-                          + (f", Retry-After={ra:.0f}s" if ra else "") + "; stopping (resumable).")
-                    ctx.write(lambda c: _event(c, rid, "rate_limited", wait_seconds=ra, detail="429; stopped run"))
-                    ctx.on_progress({"phase": "rate_limited", "say": f"  [429] {rid} — HF rate limit; stopping."})
-                    result["throttled"] = True
-                    break
-                print(f"  [error   ] {rid}: {str(e)[:100]}")
-                detail = str(e)[:200]
-                ctx.write(lambda c: _event(c, rid, "error", detail=detail))
-                result["failed_repos"].append(rid)
-            except RepositoryNotFoundError as e:
-                print(f"  [error   ] {rid}: {str(e)[:100]}")
-                ctx.write(lambda c: _event(c, rid, "error", detail="repo not found"))
-                result["failed_repos"].append(rid)
-            except Exception as e:                       # INC-004: isolate ANY other repo failure (stalled
-                print(f"  [error   ] {rid}: {type(e).__name__}: {str(e)[:100]}")   # download exhausted retries,
-                detail = f"{type(e).__name__}: {str(e)[:180]}"
-                ctx.write(lambda c: _event(c, rid, "error", detail=detail))
-                result["failed_repos"].append(rid)
-                if not _dest_writable(dest):             # the DRIVE went unwritable mid-batch (USB drop), not just this
-                    ctx.write(lambda c: _event(c, rid, "awaiting-drive",           # DEF-021: a disruption boundary
-                              detail=f"{drive_label} went unwritable mid-fill"))
-                    ctx.on_progress({"phase": "awaiting-drive", "awaiting_drive": drive_label,   # repo → bail; the guided
-                                     "say": f"⚠ {drive_label} stopped accepting writes mid-fill — re-seat it."})
-                    result["drive_unwritable"] = True
-                    break                                # re-plan loop re-awaits + write-probes it (no silent churn)
-                if ctx.should_stop():                    # canary fail, etc.) — log + move on, don't wedge the fill
-                    break
-        # DEC-006: propagate to the central map — sync the drive (commit + push the
-        # location log) then sync the map (merge the file tree into its index) so the map
-        # is both the authoritative "where" (location log) and a browsable "what".
-        if annex:
-            s = subprocess.run(["git", "-C", str(dest), "annex", "sync"], capture_output=True, text=True)
-            m = subprocess.run(["git", "-C", str(register.library_root()), "annex", "sync"],
-                               capture_output=True, text=True)
-            if s.returncode == 0 and m.returncode == 0:
-                print("  synced drive + map (location log + index)")
-            else:
-                print(f"  sync warning: {((s.stderr or s.stdout) + ' ' + (m.stderr or m.stdout)).strip()[:160]}")
+
+        # RFC-002 / DEC-049 physical-mutation envelope: fence this drive, commit the dirty generation
+        # before any staging/download/publish, hold the drive fence across the whole batch, reconcile
+        # only the touched set, then publish a fresh clean anchor. Monitored/git children inherit the
+        # held fence FDs. An unproven/mismatched identity, an unavailable fence, or a reconciliation gap
+        # surfaces as a typed terminal (never a leaked exception) and leaves the generation durably dirty.
+        def _observe(label):
+            return _observe_drive(con, label)
+
+        def _reconcile(label, paths, keys):
+            return _reconcile_touched(con, label, dest, annex, paths, keys)
+
+        try:
+            with drive_mutation.drive_mutation(
+                    con, [drive_label], "fill", observe=_observe, reconcile=_reconcile,
+                    now=datetime.now(timezone.utc).isoformat(sep=" ")) as _writer:
+                for k, rid in enumerate(ids):
+                    if ctx.should_stop():
+                        break
+                    with ctx.lock:
+                        used = _bytes_last_24h(con) if cap else 0
+                    if cap and used >= cap:
+                        print(f"  throttle: {used/1e12:.2f} TB downloaded in last 24h ≥ {cap/1e12:.2f} TB cap "
+                              f"— stopping at repo boundary (resumable, re-run to continue).")
+                        ctx.write(lambda c: _event(c, None, "throttled", detail=f"{used/1e9:.0f} GB in 24h"))
+                        ctx.on_progress({"phase": "throttled", "say":
+                                         f"  throttle: {used/1e12:.2f} TB in 24h ≥ cap — stopping (resumable)."})
+                        result["throttled"] = True
+                        break
+                    if fits is not None and not fits(rid):
+                        # #37 per-model failsafe: this drive's LIVE free can no longer hold `rid` in the plan's
+                        # capacity mode (actual > estimate, or a compression-aware forecast coming up short).
+                        # Break the batch so fill.execute re-plans — it re-homes rid onto another plan drive, or
+                        # (nothing fits anywhere) stops cleanly as plan-capacity-stop. Prevents an ENOSPC mid-shard.
+                        print(f"  [plan-capacity] {drive_label} full for {rid} — breaking batch to re-plan.")
+                        ctx.on_progress({"phase": "plan-capacity", "drive": drive_label, "repo": rid,
+                                         "say": f"  {drive_label} full for {rid} — re-planning (add a drive if nothing else fits)."})
+                        break
+                    ctx.on_progress({"drive": drive_label, "repo": rid, "repo_index": k + 1, "n_repos": len(ids),
+                                     "used_24h": used, "cap_24h": cap})
+                    try:
+                        task_args = {}
+                        if task_manifests is not None:
+                            task_args["manifest"] = task_manifests.get(rid)
+                        if before_file is not None:
+                            task_args["before_file"] = lambda item, _rid=rid: before_file(_rid, item)
+                        r = fetch_model(ctx, rid, dest, drive_label, annex, compress_cfg,
+                                        mutation_writer=_writer, **task_args)
+                        tag = f"{r['files']} files" + (f" (+{r['skipped']} already had)" if r["skipped"] else "")
+                        print(f"  [archived] {rid}  ({tag})")
+                        ctx.write(lambda c: _event(c, rid, "archived", bytes=r["bytes"], detail=tag))
+                        result["stored_repos"].append(rid)
+                    except _StopRequested:
+                        result["stopped"] = True
+                        break                                    # clean stop requested mid-shard (INC-004)
+                    except CapacityPreflightError as exc:
+                        result["capacity_failure"] = exc.failure
+                        ctx.on_progress({"phase": "plan-capacity", "drive": drive_label, "repo": rid,
+                                         "code": exc.failure.code.value,
+                                         "say": f"  {drive_label} lacks safe workspace for {rid} — re-planning."})
+                        break
+                    except FetchTerminalError as exc:
+                        result["terminal_failure"] = exc.as_dict()
+                        result["terminal_repo"] = rid
+                        print(f"  [{exc.code.lower():8}] {rid}: {exc}")
+                        event_detail = f"{exc.code}: {str(exc)[:150]}"
+                        ctx.write(lambda c: _event(c, rid, "error", detail=event_detail))   # typed code in detail
+                        ctx.on_progress({
+                            "phase": "fetch-blocked", "repo": rid, "code": exc.code,
+                            "evidence": exc.evidence, "actions": list(exc.actions),
+                            "say": f"🔴 {exc}",
+                        })
+                        break
+                    except ArchivePolicyError as e:
+                        print(f"  [policy  ] {rid}: {e}")
+                        detail = str(e)[:200]
+                        ctx.write(lambda c: _event(c, rid, "policy", detail=detail))
+                        result["failed_repos"].append(rid)
+                    except GatedRepoError:
+                        print(f"  [gated   ] {rid}  — needs accepted Hugging Face repository access")
+                        ctx.write(lambda c: _event(c, rid, "auth", detail="gated / needs accepted access"))
+                        if on_gated is None:                    # plain fetch/CLI compatibility: no prompt broker
+                            result["failed_repos"].append(rid)
+                            continue
+                        action = on_gated(rid)
+                        if action == "retry":
+                            result["gated_retry"] = rid
+                            break                               # reconcile and retry this repo immediately
+                        if action in {"skip", "timeout"}:
+                            detail = json.dumps({
+                                "type": "access-gated", "resolution": action,
+                                "url": f"https://huggingface.co/{rid}",
+                            }, sort_keys=True)
+                            ctx.write(lambda c: _event(c, rid, "auth", detail=detail))
+                            result["gated_repos"].append({"repo": rid, "resolution": action})
+                    except HfHubHTTPError as e:
+                        code = getattr(getattr(e, "response", None), "status_code", None)
+                        if code == 401:
+                            failure = _hf_auth_invalid_failure()
+                            result["terminal_failure"] = failure
+                            result["terminal_repo"] = rid
+                            ctx.write(lambda c: _event(c, rid, "auth", detail="configured HF credential rejected"))
+                            ctx.on_progress({
+                                "phase": "auth-invalid", "repo": rid, "code": failure["code"],
+                                "evidence": failure["evidence"], "actions": failure["actions"],
+                                "say": f"🔴 {failure['message']}",
+                            })
+                            break
+                        if code == 429:
+                            ra = _retry_after(e)
+                            print(f"  [429     ] {rid} — HF rate limit"
+                                  + (f", Retry-After={ra:.0f}s" if ra else "") + "; stopping (resumable).")
+                            ctx.write(lambda c: _event(c, rid, "rate_limited", wait_seconds=ra, detail="429; stopped run"))
+                            ctx.on_progress({"phase": "rate_limited", "say": f"  [429] {rid} — HF rate limit; stopping."})
+                            result["throttled"] = True
+                            break
+                        print(f"  [error   ] {rid}: {str(e)[:100]}")
+                        detail = str(e)[:200]
+                        ctx.write(lambda c: _event(c, rid, "error", detail=detail))
+                        result["failed_repos"].append(rid)
+                    except RepositoryNotFoundError as e:
+                        print(f"  [error   ] {rid}: {str(e)[:100]}")
+                        ctx.write(lambda c: _event(c, rid, "error", detail="repo not found"))
+                        result["failed_repos"].append(rid)
+                    except Exception as e:                       # INC-004: isolate ANY other repo failure (stalled
+                        print(f"  [error   ] {rid}: {type(e).__name__}: {str(e)[:100]}")   # download exhausted retries,
+                        detail = f"{type(e).__name__}: {str(e)[:180]}"
+                        ctx.write(lambda c: _event(c, rid, "error", detail=detail))
+                        result["failed_repos"].append(rid)
+                        if not _dest_writable(dest):             # the DRIVE went unwritable mid-batch (USB drop), not just this
+                            ctx.write(lambda c: _event(c, rid, "awaiting-drive",           # DEF-021: a disruption boundary
+                                      detail=f"{drive_label} went unwritable mid-fill"))
+                            ctx.on_progress({"phase": "awaiting-drive", "awaiting_drive": drive_label,   # repo → bail; the guided
+                                             "say": f"⚠ {drive_label} stopped accepting writes mid-fill — re-seat it."})
+                            result["drive_unwritable"] = True
+                            break                                # re-plan loop re-awaits + write-probes it (no silent churn)
+                        if ctx.should_stop():                    # canary fail, etc.) — log + move on, don't wedge the fill
+                            break
+                # DEC-006: propagate to the central map — sync the drive (commit + push the location
+                # log) then sync the map (merge the file tree into its index) so the map is both the
+                # authoritative "where" (location log) and a browsable "what". These mutating sync
+                # children inherit the held drive-fence FDs.
+                if annex:
+                    s = subprocess.run(["git", "-C", str(dest), "annex", "sync"], capture_output=True,
+                                       text=True, pass_fds=tuple(_writer.child_fence_fds))
+                    m = subprocess.run(["git", "-C", str(register.library_root()), "annex", "sync"],
+                                       capture_output=True, text=True, pass_fds=tuple(_writer.child_fence_fds))
+                    if s.returncode == 0 and m.returncode == 0:
+                        print("  synced drive + map (location log + index)")
+                    else:
+                        print(f"  sync warning: {((s.stderr or s.stdout) + ' ' + (m.stderr or m.stdout)).strip()[:160]}")
+        except drive_mutation.DriveMutationRefused as exc:
+            # entry: identity unproven/mismatched or fence unavailable; clean close: reconciliation gap.
+            # Surface a typed terminal without clobbering a per-repo terminal; the affected generation
+            # stays durably dirty with no clean anchor for recovery.
+            code = exc.code
+            evidence = {str(ek): str(ev) for ek, ev in exc.evidence.items()}
+            result["terminal_failure"] = result["terminal_failure"] or {
+                "code": code, "message": f"{code} on drive {drive_label}",
+                "evidence": evidence,
+                "actions": ["reconcile_drive", "retry_fill"], "gate": "C",
+            }
+            ctx.write(lambda c: _event(c, None, "error", detail=f"{code}: drive {drive_label}"))
+            ctx.on_progress({"phase": "fetch-blocked", "drive": drive_label, "code": code,
+                             "say": f"🔴 {code} on {drive_label} — reconcile required."})
         return result
     finally:
         if own:
@@ -1025,7 +1140,13 @@ def run_replica_tasks(tasks: Sequence[Any], ctx: RunCtx | None = None) -> dict:
         for task in tasks:
             grouped.setdefault((task.source_drive, task.target_drive), []).append(task)
         lib = register.library_root()
-        copied_any = False
+
+        def _observe(label):
+            return _observe_drive(con, label)
+
+        def _reconcile(label, paths, keys):
+            return _reconcile_touched(con, label, register.archive_path(con, label), True, paths, keys)
+
         for (source, target), group in sorted(grouped.items(), key=lambda item: (item[0][1], item[0][0] or "")):
             if source is None:
                 result["failed"].append({
@@ -1040,7 +1161,9 @@ def run_replica_tasks(tasks: Sequence[Any], ctx: RunCtx | None = None) -> dict:
                 target_uuid = (con.execute(
                     "SELECT annex_uuid FROM drives WHERE drive_label=?", [target]
                 ).fetchone() or [None])[0]
-            if source_path is None or not _dest_writable(Path(source_path)):
+            # non-mutating presence checks before the fence (DEF-022 resumable defer); the mutating
+            # writability probe runs after dirtying, inside the envelope.
+            if source_path is None or not Path(source_path).exists():
                 result.update(deferred=True, source_offline=True)
                 result["deferred_targets"].append(target)
                 ctx.on_progress({
@@ -1048,7 +1171,7 @@ def run_replica_tasks(tasks: Sequence[Any], ctx: RunCtx | None = None) -> dict:
                     "say": f"⏳ replica source {source} is offline/read-only — copy #2 deferred; re-seat it.",
                 })
                 continue
-            if target_path is None or not _dest_writable(Path(target_path)):
+            if target_path is None or not Path(target_path).exists():
                 result["deferred"] = True
                 result["deferred_targets"].append(target)
                 ctx.on_progress({
@@ -1063,90 +1186,113 @@ def run_replica_tasks(tasks: Sequence[Any], ctx: RunCtx | None = None) -> dict:
                 })
                 continue
             source_repo, target_repo = Path(source_path), Path(target_path)
-            remote = subprocess.run(
-                ["git", "-C", str(source_repo), "remote", "set-url", target, str(target_repo)],
-                capture_output=True,
-                text=True,
-            )
-            if remote.returncode != 0:
-                subprocess.run(
-                    ["git", "-C", str(source_repo), "remote", "add", target, str(target_repo)],
-                    capture_output=True,
-                    text=True,
-                )
-            ctx.on_progress({
-                "phase": "replica", "drive": target, "n_repos": len(group),
-                "say": f"-- replica {target} ← {source} ({len(group)} task(s)) --",
-            })
-            group_deferred = False
-            for task in sorted(group, key=lambda item: item.requirement_id):
-                for rfilename in task.budget.missing_files:
-                    with ctx.lock:
-                        if con.execute(
-                            "SELECT 1 FROM archived WHERE repo_id=? AND rfilename=? AND drive_label=?",
-                            [task.repo_id, rfilename, target],
-                        ).fetchone():
-                            continue
-                        source_row = con.execute(
-                            "SELECT stored_name,stored_relpath,orig_sha256,znn_sha256,orig_bytes,"
-                            "stored_bytes,compressed,annex_key FROM archived "
-                            "WHERE repo_id=? AND rfilename=? AND drive_label=?",
-                            [task.repo_id, rfilename, source],
-                        ).fetchone()
-                    if source_row is None or not source_row[7]:
-                        result["failed"].append({
-                            "code": "SOURCE_KEY_MISSING", "requirement_id": task.requirement_id,
-                            "repo": task.repo_id, "file": rfilename, "source": source,
+            try:
+                # Fence BOTH source (remote config + bookkeeping) and target (copy); every mutating git
+                # child inherits both held FDs, and the mutating writability probe runs after dirtying.
+                with drive_mutation.drive_mutation(
+                        con, [source, target], "replica", observe=_observe, reconcile=_reconcile,
+                        now=datetime.now(timezone.utc).isoformat(sep=" ")) as _writer:
+                    fds = tuple(_writer.child_fence_fds)
+                    if not _dest_writable(source_repo) or not _dest_writable(target_repo):
+                        result["deferred"] = True
+                        result["deferred_targets"].append(target)
+                        ctx.on_progress({
+                            "phase": "awaiting-drive", "awaiting_drive": target,
+                            "say": f"⏳ replica {source}→{target} unwritable under fence — deferred; re-seat it.",
                         })
                         continue
-                    key = source_row[7]
-                    copied = subprocess.run(
-                        ["git", "-C", str(source_repo), "annex", "copy", "--to", target, f"--key={key}"],
-                        capture_output=True,
-                        text=True,
+                    remote = subprocess.run(
+                        ["git", "-C", str(source_repo), "remote", "set-url", target, str(target_repo)],
+                        capture_output=True, text=True, pass_fds=fds,
                     )
-                    if copied.returncode != 0:
-                        if not _dest_writable(target_repo):
-                            result["deferred"] = True
-                            result["deferred_targets"].append(target)
-                            group_deferred = True
+                    if remote.returncode != 0:
+                        subprocess.run(
+                            ["git", "-C", str(source_repo), "remote", "add", target, str(target_repo)],
+                            capture_output=True, text=True, pass_fds=fds,
+                        )
+                    ctx.on_progress({
+                        "phase": "replica", "drive": target, "n_repos": len(group),
+                        "say": f"-- replica {target} ← {source} ({len(group)} task(s)) --",
+                    })
+                    group_deferred = False
+                    group_copied = False
+                    for task in sorted(group, key=lambda item: item.requirement_id):
+                        for rfilename in task.budget.missing_files:
+                            with ctx.lock:
+                                if con.execute(
+                                    "SELECT 1 FROM archived WHERE repo_id=? AND rfilename=? AND drive_label=?",
+                                    [task.repo_id, rfilename, target],
+                                ).fetchone():
+                                    continue
+                                source_row = con.execute(
+                                    "SELECT stored_name,stored_relpath,orig_sha256,znn_sha256,orig_bytes,"
+                                    "stored_bytes,compressed,annex_key FROM archived "
+                                    "WHERE repo_id=? AND rfilename=? AND drive_label=?",
+                                    [task.repo_id, rfilename, source],
+                                ).fetchone()
+                            if source_row is None or not source_row[7]:
+                                result["failed"].append({
+                                    "code": "SOURCE_KEY_MISSING", "requirement_id": task.requirement_id,
+                                    "repo": task.repo_id, "file": rfilename, "source": source,
+                                })
+                                continue
+                            key = source_row[7]
+                            copied = subprocess.run(
+                                ["git", "-C", str(source_repo), "annex", "copy", "--to", target, f"--key={key}"],
+                                capture_output=True, text=True, pass_fds=fds,
+                            )
+                            if copied.returncode != 0:
+                                if not _dest_writable(target_repo):
+                                    result["deferred"] = True
+                                    result["deferred_targets"].append(target)
+                                    group_deferred = True
+                                    break
+                                result["failed"].append({
+                                    "code": "ANNEX_COPY_FAILED", "requirement_id": task.requirement_id,
+                                    "repo": task.repo_id, "file": rfilename, "target": target,
+                                })
+                                continue
+                            if not _annex_key_on_uuid(source_repo, key, target_uuid):
+                                result["failed"].append({
+                                    "code": "TARGET_KEY_UNVERIFIED", "requirement_id": task.requirement_id,
+                                    "repo": task.repo_id, "file": rfilename, "target": target,
+                                })
+                                continue
+                            stored_name, stored_relpath, orig_sha, znn_sha, orig_bytes, stored_bytes, compressed, _ = source_row
+                            ctx.write(lambda c, _task=task, _file=rfilename, _target=target, _values=(
+                                stored_name, stored_relpath, orig_sha, znn_sha, orig_bytes, stored_bytes,
+                                compressed, key,
+                            ): db.upsert(c, "archived", {
+                                "repo_id": _task.repo_id, "rfilename": _file,
+                                "stored_name": _values[0], "stored_relpath": _values[1],
+                                "drive_label": _target, "orig_sha256": _values[2],
+                                "znn_sha256": _values[3], "orig_bytes": _values[4],
+                                "stored_bytes": _values[5], "compressed": _values[6],
+                                "annex_key": _values[7],
+                            }, pk=["repo_id", "rfilename", "drive_label"], touch=["verified_at"]))
+                            _writer.record_touched(
+                                target, paths=[f"{task.repo_id}/{stored_relpath}"], keys=[key])
+                            result["copied_files"] += 1
+                            group_copied = True
+                        if group_deferred:
                             break
-                        result["failed"].append({
-                            "code": "ANNEX_COPY_FAILED", "requirement_id": task.requirement_id,
-                            "repo": task.repo_id, "file": rfilename, "target": target,
+                    if group_copied and not group_deferred:
+                        # propagate the landed copies into the central map (inside the fence; the sync
+                        # child inherits the held FDs)
+                        subprocess.run(["git", "-C", str(lib), "annex", "sync"],
+                                       capture_output=True, text=True, pass_fds=fds)
+                    if group_deferred:
+                        ctx.on_progress({
+                            "phase": "awaiting-drive", "awaiting_drive": target,
+                            "say": f"⏳ replica target {target} went unwritable mid-copy — deferred; re-seat it.",
                         })
-                        continue
-                    if not _annex_key_on_uuid(source_repo, key, target_uuid):
-                        result["failed"].append({
-                            "code": "TARGET_KEY_UNVERIFIED", "requirement_id": task.requirement_id,
-                            "repo": task.repo_id, "file": rfilename, "target": target,
-                        })
-                        continue
-                    stored_name, stored_relpath, orig_sha, znn_sha, orig_bytes, stored_bytes, compressed, _ = source_row
-                    ctx.write(lambda c, _task=task, _file=rfilename, _target=target, _values=(
-                        stored_name, stored_relpath, orig_sha, znn_sha, orig_bytes, stored_bytes,
-                        compressed, key,
-                    ): db.upsert(c, "archived", {
-                        "repo_id": _task.repo_id, "rfilename": _file,
-                        "stored_name": _values[0], "stored_relpath": _values[1],
-                        "drive_label": _target, "orig_sha256": _values[2],
-                        "znn_sha256": _values[3], "orig_bytes": _values[4],
-                        "stored_bytes": _values[5], "compressed": _values[6],
-                        "annex_key": _values[7],
-                    }, pk=["repo_id", "rfilename", "drive_label"], touch=["verified_at"]))
-                    result["copied_files"] += 1
-                    copied_any = True
-                if group_deferred:
-                    break
-            if group_deferred:
-                ctx.on_progress({
-                    "phase": "awaiting-drive", "awaiting_drive": target,
-                    "say": f"⏳ replica target {target} went unwritable mid-copy — deferred; re-seat it.",
+                    elif target not in result["deferred_targets"]:
+                        result["copied_targets"].append(target)
+            except drive_mutation.DriveMutationRefused as exc:
+                result["failed"].append({
+                    "code": exc.code, "target": target,
+                    "requirements": [task.requirement_id for task in group],
                 })
-            elif target not in result["deferred_targets"]:
-                result["copied_targets"].append(target)
-        if copied_any:
-            subprocess.run(["git", "-C", str(lib), "annex", "sync"], capture_output=True, text=True)
         result["deferred_targets"] = sorted(set(result["deferred_targets"]))
         result["copied_targets"] = sorted(set(result["copied_targets"]))
         return result

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -614,6 +614,12 @@ def _reconcile_touched(con, label: str, dest, annex: bool, paths, keys) -> None:
     paths and annex keys against durable catalog facts + physical presence, using the existing proof
     helpers. Any gap raises a typed refusal so the generation stays dirty rather than being marked clean.
     Touched paths are drive-relative (``repo_id`` + '/' + ``stored_relpath``)."""
+    if not paths and not keys:
+        return                              # nothing was touched on this drive -> nothing to reconcile
+    if dest is None:
+        # the drive is unresolvable/unmounted at close (archive_path -> None): a TYPED refusal, never a
+        # Path(None) TypeError that would escape the DriveMutationRefused handler and crash the caller.
+        raise drive_mutation.DriveMutationRefused("DRIVE_RECONCILIATION_REQUIRED", drive=label)
     dest = Path(dest)
     for relpath in paths:
         durable = con.execute(

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -632,7 +632,14 @@ def _reconcile_touched(con, label: str, dest, annex: bool, paths, keys) -> None:
         durable = con.execute(
             "SELECT 1 FROM archived WHERE drive_label=? AND repo_id || '/' || stored_relpath = ?",
             [label, relpath]).fetchone()
-        if durable is None or not (dest / relpath).exists():
+        if durable is None:
+            raise drive_mutation.DriveMutationRefused(
+                "DRIVE_RECONCILIATION_REQUIRED", drive=label, path=relpath)
+        # A raw (non-annex) file must be physically present in the worktree. For an annex drive the
+        # worktree symlink is NOT the proof — `git annex copy --to` deposits the object without creating
+        # a working-tree link — so annex presence is proven by the key below (whereis/lookupkey), never
+        # by exists(); requiring the symlink here would false-fail every first-time replica copy.
+        if not annex and not (dest / relpath).exists():
             raise drive_mutation.DriveMutationRefused(
                 "DRIVE_RECONCILIATION_REQUIRED", drive=label, path=relpath)
     if annex and keys:

--- a/modelark/register.py
+++ b/modelark/register.py
@@ -452,6 +452,32 @@ def archive_path(con, label: str) -> Path | None:
     return Path(mp) / ARCHIVE_SUBDIR if mp else None
 
 
+# ---- live identity probes (read the mounted volume, never the catalog) ------
+# These back the fenced observation used by the physical-mutation envelope: identity is proven from the
+# CURRENT device, so a stale catalog row cannot vouch for a swapped/mismounted volume. Linux-only
+# (findmnt/lsblk); off-platform they degrade to None → identity unknown → the envelope refuses.
+
+def probe_fs_uuid(path) -> str | None:
+    """Live filesystem UUID of the volume containing `path`."""
+    out = _run("findmnt", "-fno", "UUID", "--target", str(path), check=False).stdout.strip()
+    return out.splitlines()[0] if out else None
+
+
+def probe_annex_uuid(path) -> str | None:
+    """Live git-annex UUID recorded in the archive repo at `path`, or None if absent."""
+    return _git(Path(path), "config", "annex.uuid", check=False) or None
+
+
+def probe_serial(path) -> str | None:
+    """Live hardware serial of the device backing `path` (supporting identity evidence), or None."""
+    src = _run("findmnt", "-fno", "SOURCE", "--target", str(path), check=False).stdout.strip()
+    src = src.splitlines()[0] if src else ""
+    if not src:
+        return None
+    out = _run("lsblk", "-dno", "SERIAL", src, check=False).stdout.strip()
+    return out.splitlines()[0] if out else None
+
+
 def list_drives(con) -> list[dict]:
     cols = ["drive_label", "hw_model", "serial", "health", "capacity_bytes",
             "free_bytes", "annex_uuid", "physical_location", "last_seen"]

--- a/tests/test_compress_isolation.py
+++ b/tests/test_compress_isolation.py
@@ -139,7 +139,7 @@ def test_stall_window_scales_with_shard_size(tmp_path):
     with open(local, "wb") as f:
         f.truncate(30_000_000_000)                             # 30 GB sparse — logical size only, no disk cost
     captured = {}
-    def capture(cmd, progress, stall_secs, should_stop):
+    def capture(cmd, progress, stall_secs, should_stop, **_kw):
         captured["stall"] = stall_secs
         return {"outcome": "stalled", "rc": None, "stderr": ""}  # short-circuit; we only want the passed window
     with mock.patch("modelark.fetch._run_monitored", side_effect=capture):
@@ -151,7 +151,7 @@ def test_stall_window_scales_with_shard_size(tmp_path):
 def test_stall_window_floor_for_small_shard(tmp_path):
     local, sha = _shard(tmp_path, "small.safetensors")         # ~2 MB → scaled term ≈ 0, so the floor wins
     captured = {}
-    def capture(cmd, progress, stall_secs, should_stop):
+    def capture(cmd, progress, stall_secs, should_stop, **_kw):
         captured["stall"] = stall_secs
         return {"outcome": "stalled", "rc": None, "stderr": ""}
     with mock.patch("modelark.fetch._run_monitored", side_effect=capture):

--- a/tests/test_drive_mutation_envelope.py
+++ b/tests/test_drive_mutation_envelope.py
@@ -4,8 +4,8 @@ Gate 1/2 test contract for the same-host fence + dirty-generation/clean-anchor e
 production. RED until modelark.drive_fence / modelark.drive_mutation exist; find_spec activates the
 guard only for an ABSENT module, so a present-but-broken module surfaces its real error.
 
-Scope: the COMPLETE internal envelope, unconnected to any production call site (dormant). Corrections
-folded in across review:
+Scope: the COMPLETE internal envelope contract; PR-03b now wires it into exactly one reviewed transport
+(modelark/fetch.py), enforced by the wiring guard below. Corrections folded in across review:
   * identity proven under the locks BEFORE dirtying (initial mismatch -> refuse, no dirty; failure
     after dirtying -> durably dirty, no anchor), with dirty durability proven via a SECOND connection;
   * generation start requires generation zero OR an exact clean current generation whose anchor still
@@ -608,15 +608,18 @@ def test_multi_drive_anchor_publish_is_all_or_nothing(tmp_path):
             other.close()
 
 
-# =========================================================================== dormancy guard
+# =========================================================================== wiring guard (PR-03b)
 
-def test_envelope_has_no_production_call_sites():
-    """PR-03a stays dormant/non-authoritative: no production module imports the envelope until 03b/03c.
+def test_envelope_wired_only_into_reviewed_transport():
+    """PR-03b wires the envelope into exactly ONE reviewed production transport (modelark/fetch.py) and
+    nothing else. This supersedes the PR-03a dormancy guard: fetch.py MUST import the envelope, and no
+    other production module may (registration/recovery/operator paths are PR-03c; admission is #35-C).
     Inspect import AST nodes so `import modelark.drive_fence` and `from modelark.drive_mutation import X`
     are both caught."""
     root = Path(__file__).resolve().parent.parent / "modelark"
     envelope = {"drive_fence", "drive_mutation"}
-    offenders = []
+    allowed = {"fetch.py"}
+    importers, offenders = set(), []
     for path in root.rglob("*.py"):
         if path.name in ("drive_fence.py", "drive_mutation.py"):
             continue
@@ -629,8 +632,13 @@ def test_envelope_has_no_production_call_sites():
                 module = (node.module or "").split(".")
                 hit = bool(set(module) & envelope) or any(a.name in envelope for a in node.names)
             if hit:
-                offenders.append(f"{path.relative_to(root)}:{node.lineno}")
-    assert offenders == [], f"envelope must not be wired into production yet: {offenders}"
+                importers.add(path.name)
+                if path.name not in allowed:
+                    offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+    assert offenders == [], f"only {sorted(allowed)} may import the envelope; found: {offenders}"
+    assert "fetch.py" in importers, (
+        "PR-03b must wire the envelope into modelark/fetch.py (the reviewed transport); "
+        "the dormancy phase is over")
 
 
 def main():

--- a/tests/test_hash_repair.py
+++ b/tests/test_hash_repair.py
@@ -246,7 +246,7 @@ def test_fetch_records_hash_for_hub_file_without_canonical_sha(tmp_path):
         storage_action="raw",
     ),)
 
-    def download(_ctx, _repo, rfilename, model_dir, _base):
+    def download(_ctx, _repo, rfilename, model_dir, _base, **_kw):
         path = model_dir / rfilename
         path.write_bytes(data)
         return path
@@ -274,7 +274,7 @@ def test_fetch_uses_computed_hash_for_canary_when_hub_sha_is_missing(tmp_path):
         storage_action="compress",
     ),)
 
-    def download(_ctx, _repo, rfilename, model_dir, _base):
+    def download(_ctx, _repo, rfilename, model_dir, _base, **_kw):
         path = model_dir / rfilename
         path.write_bytes(data)
         return path
@@ -306,7 +306,7 @@ def test_fetch_rejects_hub_hash_mismatch_before_archiving(tmp_path):
         format="safetensors", quant="gptq", storage_action="raw",
     ),)
 
-    def download(_ctx, _repo, rfilename, model_dir, _base):
+    def download(_ctx, _repo, rfilename, model_dir, _base, **_kw):
         path = model_dir / rfilename
         path.write_bytes(data)
         return path

--- a/tests/test_replan.py
+++ b/tests/test_replan.py
@@ -11,12 +11,23 @@ Covers:
 """
 from __future__ import annotations
 
+import contextlib
 import sqlite3
+import types
 from pathlib import Path
 from unittest import mock
 
 from modelark.core import db
 from modelark import capacity, fetch, fill, plan, reconcile
+
+
+@contextlib.contextmanager
+def _passthru_mutation(*_a, **_k):
+    """Bypass the physical-mutation envelope so the transport-logic characterization tests below drive
+    the batch loop directly. The envelope's identity/fence/reconciliation integration is covered by
+    tests/test_transport_fence.py; these tests fix the transport branch behavior (dead-drive bail, 401
+    stop, gated follow-up, replica key proof) that the envelope must not change."""
+    yield types.SimpleNamespace(child_fence_fds=(), record_touched=lambda *a, **k: None)
 
 # ---- the write-probe --------------------------------------------------------------------------
 
@@ -439,11 +450,12 @@ def test_fetch_run_bails_on_dead_drive_midbatch(tmp_path):
     # not churn one error per repo through the whole assignment.
     from modelark import fetch
     events, calls = [], {"n": 0}
-    def boom(ctx, rid, dest, label, annex, cfg):
+    def boom(ctx, rid, dest, label, annex, cfg, **kw):
         calls["n"] += 1
         raise RuntimeError("write failed: I/O error")
     ctx = fetch.RunCtx(con=object(), on_progress=events.append)
-    with mock.patch.object(fetch.register, "archive_path", side_effect=lambda con, l: tmp_path), \
+    with mock.patch.object(fetch.drive_mutation, "drive_mutation", _passthru_mutation), \
+         mock.patch.object(fetch.register, "archive_path", side_effect=lambda con, l: tmp_path), \
          mock.patch.object(fetch, "_is_annex", side_effect=lambda d: False), \
          mock.patch.object(fetch, "fetch_model", side_effect=boom), \
          mock.patch.object(fetch, "_dest_writable", side_effect=lambda d: False), \
@@ -462,13 +474,14 @@ def test_fetch_run_stops_on_midrun_unauthorized_without_repo_churn(tmp_path):
 
     calls = []
 
-    def unauthorized(ctx, rid, dest, label, annex, cfg):
+    def unauthorized(ctx, rid, dest, label, annex, cfg, **kw):
         calls.append(rid)
         response = httpx.Response(401, request=httpx.Request("GET", "https://huggingface.co"))
         raise HfHubHTTPError("unauthorized", response=response)
 
     ctx = fetch.RunCtx(con=object())
-    with mock.patch.object(fetch.register, "archive_path", return_value=tmp_path), \
+    with mock.patch.object(fetch.drive_mutation, "drive_mutation", _passthru_mutation), \
+         mock.patch.object(fetch.register, "archive_path", return_value=tmp_path), \
          mock.patch.object(fetch, "_is_annex", return_value=False), \
          mock.patch.object(fetch, "fetch_model", side_effect=unauthorized), \
          mock.patch.object(fetch, "_bytes_last_24h", return_value=0), \
@@ -493,7 +506,8 @@ def test_fetch_run_records_typed_gated_followup_without_generic_retry(tmp_path):
     response = httpx.Response(403, request=httpx.Request("GET", "https://huggingface.co/org/gated"))
     gated = GatedRepoError("access required", response=response)
     ctx = fetch.RunCtx(con=con)
-    with mock.patch.object(fetch.register, "archive_path", return_value=tmp_path), \
+    with mock.patch.object(fetch.drive_mutation, "drive_mutation", _passthru_mutation), \
+         mock.patch.object(fetch.register, "archive_path", return_value=tmp_path), \
          mock.patch.object(fetch, "_is_annex", return_value=False), \
          mock.patch.object(fetch, "fetch_model", side_effect=gated), \
          mock.patch.object(fetch.wishlist, "compression", return_value={}):
@@ -621,7 +635,8 @@ def test_replica_records_only_after_target_uuid_proof(tmp_path):
 
     completed = mock.Mock(returncode=0, stdout="", stderr="")
     ctx = fetch.RunCtx(con=con)
-    with mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
+    with mock.patch.object(fetch.drive_mutation, "drive_mutation", _passthru_mutation), \
+         mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
          mock.patch.object(fetch.register, "library_root", return_value=library), \
          mock.patch.object(fetch, "_dest_writable", return_value=True), \
          mock.patch.object(fetch.subprocess, "run", return_value=completed), \
@@ -632,7 +647,8 @@ def test_replica_records_only_after_target_uuid_proof(tmp_path):
         "SELECT 1 FROM archived WHERE repo_id='must' AND drive_label='drive-04'"
     ).fetchone() is None
 
-    with mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
+    with mock.patch.object(fetch.drive_mutation, "drive_mutation", _passthru_mutation), \
+         mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
          mock.patch.object(fetch.register, "library_root", return_value=library), \
          mock.patch.object(fetch, "_dest_writable", return_value=True), \
          mock.patch.object(fetch.subprocess, "run", return_value=completed), \

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -692,6 +692,26 @@ def test_live_identity_mismatch_refuses(tmp_path):
         assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
 
 
+def test_observe_drive_unmounted_is_unproven_not_a_crash(tmp_path):
+    """If the live filesystem probe fails (drive registered but its archive dir is unmounted/absent),
+    _observe_drive returns an UNPROVEN observation, so the mutation refuses DRIVE_IDENTITY_UNPROVEN
+    rather than letting an OSError escape the refusal handler and crash the caller."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP)
+        assert hasattr(fetch, "_observe_drive"), "PR-03b must add fetch._observe_drive"
+        with mock.patch.object(fetch.register, "archive_path", return_value=tmp_path / "gone"), \
+             mock.patch.object(fetch.os, "statvfs", side_effect=FileNotFoundError(2, "not mounted")):
+            assert fetch._observe_drive(con, "drive-00").identity_proven is False
+            try:
+                with dm.drive_mutation(con, ["drive-00"], "op",
+                                       observe=lambda label: fetch._observe_drive(con, label),
+                                       reconcile=_reconciler(con), now="2026-01-01"):
+                    raise AssertionError("body must not run when the live probe fails")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_IDENTITY_UNPROVEN", exc.code
+        assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
+
+
 # ===================================================================== seam 2: end-to-end fence FDs
 
 def test_writer_exposes_actual_held_drive_fence_fds(tmp_path):

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -573,6 +573,31 @@ def test_reconcile_touched_tolerates_unresolvable_dest(tmp_path):
             assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
 
 
+def test_reconcile_touched_probe_timeout_is_a_typed_refusal_not_a_crash(tmp_path):
+    """A git-annex lookupkey timeout during clean-close reconciliation (DownloadLocalError from
+    _annex_key_for_path) must surface as a typed DRIVE_RECONCILIATION_REQUIRED refusal, never a
+    FetchTerminalError escaping _reconcile_touched past run()'s DriveMutationRefused handler."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+        con.execute("INSERT INTO models(repo_id) VALUES('must')")
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('must','model.gguf',5,'gguf')")
+        (tmp_path / "must").mkdir()
+        (tmp_path / "must" / "model.gguf").write_bytes(b"bytes")
+        con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                    "orig_bytes,stored_bytes,compressed,annex_key) VALUES('must','model.gguf',"
+                    "'model.gguf','model.gguf','drive-00',5,5,0,'KEY-x')")
+        assert hasattr(fetch, "_reconcile_touched"), "PR-03b must add fetch._reconcile_touched"
+        with mock.patch.object(fetch, "_annex_key_on_uuid", return_value=False), \
+             mock.patch.object(fetch, "_annex_key_for_path",
+                               side_effect=fetch.DownloadLocalError("git-annex probe exceeded 30s")):
+            try:
+                fetch._reconcile_touched(con, "drive-00", tmp_path, True, ["must/model.gguf"], ["KEY-x"])
+                raise AssertionError("a probe timeout during reconciliation must be a typed refusal")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
+
+
 # ===================================================================== R (stop/error): typed + dirty
 
 def test_typed_terminal_is_preserved_as_result_and_durable_event(tmp_path):

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -532,29 +532,47 @@ def test_touched_reconciliation_validates_recorded_set_narrowly(tmp_path):
         fetch._reconcile_touched(con, "drive-00", tmp_path, False, ["must/model.safetensors"], [])
 
 
-def test_touched_reconciliation_fails_closed_on_unprovable_annex_key(tmp_path):
-    """R7: reconciliation validates annex KEYS, not just paths — a recorded key that cannot be proven on
-    the drive fails closed. An implementation that ignores keys entirely cannot pass this."""
+def test_touched_reconciliation_annex_key_invariant(tmp_path):
+    """R7: an annex touched path reconciles ONLY with a non-null durable ``archived.annex_key`` that
+    AGREES with a writer-recorded key AND is provably the exact key present (path lookup or target-uuid
+    whereis). Each failure mode fails closed independently: a NULL durable key, a durable key the writer
+    never recorded (mismatched/unrelated), and a recorded-but-unprovable key. Bytes are present in every
+    case — the KEY is the problem — so an implementation that trusts the row/worktree alone cannot pass."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00")
         con.execute("INSERT INTO models(repo_id) VALUES('must')")
-        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
-                    "VALUES('must','model.gguf',5,'gguf')")
+        for name in ("model.gguf", "nokey.gguf", "mismatch.gguf"):
+            con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) VALUES('must',?,5,'gguf')",
+                        [name])
         (tmp_path / "must").mkdir()
-        (tmp_path / "must" / "model.gguf").write_bytes(b"bytes")   # bytes present — the KEY is the problem
+        for name in ("model.gguf", "nokey.gguf", "mismatch.gguf"):
+            (tmp_path / "must" / name).write_bytes(b"bytes")   # bytes present — the KEY is the problem
+        # recorded-but-unprovable: durable key == the writer-recorded key, yet neither proof helper resolves it
         con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
                     "orig_bytes,stored_bytes,compressed,annex_key) VALUES('must','model.gguf',"
                     "'model.gguf','model.gguf','drive-00',5,5,0,'KEY-x')")
+        # missing key: an annex row whose durable key is NULL
+        con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                    "orig_bytes,stored_bytes,compressed) VALUES('must','nokey.gguf',"
+                    "'nokey.gguf','nokey.gguf','drive-00',5,5,0)")
+        # mismatched key: a durable key the writer never recorded for this generation
+        con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                    "orig_bytes,stored_bytes,compressed,annex_key) VALUES('must','mismatch.gguf',"
+                    "'mismatch.gguf','mismatch.gguf','drive-00',5,5,0,'KEY-durable')")
         assert hasattr(fetch, "_reconcile_touched"), "PR-03b must add fetch._reconcile_touched"
-        # both annex-key proof helpers report the key unprovable on this drive
+        # both annex-key proof helpers report the recorded key unprovable on this drive
         with mock.patch.object(fetch, "_annex_key_on_uuid", return_value=False), \
              mock.patch.object(fetch, "_annex_key_for_path", return_value=None):
-            try:
-                fetch._reconcile_touched(con, "drive-00", tmp_path, True,
-                                         ["must/model.gguf"], ["KEY-x"])
-                raise AssertionError("reconciliation must fail closed on an unprovable annex key")
-            except dm.DriveMutationRefused as exc:
-                assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
+            for path, recorded, why in [
+                ("must/model.gguf", ["KEY-x"], "a recorded key neither proof helper can resolve"),
+                ("must/nokey.gguf", ["KEY-x"], "an annex path whose durable key is NULL"),
+                ("must/mismatch.gguf", ["KEY-x"], "a durable key the writer never recorded"),
+            ]:
+                try:
+                    fetch._reconcile_touched(con, "drive-00", tmp_path, True, [path], recorded)
+                    raise AssertionError(f"reconciliation must fail closed on {why}")
+                except dm.DriveMutationRefused as exc:
+                    assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", (path, exc.code)
 
 
 def test_reconcile_touched_tolerates_unresolvable_dest(tmp_path):

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -492,6 +492,9 @@ def test_replica_fences_source_and_target_and_passes_both_fds(tmp_path):
         for cmd, fds in mutating:
             assert tuple(fds or ()) == held["fds"], \
                 f"replica child {cmd[:5]} must inherit BOTH actual held fence FDs; got {fds}"
+        syncs = [cmd for cmd, _fds in captured if "annex" in cmd and "sync" in cmd]
+        assert syncs and all("drive-00" in cmd and "drive-04" in cmd for cmd in syncs), \
+            f"the replica map sync must name only this group's source+target remotes; got {syncs}"
         # the copied target key must reach reconciliation (not just be written and forgotten)
         assert any(label == "drive-04" and "key-must" in keys for label, _paths, keys in reconciled), \
             f"the copied target path/key must reach reconciliation; saw {reconciled}"
@@ -719,9 +722,12 @@ def test_run_threads_writer_fence_fds_into_fetch_model_and_tail_sync(tmp_path):
             "run() must pass the mutation writer (with child_fence_fds) into fetch_model"
         assert tuple(writer.child_fence_fds) == held.get("fds"), \
             "fetch_model must receive the ACTUAL held drive-fence FDs"
-        syncs = [fds for cmd, fds in runs if "annex" in cmd and "sync" in cmd]
-        assert syncs and all(tuple(f or ()) == held.get("fds") for f in syncs), \
+        syncs = [(cmd, fds) for cmd, fds in runs if "annex" in cmd and "sync" in cmd]
+        assert syncs and all(tuple(f or ()) == held.get("fds") for _c, f in syncs), \
             f"the run()-tail annex sync must inherit the held fence FDs; got {syncs}"
+        map_sync = [cmd for cmd, _f in syncs if str(tmp_path / "lib") in cmd]
+        assert map_sync and "drive-00" in map_sync[0], \
+            f"the library-map sync must name only the current drive remote (drive-00); got {map_sync}"
 
 
 def test_download_and_compression_forward_inherit_fds_to_run_monitored(tmp_path):

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -1,0 +1,540 @@
+"""PR-03b Gate-1 contract — wire the Fill/download/compression/annex/replica transport through the
+merged catalog-v3 mutation envelope with inherited child fence FDs (RFC-002 / DEC-049 issue #35-B slice 2).
+
+Tests-first, pinned BEFORE production. The change-contract tests are RED against the current transport
+(the envelope is dormant); the characterization/mechanism tests are GREEN now and must stay GREEN.
+
+Binding Gate-0 rulings encoded here:
+  R1  an unproven target FAILS CLOSED with DRIVE_IDENTITY_UNPROVEN and mutates nothing (no unfenced
+      fallback); everything is tested with synthetic proven drives.
+  R2  acquisition is controller -> sorted drive locks -> committed dirty advance, then the controller
+      is RELEASED while the drive locks are retained across body, reconciliation, and anchor publish.
+  R3  sessionless FD inheritance + the parent-death lock invariant (tokens/leases/recovery are #39).
+  R4  the envelope wraps ONE drive batch of fetch.run() (not per repository), so an isolated repo
+      failure cannot leave the whole drive dirty and DIRTY_GENERATION_CONFLICT every later repo.
+  R5  replica fences BOTH source and target and passes BOTH FDs to writing children.
+  R6  every mutating child (download/compress, git annex add/metadata/copy/sync, git remote config)
+      inherits the fence FDs; read-only lookups/version/whereis do NOT.
+  R7  touched reconciliation is narrow and real: it validates only the recorded published paths, annex
+      keys, and their durable catalog facts (no full-drive scan, no new cleanup policy).
+
+Proposed production API surfaced by these tests (for Gate-1 review; names are the contract to confirm):
+  * fetch._run_monitored(..., inherit_fds=())     -> Popen(pass_fds=inherit_fds)  [download + compress]
+  * fetch._annex_add(dest, path, inherit_fds=())  / fetch._annex_metadata(..., inherit_fds=())
+  * fetch._reconcile_touched(con, label, dest, annex, paths, keys) -> None | raise DriveMutationRefused
+  * run() wraps its drive-batch loop in drive_mutation and surfaces DRIVE_IDENTITY_UNPROVEN as a typed
+    terminal; replica enters a two-drive drive_mutation.
+
+Disposable temp trees / synthetic proven drives / real subprocesses only — never a live catalog/drive.
+"""
+from __future__ import annotations
+
+import fcntl
+import inspect
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+from modelark.core import db
+from modelark import drive_fence
+from modelark import drive_mutation as dm
+from modelark import fetch
+
+_FP = "a" * 64
+_FP2 = "c" * 64
+
+
+# Restore the db module globals around EVERY test so a test that repoints CATALOG_DIR/DB_PATH/STATE_DIR
+# cannot leak a temp path into a later test (autouse under pytest; main() save/restores under the script
+# runner, matching tests/test_drive_mutation_envelope.py).
+try:
+    import pytest
+
+    @pytest.fixture(autouse=True)
+    def _isolate_db_globals():
+        saved = (db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR)
+        try:
+            yield
+        finally:
+            db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = saved
+except ImportError:                              # the plain script runner does not need pytest
+    pass
+
+
+@contextmanager
+def _catalog(tmp_path):
+    saved = (db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR)
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    db.STATE_DIR = tmp_path / "state"
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture must be a v3 catalog"
+    try:
+        yield con
+    finally:
+        con.close()
+        db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = saved
+
+
+def _proven_drive(con, label="drive-00", *, epoch=1, generation=0, fp=_FP,
+                  fscap=1000, free=900, annex_uuid=None):
+    """A drive with proven identity for the current epoch (PR-03c will establish this on real drives)."""
+    con.execute(
+        "INSERT INTO drives(drive_label,capacity_bytes,free_bytes,identity_epoch,write_generation,"
+        "filesystem_capacity_bytes,identity_fingerprint,write_authority,annex_uuid) "
+        "VALUES(?,?,?,?,?,?,?, 'dedicated_local', ?)",
+        [label, fscap, free, epoch, generation, fscap, fp, annex_uuid])
+
+
+def _unproven_drive(con, label="drive-00"):
+    """A migrated row: epoch-1 namespace only, no fingerprint/authority (DEC-049 / #35 contract)."""
+    con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) VALUES(?,?,?)",
+                [label, 1000, 900])
+
+
+def _obs(free=500, *, capacity=1000, fp=_FP, proven=True):
+    return dm.Observation(identity_proven=proven, free_bytes=free, filesystem_capacity=capacity,
+                          fingerprint=fp, identity_proof="proof", fence_proof="fence")
+
+
+def _observer(con, *frees):
+    """A fenced observer attesting the drive's CURRENT fingerprint/capacity, yielding successive frees."""
+    box = list(frees)
+
+    def observe(label):
+        assert not con.in_transaction, "no SQLite transaction may be open during a fenced observation"
+        fp, cap = con.execute(
+            "SELECT identity_fingerprint, filesystem_capacity_bytes FROM drives WHERE drive_label=?",
+            [label]).fetchone()
+        free = box.pop(0) if len(box) > 1 else (box[0] if box else 500)
+        return _obs(free, capacity=cap, fp=fp)
+    return observe
+
+
+def _reconciler(con):
+    def reconcile(label, paths, keys):
+        assert not con.in_transaction, "no SQLite transaction may be open during reconciliation"
+    return reconcile
+
+
+def _acquirable(path):
+    """True iff the advisory flock at `path` can be taken non-blocking right now (released immediately)."""
+    try:
+        fh = open(path, "w")                      # noqa: SIM115 — released below
+    except OSError:
+        return False
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        fh.close()
+        return False
+    fcntl.flock(fh, fcntl.LOCK_UN)
+    fh.close()
+    return True
+
+
+def _drive_acquirable(fp, epoch):
+    try:
+        with drive_fence.hold_drives_sorted([(fp, epoch)], blocking=False):
+            return True
+    except drive_fence.FenceUnavailable:
+        return False
+
+
+def _run_kwargs(**over):
+    base = {"dest": None, "drive_label": "drive-00", "repos": ["a"], "max_24h_gb": 0}
+    base.update(over)
+    return base
+
+
+# ===================================================================== R4/R1: dirty before mutation
+
+def test_dirty_generation_committed_before_first_batch_mutation(tmp_path):
+    """The drive's dirty generation must be committed (visible to an INDEPENDENT connection) before the
+    first batch mutation — the first staging/temp/probe/download the transport performs."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+        probe = sqlite3.connect(str(db.DB_PATH))
+        seen = {}
+
+        def fake_model(ctx, rid, dest, label, annex, cfg, **kw):
+            seen[rid] = probe.execute(
+                "SELECT count(*) FROM drive_dirty_generations WHERE drive_label='drive-00'"
+            ).fetchone()[0]
+            return {"repo_id": rid, "files": 1, "skipped": 0, "bytes": 1}
+
+        try:
+            with mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
+                 mock.patch.object(fetch, "_is_annex", return_value=False), \
+                 mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+                fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+        finally:
+            probe.close()
+        assert seen.get("a") == 1, (
+            "the dirty generation must be committed and visible to a second connection BEFORE the first "
+            f"batch mutation runs (saw {seen.get('a')})")
+
+
+def test_one_dirty_generation_and_anchor_per_drive_batch_not_per_repo(tmp_path):
+    """R4: the envelope wraps ONE drive batch, so N repositories share ONE dirty generation and publish
+    ONE clean anchor — not one generation per repo (which would DIRTY_GENERATION_CONFLICT repo 2)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+
+        def fake_model(ctx, rid, dest, label, annex, cfg, **kw):
+            return {"repo_id": rid, "files": 1, "skipped": 0, "bytes": 1}
+
+        with mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
+             mock.patch.object(fetch, "_is_annex", return_value=False), \
+             mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+            fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path, repos=["a", "b", "c"]))
+        dirty = con.execute("SELECT count(*) FROM drive_dirty_generations "
+                            "WHERE drive_label='drive-00'").fetchone()[0]
+        anchors = con.execute("SELECT count(*) FROM drive_clean_anchors "
+                              "WHERE drive_label='drive-00'").fetchone()[0]
+        assert (dirty, anchors) == (1, 1), (
+            f"a 3-repo drive batch must open exactly one generation and publish one anchor; "
+            f"got dirty={dirty} anchors={anchors}")
+
+
+# ===================================================================== R2: controller release
+
+def test_controller_released_but_drive_fence_retained_during_body(tmp_path):
+    """R2: once the dirty advance is committed the controller fence is released (so operator graph
+    writes / recovery are not blocked for the whole multi-day body) while the drive fence stays held."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=0)
+        probe = {}
+        with dm.drive_mutation(con, ["drive-00"], "op", observe=_observer(con, 900, 400),
+                               reconcile=_reconciler(con), now="2026-01-01"):
+            probe["controller_free"] = _acquirable(drive_fence.controller_lock_path(db.DB_PATH))
+            probe["drive_locked"] = not _acquirable(drive_fence.drive_lock_path(_FP, 1))
+        assert probe["drive_locked"], "the drive fence must remain HELD across the transport body"
+        assert probe["controller_free"], (
+            "the controller fence must be RELEASED after the committed dirty advance, not held across "
+            "the transport body")
+
+
+# ===================================================================== R1: unproven fails closed
+
+def test_unproven_target_fails_closed_without_filesystem_mutation(tmp_path):
+    """R1: a not-yet-proven drive must refuse with DRIVE_IDENTITY_UNPROVEN before any transport runs —
+    never the old unfenced transport. The integration branch is deliberately not live-ready until 03c."""
+    with _catalog(tmp_path) as con:
+        _unproven_drive(con, "drive-00")
+        called = {"n": 0}
+
+        def fake_model(ctx, rid, dest, label, annex, cfg, **kw):
+            called["n"] += 1
+            return {"repo_id": rid, "files": 0, "skipped": 0, "bytes": 0}
+
+        with mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
+             mock.patch.object(fetch, "_is_annex", return_value=False), \
+             mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+            result = fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+        assert called["n"] == 0, "an unproven drive must fail closed BEFORE any transport mutation runs"
+        terminal = result.get("terminal_failure") or {}
+        assert terminal.get("code") == "DRIVE_IDENTITY_UNPROVEN", (
+            f"an unproven target must surface a typed DRIVE_IDENTITY_UNPROVEN terminal; got {terminal}")
+        assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
+
+
+# ===================================================================== R3: parent-death lock invariant
+
+def test_inherited_fd_survives_parent_death(tmp_path):
+    """R3 core crash-safety invariant (pure OS + drive_fence mechanism): a child that inherits the
+    drive-fence FD keeps the flock held after the parent dies, so nothing else can acquire the drive
+    lock while the child may still be writing. Releases only when the child exits."""
+    fpd, epoch = "e" * 64, 7
+    ready, release = tmp_path / "ready", tmp_path / "release"
+    child_script = (
+        "import sys, time\n"
+        "from pathlib import Path\n"
+        "rel = Path(sys.argv[2])\n"          # argv[1] is the fd number (kept open via pass_fds)
+        "while not rel.exists():\n"
+        "    time.sleep(0.02)\n"
+    )
+    parent_src = (
+        "import os, sys, time, subprocess\n"
+        "from pathlib import Path\n"
+        "from modelark import drive_fence\n"
+        # keep `cm` referenced: a temporary would be GC'd, closing the fence handle at once
+        f"cm = drive_fence.hold_drives_sorted([({fpd!r}, {epoch})])\n"
+        "handles = cm.__enter__()\n"
+        "fd = handles[0].fileno()\n"
+        "os.set_inheritable(fd, True)\n"
+        f"subprocess.Popen([sys.executable, '-c', {child_script!r}, str(fd), {str(release)!r}], "
+        "pass_fds=[fd])\n"
+        f"Path({str(ready)!r}).write_text('x')\n"
+        "time.sleep(600)\n"
+    )
+    parent = subprocess.Popen([sys.executable, "-c", parent_src])
+    try:
+        for _ in range(500):
+            if ready.exists():
+                break
+            time.sleep(0.01)
+        assert ready.exists(), "parent never acquired the fence and spawned the inheriting child"
+        parent.kill()
+        parent.wait(timeout=10)                       # reap so the parent's own fd is definitely closed
+        assert not _drive_acquirable(fpd, epoch), (
+            "the drive lock must NOT be acquirable while a surviving child still holds the inherited "
+            "fence FD after parent death")
+    finally:
+        release.write_text("go")
+        if parent.poll() is None:                 # only if an early assertion skipped the kill above
+            parent.kill()
+            parent.wait(timeout=10)
+    acquired = False
+    for _ in range(500):
+        if _drive_acquirable(fpd, epoch):
+            acquired = True
+            break
+        time.sleep(0.01)
+    assert acquired, "the drive lock must become acquirable once the inheriting child exits"
+
+
+# ===================================================================== R6: every mutating child gets FDs
+
+def test_run_monitored_forwards_inherit_fds_to_child(tmp_path):
+    """R6: the monitored-child spawner (download + compression) forwards the held fence FDs to the
+    child via pass_fds, so a killed/orphaned child keeps the drive fence."""
+    assert "inherit_fds" in inspect.signature(fetch._run_monitored).parameters, \
+        "PR-03b must add an `inherit_fds` parameter to _run_monitored (download + compression children)"
+    fd = os.open(os.devnull, os.O_RDONLY)
+    captured = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+    def fake_popen(cmd, **kw):
+        captured["pass_fds"] = kw.get("pass_fds")
+        return _FakeProc()
+
+    try:
+        with mock.patch.object(fetch.subprocess, "Popen", side_effect=fake_popen):
+            fetch._run_monitored([sys.executable, "-c", "pass"], lambda: 0, 999,
+                                 lambda: False, inherit_fds=(fd,))
+    finally:
+        os.close(fd)
+    assert tuple(captured.get("pass_fds") or ()) == (fd,), (
+        f"the monitored child must inherit the held fence FD via pass_fds; got {captured.get('pass_fds')}")
+
+
+def test_annex_children_inherit_fence_fds_only_when_mutating(tmp_path):
+    """R6: git-annex add/metadata (mutating) inherit the fence FDs; the read-only lookupkey does not."""
+    assert "inherit_fds" in inspect.signature(fetch._annex_add).parameters, \
+        "PR-03b must add `inherit_fds` to _annex_add"
+    assert "inherit_fds" in inspect.signature(fetch._annex_metadata).parameters, \
+        "PR-03b must add `inherit_fds` to _annex_metadata"
+    dest = tmp_path
+    (dest / "must").mkdir()
+    target = dest / "must" / "model.gguf"
+    target.write_bytes(b"x")
+    fd = os.open(os.devnull, os.O_RDONLY)
+    calls = []
+
+    def cap_run(cmd, *a, **k):
+        calls.append((tuple(cmd), k.get("pass_fds")))
+        return subprocess.CompletedProcess(cmd, 0, "key123\n", "")
+
+    try:
+        with mock.patch.object(fetch.subprocess, "run", side_effect=cap_run):
+            fetch._annex_add(dest, target, inherit_fds=(fd,))
+            fetch._annex_metadata(dest, "key123", "org/repo", None, "gguf", None, inherit_fds=(fd,))
+    finally:
+        os.close(fd)
+    add = [fds for cmd, fds in calls if "annex" in cmd and "add" in cmd]
+    meta = [fds for cmd, fds in calls if "annex" in cmd and "metadata" in cmd]
+    lookup = [fds for cmd, fds in calls if "lookupkey" in cmd]
+    assert add and all(tuple(fds or ()) == (fd,) for fds in add), f"annex add must inherit the fence FD: {calls}"
+    assert meta and all(tuple(fds or ()) == (fd,) for fds in meta), f"annex metadata must inherit the FD: {calls}"
+    assert lookup and all(not fds for fds in lookup), \
+        f"read-only annex lookupkey must NOT inherit the fence FD: {calls}"
+
+
+def test_readonly_git_probes_do_not_inherit_fence_fds(tmp_path):
+    """R6 characterization: read-only probes (annex version, whereis) never carry a fence FD."""
+    (tmp_path / ".git").mkdir()
+    calls = []
+
+    def cap_run(cmd, *a, **k):
+        calls.append((tuple(cmd), k.get("pass_fds")))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    with mock.patch.object(fetch.subprocess, "run", side_effect=cap_run):
+        fetch._is_annex(tmp_path)                                   # git annex version
+        fetch._annex_key_on_uuid(tmp_path, "key", "uuid")          # git annex whereis --key
+    assert calls, "expected the read-only git probes to run"
+    assert all(not fds for _cmd, fds in calls), \
+        f"read-only probes must not carry pass_fds: {calls}"
+
+
+# ===================================================================== R5: replica fences source+target
+
+def test_replica_fences_source_and_target_and_passes_both_fds(tmp_path):
+    """R5: a replica copy mutates the target (copy) and the source (remote config + bookkeeping), so the
+    envelope holds BOTH identity+epoch fences and the copy child inherits BOTH FDs."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, annex_uuid="uuid-src")
+        _proven_drive(con, "drive-04", fp=_FP2, annex_uuid="uuid-tgt")
+        con.execute("INSERT INTO models(repo_id) VALUES('must')")   # archived FK -> files -> models
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('must','model.gguf',200,'gguf')")
+        con.execute(
+            "INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+            "orig_sha256,znn_sha256,orig_bytes,stored_bytes,compressed,annex_key) "
+            "VALUES('must','model.gguf','model.gguf','must/model.gguf','drive-00',"
+            "'orig','stored',200,200,0,'key-must')")
+        source, target, library = tmp_path / "src", tmp_path / "tgt", tmp_path / "lib"
+        for d in (source, target, library):
+            d.mkdir()
+        task = types.SimpleNamespace(
+            source_drive="drive-00", target_drive="drive-04", requirement_id="r1",
+            repo_id="must", budget=types.SimpleNamespace(missing_files=["model.gguf"]))
+        captured = []
+
+        def cap_run(cmd, *a, **k):
+            captured.append((tuple(cmd), k.get("pass_fds")))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        def archive_path(_con, label):
+            return source if label == "drive-00" else target
+
+        with mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
+             mock.patch.object(fetch.register, "library_root", return_value=library), \
+             mock.patch.object(fetch, "_dest_writable", return_value=True), \
+             mock.patch.object(fetch, "_annex_key_on_uuid", return_value=True), \
+             mock.patch.object(fetch.subprocess, "run", side_effect=cap_run):
+            fetch.run_replica_tasks([task], ctx=fetch.RunCtx(con=con))
+        copies = [(cmd, fds) for cmd, fds in captured if "annex" in cmd and "copy" in cmd]
+        assert copies, f"expected an `annex copy` child; captured {[c for c, _ in captured]}"
+        for cmd, fds in copies:
+            assert fds is not None and len(tuple(fds)) == 2, (
+                f"the replica copy child must inherit BOTH source+target fence FDs; got pass_fds={fds}")
+
+
+# ===================================================================== R7: narrow real reconciliation
+
+def test_touched_reconciliation_validates_recorded_set_narrowly(tmp_path):
+    """R7: reconciliation validates only the recorded touched paths/keys against durable catalog facts;
+    an unrelated (untouched) durable row + file on the same drive is ignored (no full-drive scan)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+        assert hasattr(fetch, "_reconcile_touched"), \
+            "PR-03b must add a narrow touched-set reconciler (fetch._reconcile_touched)"
+        (tmp_path / "must").mkdir()
+        (tmp_path / "must" / "model.safetensors").write_bytes(b"bytes")
+        con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                    "orig_bytes,stored_bytes,compressed) VALUES('must','model.safetensors',"
+                    "'model.safetensors','must/model.safetensors','drive-00',5,5,0)")
+        (tmp_path / "other").mkdir()                       # decoy a NARROW reconciler must never inspect
+        (tmp_path / "other" / "x.bin").write_bytes(b"z")
+        con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                    "orig_bytes,stored_bytes,compressed) VALUES('decoy','x.bin','x.bin',"
+                    "'other/x.bin','drive-00',1,1,0)")
+        fetch._reconcile_touched(con, "drive-00", tmp_path, False, ["must/model.safetensors"], [])
+
+
+def test_touched_reconciliation_fails_closed_on_missing_durable_fact(tmp_path):
+    """R7: a recorded touched path with no durable catalog fact is a typed reconciliation refusal — the
+    reconciler is not a no-op, so the mutation leaves the generation dirty instead of publishing clean."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+        assert hasattr(fetch, "_reconcile_touched"), \
+            "PR-03b must add a narrow touched-set reconciler (fetch._reconcile_touched)"
+        try:
+            fetch._reconcile_touched(con, "drive-00", tmp_path, False, ["must/missing.safetensors"], [])
+            raise AssertionError("reconciliation must fail closed on a touched path with no durable fact")
+        except dm.DriveMutationRefused as exc:
+            assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
+
+
+# ===================================================================== R (stop/error): typed + dirty
+
+def test_typed_terminal_result_is_preserved(tmp_path):
+    """Baseline the envelope must not corrupt: a per-repo typed terminal stops the batch and surfaces
+    the same typed result shape it does today (RFC-002 stop-condition: lose no typed terminal)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+
+        def terminal_model(ctx, rid, dest, label, annex, cfg, **kw):
+            raise fetch.TargetPathConflictError(rid, "existing file has different verified bytes")
+
+        # _event is mocked: the current run() records a terminal via _event(..., "terminal", ...), an
+        # outcome the fetch_events CHECK does not allow (a pre-existing defect unrelated to PR-03b,
+        # flagged separately). This test characterizes the RESULT contract the envelope must preserve.
+        with mock.patch.object(fetch, "fetch_model", side_effect=terminal_model), \
+             mock.patch.object(fetch, "_event"), \
+             mock.patch.object(fetch, "_is_annex", return_value=False), \
+             mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+            result = fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+        assert result["terminal_failure"]["code"] == "TARGET_PATH_CONFLICT", result
+        assert result["terminal_repo"] == "a"
+
+
+def test_crash_during_batch_leaves_generation_dirty_without_anchor(tmp_path):
+    """An abrupt crash mid-batch (no clean close) must leave the generation durably dirty with no clean
+    anchor, so 03c recovery reconciles it rather than trusting stale free-space."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+
+        class _Crash(BaseException):
+            pass
+
+        def crashing_model(ctx, rid, dest, label, annex, cfg, **kw):
+            raise _Crash("abrupt death mid-transport")
+
+        with mock.patch.object(fetch, "fetch_model", side_effect=crashing_model), \
+             mock.patch.object(fetch, "_is_annex", return_value=False), \
+             mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+            try:
+                fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+            except _Crash:
+                pass
+        dirty = con.execute("SELECT count(*) FROM drive_dirty_generations "
+                            "WHERE drive_label='drive-00'").fetchone()[0]
+        anchors = con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0]
+        assert (dirty, anchors) == (1, 0), (
+            f"an abrupt crash must leave the generation dirty with no clean anchor; "
+            f"dirty={dirty} anchors={anchors}")
+
+
+def main():
+    import tempfile
+    tests = sorted((n, f) for n, f in globals().items()
+                   if n.startswith("test_") and callable(f))
+    passed, failed = [], []
+    for name, fn in tests:
+        db_globals = (db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR)
+        try:
+            if "tmp_path" in inspect.signature(fn).parameters:
+                fn(Path(tempfile.mkdtemp(prefix="mark-03b-")))
+            else:
+                fn()
+            passed.append(name)
+            print(f"PASS  {name}")
+        except Exception as exc:                 # noqa: BLE001 — Gate-1 wants the full red/green map
+            failed.append(name)
+            print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
+        finally:
+            db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = db_globals
+    print(f"\n{len(passed)} passed, {len(failed)} failed")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -557,6 +557,22 @@ def test_touched_reconciliation_fails_closed_on_unprovable_annex_key(tmp_path):
                 assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
 
 
+def test_reconcile_touched_tolerates_unresolvable_dest(tmp_path):
+    """At clean close a drive can be unresolvable (archive_path -> None, e.g. NULL physical_location),
+    which the replica closure passes straight through. An empty touched set is a no-op; a non-empty one
+    is a TYPED refusal — never a Path(None) TypeError that would escape the DriveMutationRefused handler
+    and crash the caller with the generation left dirty."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+        assert hasattr(fetch, "_reconcile_touched"), "PR-03b must add fetch._reconcile_touched"
+        fetch._reconcile_touched(con, "drive-00", None, True, [], [])        # empty set -> no-op, no crash
+        try:
+            fetch._reconcile_touched(con, "drive-00", None, True, ["must/model.gguf"], ["KEY-x"])
+            raise AssertionError("an unresolvable dest with a touched set must be a typed refusal")
+        except dm.DriveMutationRefused as exc:
+            assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
+
+
 # ===================================================================== R (stop/error): typed + dirty
 
 def test_typed_terminal_is_preserved_as_result_and_durable_event(tmp_path):

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -598,6 +598,26 @@ def test_reconcile_touched_probe_timeout_is_a_typed_refusal_not_a_crash(tmp_path
                 assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
 
 
+def test_reconcile_touched_annex_accepts_proven_key_without_worktree_symlink(tmp_path):
+    """Replica presence is proven by the annex KEY, not a worktree symlink — `git annex copy --to`
+    deposits the object without creating the target link. _reconcile_touched must NOT require
+    (dest/relpath).exists() for the annex case; a proven key reconciles cleanly even with no symlink
+    (exercises the REAL reconciler — the replica integration test mocks it, so this is where it's caught)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-04", fp=_FP2, annex_uuid="uuid-tgt")
+        con.execute("INSERT INTO models(repo_id) VALUES('must')")
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('must','model.gguf',5,'gguf')")
+        con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                    "orig_bytes,stored_bytes,compressed,annex_key) VALUES('must','model.gguf',"
+                    "'model.gguf','model.gguf','drive-04',5,5,0,'KEY-x')")
+        assert hasattr(fetch, "_reconcile_touched"), "PR-03b must add fetch._reconcile_touched"
+        # NB: no file/symlink at dest/must/model.gguf — only the annex object transferred; the key proves it
+        with mock.patch.object(fetch, "_annex_key_on_uuid", return_value=True), \
+             mock.patch.object(fetch, "_annex_key_for_path", return_value=None):
+            fetch._reconcile_touched(con, "drive-04", tmp_path, True, ["must/model.gguf"], ["KEY-x"])
+
+
 # ===================================================================== R (stop/error): typed + dirty
 
 def test_typed_terminal_is_preserved_as_result_and_durable_event(tmp_path):

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -212,7 +212,7 @@ def _replica_setup(con, tmp_path):
                 "VALUES('must','model.gguf',200,'gguf')")
     con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
                 "orig_sha256,znn_sha256,orig_bytes,stored_bytes,compressed,annex_key) "
-                "VALUES('must','model.gguf','model.gguf','must/model.gguf','drive-00',"
+                "VALUES('must','model.gguf','model.gguf','model.gguf','drive-00',"
                 "'orig','stored',200,200,0,'key-must')")
     source, target, library = tmp_path / "src", tmp_path / "tgt", tmp_path / "lib"
     for d in (source, target, library):
@@ -513,7 +513,7 @@ def test_touched_reconciliation_validates_recorded_set_narrowly(tmp_path):
         (tmp_path / "must" / "model.safetensors").write_bytes(b"bytes")
         con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
                     "orig_bytes,stored_bytes,compressed) VALUES('must','model.safetensors',"
-                    "'model.safetensors','must/model.safetensors','drive-00',5,5,0)")
+                    "'model.safetensors','model.safetensors','drive-00',5,5,0)")
         # a decoy unrelated durable row + file that a NARROW reconciler must never inspect
         con.execute("INSERT INTO models(repo_id) VALUES('decoy')")
         con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
@@ -541,7 +541,7 @@ def test_touched_reconciliation_fails_closed_on_unprovable_annex_key(tmp_path):
         (tmp_path / "must" / "model.gguf").write_bytes(b"bytes")   # bytes present — the KEY is the problem
         con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
                     "orig_bytes,stored_bytes,compressed,annex_key) VALUES('must','model.gguf',"
-                    "'model.gguf','must/model.gguf','drive-00',5,5,0,'KEY-x')")
+                    "'model.gguf','model.gguf','drive-00',5,5,0,'KEY-x')")
         assert hasattr(fetch, "_reconcile_touched"), "PR-03b must add fetch._reconcile_touched"
         # both annex-key proof helpers report the key unprovable on this drive
         with mock.patch.object(fetch, "_annex_key_on_uuid", return_value=False), \
@@ -768,6 +768,10 @@ def test_fetch_model_forwards_writer_fds_and_records_touch_after_publish(tmp_pat
         con.execute("INSERT INTO models(repo_id) VALUES('org/repo')")
         con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
                     "VALUES('org/repo','config.json',2,'aux')")
+        # a supported weight so the repo satisfies the acquisition policy (the end-of-fetch_model
+        # canonical check reads the files table); the passed one-file manifest still fetches only config
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('org/repo','model.safetensors',100,'safetensors')")
         fd = os.open(os.devnull, os.O_RDONLY)
         order, seen = [], {}
 
@@ -836,7 +840,7 @@ def test_touched_reconciliation_fails_closed_on_missing_physical_path(tmp_path):
                     "VALUES('must','model.safetensors',5,'safetensors')")
         con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
                     "orig_bytes,stored_bytes,compressed) VALUES('must','model.safetensors',"
-                    "'model.safetensors','must/model.safetensors','drive-00',5,5,0)")
+                    "'model.safetensors','model.safetensors','drive-00',5,5,0)")
         # durable row present, but the published bytes are absent at dest
         assert hasattr(fetch, "_reconcile_touched"), "PR-03b must add fetch._reconcile_touched"
         try:

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -28,10 +28,14 @@ Second-round reviewer seams pinned here:
   5. the fetch_events "terminal" defect is fixed in scope (allowed outcome + code in detail), no mock.
 
 Proposed production API surfaced by these tests (for Gate-1 review; names are the contract to confirm):
-  * fetch._observe_drive(con, label) -> dm.Observation, deriving identity from
-    fetch._live_drive_evidence(con, label) (live fs_uuid/annex_uuid/serial/statvfs)
+  * fetch._observe_drive(con, label) -> dm.Observation, deriving identity via
+    fetch._live_drive_evidence(con, label), which reads only low-level probes:
+    register.probe_fs_uuid / probe_annex_uuid / probe_serial(mount) + os.statvfs(mount)
   * dm mutation writer exposes .child_fence_fds (the actual held drive-lock FDs)
-  * fetch.fetch_model(..., mutation_writer=...) uses writer.child_fence_fds + writer.record_touched
+  * fetch.fetch_model(..., mutation_writer=...) uses writer.child_fence_fds for its mutating children
+    and calls writer.record_touched(paths, keys) AFTER physical publication + the durable archived row
+  * fetch._reconcile_touched validates recorded annex KEYS (via _annex_key_on_uuid / _annex_key_for_path),
+    not only paths; run() converts a clean-close reconciliation refusal into a typed terminal
   * fetch._run_monitored/_download_shard/_compress_isolated(..., inherit_fds=()) -> Popen(pass_fds=...)
   * fetch._annex_add(dest, path, inherit_fds=())  / fetch._annex_metadata(..., inherit_fds=())
   * fetch._reconcile_touched(con, label, dest, annex, paths, keys) -> None | raise DriveMutationRefused
@@ -58,6 +62,7 @@ from pathlib import Path
 from unittest import mock
 
 from modelark.core import db
+from modelark import archive_manifest
 from modelark import capacity_evidence
 from modelark import drive_fence
 from modelark import drive_mutation as dm
@@ -168,15 +173,6 @@ def _run_kwargs(**over):
     base = {"dest": None, "drive_label": "drive-00", "repos": ["a"], "max_24h_gb": 0}
     base.update(over)
     return base
-
-
-# Synthetic LIVE identity evidence and the fingerprint it derives, so a test can prove the observer
-# computes identity from live UUID/annex/serial/statvfs rather than trusting the persisted fingerprint.
-_LIVE_EV = {"fs_uuid": "fs-uuid-A", "annex_uuid": "annex-A", "serial": "serial-A",
-            "filesystem_capacity_bytes": 1000, "free_bytes": 850}
-_FP_LIVE = capacity_evidence.identity_fingerprint_v1(
-    fs_uuid=_LIVE_EV["fs_uuid"], annex_uuid=_LIVE_EV["annex_uuid"], serial=_LIVE_EV["serial"],
-    filesystem_capacity_bytes=_LIVE_EV["filesystem_capacity_bytes"])
 
 
 def _observe_from_rows(con):
@@ -470,14 +466,18 @@ def test_replica_fences_source_and_target_and_passes_both_fds(tmp_path):
     source+target FDs."""
     with _catalog(tmp_path) as con:
         task, archive_path, library = _replica_setup(con, tmp_path)
-        held, captured = {}, []
+        held, captured, reconciled = {}, [], []
 
         def cap_run(cmd, *a, **k):
             captured.append((tuple(cmd), k.get("pass_fds")))
             return subprocess.CompletedProcess(cmd, 0, "", "")
 
+        def cap_reconcile(_con, label, dest, annex, paths, keys):
+            reconciled.append((label, tuple(paths), tuple(keys)))
+
         with _capture_held_fence_fds(held), \
              mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+             mock.patch.object(fetch, "_reconcile_touched", side_effect=cap_reconcile, create=True), \
              mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
              mock.patch.object(fetch.register, "library_root", return_value=library), \
              mock.patch.object(fetch, "_dest_writable", return_value=True), \
@@ -492,6 +492,9 @@ def test_replica_fences_source_and_target_and_passes_both_fds(tmp_path):
         for cmd, fds in mutating:
             assert tuple(fds or ()) == held["fds"], \
                 f"replica child {cmd[:5]} must inherit BOTH actual held fence FDs; got {fds}"
+        # the copied target key must reach reconciliation (not just be written and forgotten)
+        assert any(label == "drive-04" and "key-must" in keys for label, _paths, keys in reconciled), \
+            f"the copied target path/key must reach reconciliation; saw {reconciled}"
 
 
 # ===================================================================== R7: narrow real reconciliation
@@ -526,18 +529,29 @@ def test_touched_reconciliation_validates_recorded_set_narrowly(tmp_path):
         fetch._reconcile_touched(con, "drive-00", tmp_path, False, ["must/model.safetensors"], [])
 
 
-def test_touched_reconciliation_fails_closed_on_missing_durable_fact(tmp_path):
-    """R7: a recorded touched path with no durable catalog fact is a typed reconciliation refusal — the
-    reconciler is not a no-op, so the mutation leaves the generation dirty instead of publishing clean."""
+def test_touched_reconciliation_fails_closed_on_unprovable_annex_key(tmp_path):
+    """R7: reconciliation validates annex KEYS, not just paths — a recorded key that cannot be proven on
+    the drive fails closed. An implementation that ignores keys entirely cannot pass this."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00")
-        assert hasattr(fetch, "_reconcile_touched"), \
-            "PR-03b must add a narrow touched-set reconciler (fetch._reconcile_touched)"
-        try:
-            fetch._reconcile_touched(con, "drive-00", tmp_path, False, ["must/missing.safetensors"], [])
-            raise AssertionError("reconciliation must fail closed on a touched path with no durable fact")
-        except dm.DriveMutationRefused as exc:
-            assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
+        con.execute("INSERT INTO models(repo_id) VALUES('must')")
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('must','model.gguf',5,'gguf')")
+        (tmp_path / "must").mkdir()
+        (tmp_path / "must" / "model.gguf").write_bytes(b"bytes")   # bytes present — the KEY is the problem
+        con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                    "orig_bytes,stored_bytes,compressed,annex_key) VALUES('must','model.gguf',"
+                    "'model.gguf','must/model.gguf','drive-00',5,5,0,'KEY-x')")
+        assert hasattr(fetch, "_reconcile_touched"), "PR-03b must add fetch._reconcile_touched"
+        # both annex-key proof helpers report the key unprovable on this drive
+        with mock.patch.object(fetch, "_annex_key_on_uuid", return_value=False), \
+             mock.patch.object(fetch, "_annex_key_for_path", return_value=None):
+            try:
+                fetch._reconcile_touched(con, "drive-00", tmp_path, True,
+                                         ["must/model.gguf"], ["KEY-x"])
+                raise AssertionError("reconciliation must fail closed on an unprovable annex key")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
 
 
 # ===================================================================== R (stop/error): typed + dirty
@@ -567,9 +581,8 @@ def test_typed_terminal_is_preserved_as_result_and_durable_event(tmp_path):
         rows = con.execute("SELECT outcome, detail FROM fetch_events WHERE repo_id='a'").fetchall()
         assert rows, "the typed terminal must be recorded as a durable fetch_events row"
         outcome, detail = rows[-1]
-        allowed = {"archived", "policy", "auth", "rate_limited", "waiting", "error", "throttled",
-                   "awaiting-drive", "compress-fallback"}
-        assert outcome in allowed, f"terminal event outcome {outcome!r} violates the fetch_events CHECK"
+        assert outcome == "error", \
+            f"the typed terminal must be recorded under the allowed 'error' outcome, not {outcome!r}"
         assert "TARGET_PATH_CONFLICT" in (detail or ""), \
             f"the typed terminal code must be preserved in the event detail; got {detail!r}"
 
@@ -605,31 +618,51 @@ def test_crash_during_batch_leaves_generation_dirty_without_anchor(tmp_path):
 # ===================================================================== seam 1: live identity proof
 
 def test_observe_drive_derives_identity_from_live_evidence(tmp_path):
-    """The production observer derives fingerprint/capacity/free from LIVE UUID/annex/serial/statvfs
-    evidence, not from the persisted fingerprint (so a stale row cannot vouch for a swapped volume)."""
+    """The REAL `_observe_drive`+`_live_drive_evidence` derive fingerprint/capacity/free from LIVE probes
+    (fs_uuid/annex_uuid/serial/statvfs), NOT the persisted row. Only the low-level probes are mocked; the
+    persisted row is set to deliberately CONFLICTING values, so trusting the catalog would fail the test."""
     with _catalog(tmp_path) as con:
-        _proven_drive(con, "drive-00", fp=_FP_LIVE,
-                      fscap=_LIVE_EV["filesystem_capacity_bytes"], free=0)
+        # persisted row deliberately conflicts with the live probes below (stale identity + free/cap)
+        stale_fp = capacity_evidence.identity_fingerprint_v1(
+            fs_uuid="STALE-uuid", annex_uuid="STALE-annex", serial="STALE-serial",
+            filesystem_capacity_bytes=222)
+        _proven_drive(con, "drive-00", fp=stale_fp, fscap=222, free=111)
         assert hasattr(fetch, "_observe_drive") and hasattr(fetch, "_live_drive_evidence"), \
             "PR-03b must add fetch._observe_drive + fetch._live_drive_evidence (live identity proof)"
-        with mock.patch.object(fetch, "_live_drive_evidence", return_value=dict(_LIVE_EV), create=True):
+        live_fp = capacity_evidence.identity_fingerprint_v1(
+            fs_uuid="LIVE-uuid", annex_uuid="LIVE-annex", serial="LIVE-serial",
+            filesystem_capacity_bytes=1000)
+        statvfs = types.SimpleNamespace(f_frsize=1, f_blocks=1000, f_bavail=850)
+        # mock ONLY the low-level probes; the real _live_drive_evidence + _observe_drive run
+        with mock.patch.object(fetch.register, "archive_path", return_value=tmp_path), \
+             mock.patch.object(fetch.register, "probe_fs_uuid", return_value="LIVE-uuid", create=True), \
+             mock.patch.object(fetch.register, "probe_annex_uuid", return_value="LIVE-annex", create=True), \
+             mock.patch.object(fetch.register, "probe_serial", return_value="LIVE-serial", create=True), \
+             mock.patch.object(fetch.os, "statvfs", return_value=statvfs):
             obs = fetch._observe_drive(con, "drive-00")
         assert obs.identity_proven is True
-        assert obs.fingerprint == _FP_LIVE, "fingerprint must be derived from live evidence"
-        assert obs.filesystem_capacity == _LIVE_EV["filesystem_capacity_bytes"]
-        assert obs.free_bytes == _LIVE_EV["free_bytes"], "free must be the live statvfs value, not the row"
+        assert obs.fingerprint == live_fp, "fingerprint must come from live probes, not the persisted row"
+        assert obs.filesystem_capacity == 1000, "capacity must be the live statvfs total, not persisted 222"
+        assert obs.free_bytes == 850, "free must be the live statvfs value, not persisted 111"
 
 
 def test_live_identity_mismatch_refuses(tmp_path):
-    """If live evidence yields a different identity than the proven row, the mutation refuses
-    DRIVE_IDENTITY_UNPROVEN and never dirties (a swapped/mismounted volume)."""
+    """If the LIVE probes yield a different identity than the proven row, the mutation refuses
+    DRIVE_IDENTITY_UNPROVEN and never dirties (a swapped/mismounted volume). Real derivation; only the
+    low-level probes are mocked, with a divergent live fs_uuid."""
     with _catalog(tmp_path) as con:
-        _proven_drive(con, "drive-00", fp=_FP_LIVE,
-                      fscap=_LIVE_EV["filesystem_capacity_bytes"], free=0)
+        proven_fp = capacity_evidence.identity_fingerprint_v1(
+            fs_uuid="PROVEN-uuid", annex_uuid="PROVEN-annex", serial="PROVEN-serial",
+            filesystem_capacity_bytes=1000)
+        _proven_drive(con, "drive-00", fp=proven_fp, fscap=1000, free=900)
         assert hasattr(fetch, "_observe_drive") and hasattr(fetch, "_live_drive_evidence"), \
             "PR-03b must add fetch._observe_drive + fetch._live_drive_evidence"
-        wrong = dict(_LIVE_EV, fs_uuid="fs-uuid-DIFFERENT")            # a different physical volume
-        with mock.patch.object(fetch, "_live_drive_evidence", return_value=wrong, create=True):
+        statvfs = types.SimpleNamespace(f_frsize=1, f_blocks=1000, f_bavail=900)
+        with mock.patch.object(fetch.register, "archive_path", return_value=tmp_path), \
+             mock.patch.object(fetch.register, "probe_fs_uuid", return_value="SWAPPED-uuid", create=True), \
+             mock.patch.object(fetch.register, "probe_annex_uuid", return_value="PROVEN-annex", create=True), \
+             mock.patch.object(fetch.register, "probe_serial", return_value="PROVEN-serial", create=True), \
+             mock.patch.object(fetch.os, "statvfs", return_value=statvfs):
             try:
                 with dm.drive_mutation(con, ["drive-00"], "op",
                                        observe=lambda label: fetch._observe_drive(con, label),
@@ -724,29 +757,73 @@ def test_download_and_compression_forward_inherit_fds_to_run_monitored(tmp_path)
 
 # ===================================================================== seam 3: reconciliation <-> transport
 
-def test_published_touched_set_reaches_reconciliation(tmp_path):
-    """A path/key the transport publishes is recorded on the mutation writer and reaches the reconciler
-    — transport cannot record nothing yet still publish a clean anchor."""
+def test_fetch_model_forwards_writer_fds_and_records_touch_after_publish(tmp_path):
+    """Seam 3/2 end-to-end through the REAL fetch_model (one file, minimally mocked): the writer's actual
+    FDs reach its mutating children (download + annex-add), and the touch (path + annex key) is recorded
+    only AFTER the physical publication and the durable archived row."""
+    assert "mutation_writer" in inspect.signature(fetch.fetch_model).parameters, \
+        "PR-03b must add `mutation_writer` to fetch_model (writer FDs + record_touched after publish)"
     with _catalog(tmp_path) as con:
-        _proven_drive(con, "drive-00", fp=_FP)
-        reconciled = []
+        _proven_drive(con, "drive-00")
+        con.execute("INSERT INTO models(repo_id) VALUES('org/repo')")
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('org/repo','config.json',2,'aux')")
+        fd = os.open(os.devnull, os.O_RDONLY)
+        order, seen = [], {}
 
-        def fake_model(ctx, rid, dest, label, annex, cfg, *, mutation_writer=None, **kw):
-            assert mutation_writer is not None, "run() must pass the mutation writer into fetch_model"
-            mutation_writer.record_touched(label, paths=["must/model.safetensors"], keys=["KEY-must"])
-            return {"repo_id": rid, "files": 1, "skipped": 0, "bytes": 1}
+        class _Writer:
+            child_fence_fds = (fd,)
 
-        def fake_reconcile(_con, label, dest, annex, paths, keys):
-            reconciled.append((label, tuple(paths), tuple(keys)))
+            def record_touched(self, label, *, paths=(), keys=()):
+                order.append("touch")
+                seen["touch"] = (label, tuple(paths), tuple(keys))
 
-        with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
-             mock.patch.object(fetch, "_reconcile_touched", side_effect=fake_reconcile, create=True), \
-             mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
-             mock.patch.object(fetch, "_is_annex", return_value=False), \
-             mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
-            fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
-        assert ("drive-00", ("must/model.safetensors",), ("KEY-must",)) in reconciled, \
-            f"the published touched path/key must reach reconciliation; saw {reconciled}"
+        def fake_monitored(cmd, progress, stall, should_stop, *, inherit_fds=()):
+            seen["download_fds"] = tuple(inherit_fds)
+            req = json.loads(cmd[-1])
+            out = Path(req["local_dir"]) / "config.json"
+            out.write_text("{}")
+            Path(req["result"]).write_text(json.dumps({"ok": True, "path": str(out)}))
+            return {"outcome": "exited", "rc": 0, "stderr": ""}
+
+        def fake_annex_add(dest, path, *, inherit_fds=()):
+            seen["annex_add_fds"] = tuple(inherit_fds)
+            order.append("annex_add")
+            return "KEY-x"
+
+        real_publish, real_upsert = fetch._publish_staged, fetch.db.upsert
+
+        def wrapped_publish(*a, **k):
+            result = real_publish(*a, **k)
+            order.append("publish")
+            return result
+
+        def wrapped_upsert(c, table, row, **k):
+            real_upsert(c, table, row, **k)
+            if table == "archived":
+                order.append("archived")
+
+        manifest = [archive_manifest.ManifestFile("config.json", 2, None, "aux", None, "raw")]
+        try:
+            with mock.patch.object(fetch, "_run_monitored", side_effect=fake_monitored), \
+                 mock.patch.object(fetch, "_annex_add", side_effect=fake_annex_add), \
+                 mock.patch.object(fetch, "_annex_metadata"), \
+                 mock.patch.object(fetch, "_publish_staged", side_effect=wrapped_publish), \
+                 mock.patch.object(fetch.db, "upsert", side_effect=wrapped_upsert):
+                fetch.fetch_model(fetch.RunCtx(con=con), "org/repo", tmp_path, "drive-00", True,
+                                  {"threads": 1}, manifest=manifest, mutation_writer=_Writer())
+        finally:
+            os.close(fd)
+        assert seen.get("download_fds") == (fd,), \
+            f"the download child must inherit the writer's fence FDs; got {seen.get('download_fds')}"
+        assert seen.get("annex_add_fds") == (fd,), \
+            f"the annex-add child must inherit the writer's fence FDs; got {seen.get('annex_add_fds')}"
+        _label, paths, keys = seen.get("touch", (None, (), ()))
+        assert paths and "KEY-x" in keys, \
+            f"fetch_model must record the published path + annex key on the writer; got {seen.get('touch')}"
+        assert "publish" in order and "archived" in order and "touch" in order, order
+        assert order.index("touch") > order.index("publish"), "touch must be recorded after physical publication"
+        assert order.index("touch") > order.index("archived"), "touch must be recorded after the durable archived row"
 
 
 def test_touched_reconciliation_fails_closed_on_missing_physical_path(tmp_path):
@@ -767,6 +844,41 @@ def test_touched_reconciliation_fails_closed_on_missing_physical_path(tmp_path):
             raise AssertionError("reconciliation must fail closed when the published bytes are absent")
         except dm.DriveMutationRefused as exc:
             assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
+
+
+def test_run_returns_typed_terminal_when_clean_close_reconciliation_refuses(tmp_path):
+    """A clean-close reconciliation refusal must be surfaced by run() as the typed
+    DRIVE_RECONCILIATION_REQUIRED terminal, leaving the generation dirty with no anchor — not a leaked
+    exception and not a generic failure."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+
+        def ok_model(ctx, rid, dest, label, annex, cfg, *, mutation_writer=None, **kw):
+            return {"repo_id": rid, "files": 1, "skipped": 0, "bytes": 1}
+
+        def refuse_reconcile(_con, label, dest, annex, paths, keys):
+            raise dm.DriveMutationRefused("DRIVE_RECONCILIATION_REQUIRED", drive=label)
+
+        with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+             mock.patch.object(fetch, "_reconcile_touched", side_effect=refuse_reconcile, create=True), \
+             mock.patch.object(fetch, "fetch_model", side_effect=ok_model), \
+             mock.patch.object(fetch, "_is_annex", return_value=False), \
+             mock.patch.object(fetch, "_event"), \
+             mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+            try:
+                result = fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+            except dm.DriveMutationRefused as exc:
+                raise AssertionError(
+                    "run() must convert a clean-close reconciliation refusal into a typed terminal, "
+                    f"not leak it: {exc}") from exc
+        terminal = result.get("terminal_failure") or {}
+        assert terminal.get("code") == "DRIVE_RECONCILIATION_REQUIRED", \
+            f"run() must surface the typed reconciliation terminal; got {terminal}"
+        dirty = con.execute("SELECT count(*) FROM drive_dirty_generations "
+                            "WHERE drive_label='drive-00'").fetchone()[0]
+        anchors = con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0]
+        assert (dirty, anchors) == (1, 0), \
+            f"a reconciliation refusal must leave the generation dirty with no anchor; dirty={dirty} anchors={anchors}"
 
 
 # ===================================================================== seam 4: writability-probe ordering

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -18,12 +18,26 @@ Binding Gate-0 rulings encoded here:
   R7  touched reconciliation is narrow and real: it validates only the recorded published paths, annex
       keys, and their durable catalog facts (no full-drive scan, no new cleanup policy).
 
+Second-round reviewer seams pinned here:
+  1. live identity proof — the observer derives fingerprint/capacity/free from live evidence;
+  2. end-to-end fence-FD flow — writer exposes the actual held FDs, threaded run -> fetch_model ->
+     download/compress/annex/remote children and source+target replica children;
+  3. reconciliation is connected to transport — a published path/key reaches reconciliation, and a
+     durable row with absent bytes fails closed;
+  4. mutating writability probes run only after dirtying (replica + run() error path);
+  5. the fetch_events "terminal" defect is fixed in scope (allowed outcome + code in detail), no mock.
+
 Proposed production API surfaced by these tests (for Gate-1 review; names are the contract to confirm):
-  * fetch._run_monitored(..., inherit_fds=())     -> Popen(pass_fds=inherit_fds)  [download + compress]
+  * fetch._observe_drive(con, label) -> dm.Observation, deriving identity from
+    fetch._live_drive_evidence(con, label) (live fs_uuid/annex_uuid/serial/statvfs)
+  * dm mutation writer exposes .child_fence_fds (the actual held drive-lock FDs)
+  * fetch.fetch_model(..., mutation_writer=...) uses writer.child_fence_fds + writer.record_touched
+  * fetch._run_monitored/_download_shard/_compress_isolated(..., inherit_fds=()) -> Popen(pass_fds=...)
   * fetch._annex_add(dest, path, inherit_fds=())  / fetch._annex_metadata(..., inherit_fds=())
   * fetch._reconcile_touched(con, label, dest, annex, paths, keys) -> None | raise DriveMutationRefused
-  * run() wraps its drive-batch loop in drive_mutation and surfaces DRIVE_IDENTITY_UNPROVEN as a typed
-    terminal; replica enters a two-drive drive_mutation.
+  * run() wraps its drive-batch loop in drive_mutation, surfaces DRIVE_IDENTITY_UNPROVEN as a typed
+    terminal, records a typed terminal as an ALLOWED fetch_events outcome (code in detail); replica
+    enters a two-drive drive_mutation with the writability probe fenced.
 
 Disposable temp trees / synthetic proven drives / real subprocesses only — never a live catalog/drive.
 """
@@ -31,6 +45,7 @@ from __future__ import annotations
 
 import fcntl
 import inspect
+import json
 import os
 import shutil
 import sqlite3
@@ -43,6 +58,7 @@ from pathlib import Path
 from unittest import mock
 
 from modelark.core import db
+from modelark import capacity_evidence
 from modelark import drive_fence
 from modelark import drive_mutation as dm
 from modelark import fetch
@@ -154,6 +170,67 @@ def _run_kwargs(**over):
     return base
 
 
+# Synthetic LIVE identity evidence and the fingerprint it derives, so a test can prove the observer
+# computes identity from live UUID/annex/serial/statvfs rather than trusting the persisted fingerprint.
+_LIVE_EV = {"fs_uuid": "fs-uuid-A", "annex_uuid": "annex-A", "serial": "serial-A",
+            "filesystem_capacity_bytes": 1000, "free_bytes": 850}
+_FP_LIVE = capacity_evidence.identity_fingerprint_v1(
+    fs_uuid=_LIVE_EV["fs_uuid"], annex_uuid=_LIVE_EV["annex_uuid"], serial=_LIVE_EV["serial"],
+    filesystem_capacity_bytes=_LIVE_EV["filesystem_capacity_bytes"])
+
+
+def _observe_from_rows(con):
+    """A stand-in for the production ``_observe_drive`` used by batch-wiring tests (Gate-0 R1 permits
+    mocking the adapter here): attest each drive's CURRENT stored fingerprint/capacity so identity
+    proves. The dedicated adapter tests exercise the REAL observer over live evidence."""
+    def observe(_con, label):
+        fp, cap, free = con.execute(
+            "SELECT identity_fingerprint, filesystem_capacity_bytes, free_bytes FROM drives "
+            "WHERE drive_label=?", [label]).fetchone()
+        return _obs(free if free is not None else 500, capacity=cap, fp=fp)
+    return observe
+
+
+@contextmanager
+def _capture_held_fence_fds(store):
+    """Wrap drive_fence.hold_drives_sorted to record the ACTUAL held drive-lock FDs, so a test can
+    assert those exact FDs reach the writer / children rather than arbitrary values."""
+    real = drive_fence.hold_drives_sorted
+
+    @contextmanager
+    def traced(keyed_drives, *a, **k):
+        with real(keyed_drives, *a, **k) as handles:
+            store["fds"] = tuple(h.fileno() for h in handles)
+            yield handles
+
+    with mock.patch.object(drive_fence, "hold_drives_sorted", traced):
+        yield store
+
+
+def _replica_setup(con, tmp_path):
+    """Two proven drives (source/target) + a durable source archived row + a synthetic replica task."""
+    _proven_drive(con, "drive-00", fp=_FP, annex_uuid="uuid-src")
+    _proven_drive(con, "drive-04", fp=_FP2, annex_uuid="uuid-tgt")
+    con.execute("INSERT INTO models(repo_id) VALUES('must')")
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                "VALUES('must','model.gguf',200,'gguf')")
+    con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                "orig_sha256,znn_sha256,orig_bytes,stored_bytes,compressed,annex_key) "
+                "VALUES('must','model.gguf','model.gguf','must/model.gguf','drive-00',"
+                "'orig','stored',200,200,0,'key-must')")
+    source, target, library = tmp_path / "src", tmp_path / "tgt", tmp_path / "lib"
+    for d in (source, target, library):
+        d.mkdir()
+    task = types.SimpleNamespace(source_drive="drive-00", target_drive="drive-04",
+                                 requirement_id="r1", repo_id="must",
+                                 budget=types.SimpleNamespace(missing_files=["model.gguf"]))
+
+    def archive_path(_con, label):
+        return source if label == "drive-00" else target
+
+    return task, archive_path, library
+
+
 # ===================================================================== R4/R1: dirty before mutation
 
 def test_dirty_generation_committed_before_first_batch_mutation(tmp_path):
@@ -171,7 +248,8 @@ def test_dirty_generation_committed_before_first_batch_mutation(tmp_path):
             return {"repo_id": rid, "files": 1, "skipped": 0, "bytes": 1}
 
         try:
-            with mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
+            with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+                 mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
                  mock.patch.object(fetch, "_is_annex", return_value=False), \
                  mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
                 fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
@@ -191,7 +269,8 @@ def test_one_dirty_generation_and_anchor_per_drive_batch_not_per_repo(tmp_path):
         def fake_model(ctx, rid, dest, label, annex, cfg, **kw):
             return {"repo_id": rid, "files": 1, "skipped": 0, "bytes": 1}
 
-        with mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
+        with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+             mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
              mock.patch.object(fetch, "_is_annex", return_value=False), \
              mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
             fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path, repos=["a", "b", "c"]))
@@ -386,45 +465,33 @@ def test_readonly_git_probes_do_not_inherit_fence_fds(tmp_path):
 # ===================================================================== R5: replica fences source+target
 
 def test_replica_fences_source_and_target_and_passes_both_fds(tmp_path):
-    """R5: a replica copy mutates the target (copy) and the source (remote config + bookkeeping), so the
-    envelope holds BOTH identity+epoch fences and the copy child inherits BOTH FDs."""
+    """R5/seam 2: a replica copy mutates the target (copy) and the source (remote config + bookkeeping);
+    the envelope holds BOTH identity+epoch fences and every mutating child inherits the ACTUAL held
+    source+target FDs."""
     with _catalog(tmp_path) as con:
-        _proven_drive(con, "drive-00", fp=_FP, annex_uuid="uuid-src")
-        _proven_drive(con, "drive-04", fp=_FP2, annex_uuid="uuid-tgt")
-        con.execute("INSERT INTO models(repo_id) VALUES('must')")   # archived FK -> files -> models
-        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
-                    "VALUES('must','model.gguf',200,'gguf')")
-        con.execute(
-            "INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
-            "orig_sha256,znn_sha256,orig_bytes,stored_bytes,compressed,annex_key) "
-            "VALUES('must','model.gguf','model.gguf','must/model.gguf','drive-00',"
-            "'orig','stored',200,200,0,'key-must')")
-        source, target, library = tmp_path / "src", tmp_path / "tgt", tmp_path / "lib"
-        for d in (source, target, library):
-            d.mkdir()
-        task = types.SimpleNamespace(
-            source_drive="drive-00", target_drive="drive-04", requirement_id="r1",
-            repo_id="must", budget=types.SimpleNamespace(missing_files=["model.gguf"]))
-        captured = []
+        task, archive_path, library = _replica_setup(con, tmp_path)
+        held, captured = {}, []
 
         def cap_run(cmd, *a, **k):
             captured.append((tuple(cmd), k.get("pass_fds")))
             return subprocess.CompletedProcess(cmd, 0, "", "")
 
-        def archive_path(_con, label):
-            return source if label == "drive-00" else target
-
-        with mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
+        with _capture_held_fence_fds(held), \
+             mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+             mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
              mock.patch.object(fetch.register, "library_root", return_value=library), \
              mock.patch.object(fetch, "_dest_writable", return_value=True), \
              mock.patch.object(fetch, "_annex_key_on_uuid", return_value=True), \
              mock.patch.object(fetch.subprocess, "run", side_effect=cap_run):
             fetch.run_replica_tasks([task], ctx=fetch.RunCtx(con=con))
-        copies = [(cmd, fds) for cmd, fds in captured if "annex" in cmd and "copy" in cmd]
-        assert copies, f"expected an `annex copy` child; captured {[c for c, _ in captured]}"
-        for cmd, fds in copies:
-            assert fds is not None and len(tuple(fds)) == 2, (
-                f"the replica copy child must inherit BOTH source+target fence FDs; got pass_fds={fds}")
+        assert held.get("fds") and len(held["fds"]) == 2, \
+            "both source and target identity+epoch fences must be held for a replica copy"
+        mutating = [(cmd, fds) for cmd, fds in captured
+                    if "remote" in cmd or ("annex" in cmd and ("copy" in cmd or "sync" in cmd))]
+        assert mutating, f"expected mutating git children (remote/copy/sync); captured {[c for c, _ in captured]}"
+        for cmd, fds in mutating:
+            assert tuple(fds or ()) == held["fds"], \
+                f"replica child {cmd[:5]} must inherit BOTH actual held fence FDs; got {fds}"
 
 
 # ===================================================================== R7: narrow real reconciliation
@@ -475,25 +542,36 @@ def test_touched_reconciliation_fails_closed_on_missing_durable_fact(tmp_path):
 
 # ===================================================================== R (stop/error): typed + dirty
 
-def test_typed_terminal_result_is_preserved(tmp_path):
-    """Baseline the envelope must not corrupt: a per-repo typed terminal stops the batch and surfaces
-    the same typed result shape it does today (RFC-002 stop-condition: lose no typed terminal)."""
+def test_typed_terminal_is_preserved_as_result_and_durable_event(tmp_path):
+    """Seam 5: a per-repo typed terminal must surface in the result AND be recorded durably WITHOUT the
+    schema-forbidden 'terminal' fetch_events outcome. The preservation fix records an ALLOWED outcome
+    carrying the typed code in `detail` (no schema migration); the envelope must preserve both."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00")
 
         def terminal_model(ctx, rid, dest, label, annex, cfg, **kw):
             raise fetch.TargetPathConflictError(rid, "existing file has different verified bytes")
 
-        # _event is mocked: the current run() records a terminal via _event(..., "terminal", ...), an
-        # outcome the fetch_events CHECK does not allow (a pre-existing defect unrelated to PR-03b,
-        # flagged separately). This test characterizes the RESULT contract the envelope must preserve.
-        with mock.patch.object(fetch, "fetch_model", side_effect=terminal_model), \
-             mock.patch.object(fetch, "_event"), \
+        with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+             mock.patch.object(fetch, "fetch_model", side_effect=terminal_model), \
              mock.patch.object(fetch, "_is_annex", return_value=False), \
              mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
-            result = fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+            try:
+                result = fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+            except sqlite3.IntegrityError as exc:
+                raise AssertionError(
+                    "run() must record the typed terminal as an ALLOWED fetch_events outcome with the "
+                    f"code in detail, not the schema-forbidden 'terminal' outcome: {exc}") from exc
         assert result["terminal_failure"]["code"] == "TARGET_PATH_CONFLICT", result
         assert result["terminal_repo"] == "a"
+        rows = con.execute("SELECT outcome, detail FROM fetch_events WHERE repo_id='a'").fetchall()
+        assert rows, "the typed terminal must be recorded as a durable fetch_events row"
+        outcome, detail = rows[-1]
+        allowed = {"archived", "policy", "auth", "rate_limited", "waiting", "error", "throttled",
+                   "awaiting-drive", "compress-fallback"}
+        assert outcome in allowed, f"terminal event outcome {outcome!r} violates the fetch_events CHECK"
+        assert "TARGET_PATH_CONFLICT" in (detail or ""), \
+            f"the typed terminal code must be preserved in the event detail; got {detail!r}"
 
 
 def test_crash_during_batch_leaves_generation_dirty_without_anchor(tmp_path):
@@ -508,7 +586,8 @@ def test_crash_during_batch_leaves_generation_dirty_without_anchor(tmp_path):
         def crashing_model(ctx, rid, dest, label, annex, cfg, **kw):
             raise _Crash("abrupt death mid-transport")
 
-        with mock.patch.object(fetch, "fetch_model", side_effect=crashing_model), \
+        with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+             mock.patch.object(fetch, "fetch_model", side_effect=crashing_model), \
              mock.patch.object(fetch, "_is_annex", return_value=False), \
              mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
             try:
@@ -521,6 +600,236 @@ def test_crash_during_batch_leaves_generation_dirty_without_anchor(tmp_path):
         assert (dirty, anchors) == (1, 0), (
             f"an abrupt crash must leave the generation dirty with no clean anchor; "
             f"dirty={dirty} anchors={anchors}")
+
+
+# ===================================================================== seam 1: live identity proof
+
+def test_observe_drive_derives_identity_from_live_evidence(tmp_path):
+    """The production observer derives fingerprint/capacity/free from LIVE UUID/annex/serial/statvfs
+    evidence, not from the persisted fingerprint (so a stale row cannot vouch for a swapped volume)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP_LIVE,
+                      fscap=_LIVE_EV["filesystem_capacity_bytes"], free=0)
+        assert hasattr(fetch, "_observe_drive") and hasattr(fetch, "_live_drive_evidence"), \
+            "PR-03b must add fetch._observe_drive + fetch._live_drive_evidence (live identity proof)"
+        with mock.patch.object(fetch, "_live_drive_evidence", return_value=dict(_LIVE_EV), create=True):
+            obs = fetch._observe_drive(con, "drive-00")
+        assert obs.identity_proven is True
+        assert obs.fingerprint == _FP_LIVE, "fingerprint must be derived from live evidence"
+        assert obs.filesystem_capacity == _LIVE_EV["filesystem_capacity_bytes"]
+        assert obs.free_bytes == _LIVE_EV["free_bytes"], "free must be the live statvfs value, not the row"
+
+
+def test_live_identity_mismatch_refuses(tmp_path):
+    """If live evidence yields a different identity than the proven row, the mutation refuses
+    DRIVE_IDENTITY_UNPROVEN and never dirties (a swapped/mismounted volume)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP_LIVE,
+                      fscap=_LIVE_EV["filesystem_capacity_bytes"], free=0)
+        assert hasattr(fetch, "_observe_drive") and hasattr(fetch, "_live_drive_evidence"), \
+            "PR-03b must add fetch._observe_drive + fetch._live_drive_evidence"
+        wrong = dict(_LIVE_EV, fs_uuid="fs-uuid-DIFFERENT")            # a different physical volume
+        with mock.patch.object(fetch, "_live_drive_evidence", return_value=wrong, create=True):
+            try:
+                with dm.drive_mutation(con, ["drive-00"], "op",
+                                       observe=lambda label: fetch._observe_drive(con, label),
+                                       reconcile=_reconciler(con), now="2026-01-01"):
+                    raise AssertionError("mutation must refuse when live identity != proven identity")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_IDENTITY_UNPROVEN", exc.code
+        assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
+
+
+# ===================================================================== seam 2: end-to-end fence FDs
+
+def test_writer_exposes_actual_held_drive_fence_fds(tmp_path):
+    """The mutation writer exposes the ACTUAL held drive-lock FDs (child_fence_fds), so children can
+    inherit exactly what the parent holds."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP)
+        held = {}
+        with _capture_held_fence_fds(held):
+            with dm.drive_mutation(con, ["drive-00"], "op", observe=_observer(con, 900, 400),
+                                   reconcile=_reconciler(con), now="2026-01-01") as writer:
+                assert hasattr(writer, "child_fence_fds"), \
+                    "the mutation writer must expose child_fence_fds"
+                assert tuple(writer.child_fence_fds) == held.get("fds"), \
+                    "child_fence_fds must be the ACTUAL held drive-fence FDs"
+
+
+def test_run_threads_writer_fence_fds_into_fetch_model_and_tail_sync(tmp_path):
+    """run() passes the mutation writer (carrying the actual held FDs) into fetch_model, and the
+    run()-tail `git annex sync` inherits those FDs."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP)
+        (tmp_path / "lib").mkdir()
+        held, seen_model, runs = {}, {}, []
+
+        def fake_model(ctx, rid, dest, label, annex, cfg, *, mutation_writer=None, **kw):
+            seen_model["writer"] = mutation_writer
+            return {"repo_id": rid, "files": 1, "skipped": 0, "bytes": 1}
+
+        def cap_run(cmd, *a, **k):
+            runs.append((tuple(cmd), k.get("pass_fds")))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with _capture_held_fence_fds(held), \
+             mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+             mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
+             mock.patch.object(fetch, "_is_annex", return_value=True), \
+             mock.patch.object(fetch.register, "library_root", return_value=tmp_path / "lib"), \
+             mock.patch.object(fetch.subprocess, "run", side_effect=cap_run), \
+             mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+            fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+        writer = seen_model.get("writer")
+        assert writer is not None and hasattr(writer, "child_fence_fds"), \
+            "run() must pass the mutation writer (with child_fence_fds) into fetch_model"
+        assert tuple(writer.child_fence_fds) == held.get("fds"), \
+            "fetch_model must receive the ACTUAL held drive-fence FDs"
+        syncs = [fds for cmd, fds in runs if "annex" in cmd and "sync" in cmd]
+        assert syncs and all(tuple(f or ()) == held.get("fds") for f in syncs), \
+            f"the run()-tail annex sync must inherit the held fence FDs; got {syncs}"
+
+
+def test_download_and_compression_forward_inherit_fds_to_run_monitored(tmp_path):
+    """_download_shard and _compress_isolated forward their inherited fence FDs to the monitored-child
+    spawner, so the download/compress children keep the fence."""
+    for fn_name in ("_download_shard", "_compress_isolated"):
+        assert "inherit_fds" in inspect.signature(getattr(fetch, fn_name)).parameters, \
+            f"PR-03b must add `inherit_fds` to fetch.{fn_name}"
+    fd = os.open(os.devnull, os.O_RDONLY)
+    seen = {}
+
+    def fake_monitored(cmd, progress, stall, should_stop, *, inherit_fds=()):
+        if "download_worker" in " ".join(cmd):
+            seen["download"] = tuple(inherit_fds)
+            out = tmp_path / "dl.bin"
+            out.write_bytes(b"x")
+            Path(json.loads(cmd[-1])["result"]).write_text(json.dumps({"ok": True, "path": str(out)}))
+            return {"outcome": "exited", "rc": 0, "stderr": ""}
+        seen["compress"] = tuple(inherit_fds)
+        return {"outcome": "stalled", "rc": None, "stderr": ""}   # bail compression cheaply
+
+    local = tmp_path / "shard.bin"
+    local.write_bytes(b"x" * 16)
+    try:
+        with mock.patch.object(fetch, "_run_monitored", side_effect=fake_monitored):
+            fetch._download_shard(fetch.RunCtx(con=None), "repo", "f.bin", tmp_path, {}, inherit_fds=(fd,))
+            fetch._compress_isolated(local, "bf16", "zstd", 1, "deadbeef", lambda: False, inherit_fds=(fd,))
+    finally:
+        os.close(fd)
+    assert seen.get("download") == (fd,), f"download child must inherit the fence FD; got {seen.get('download')}"
+    assert seen.get("compress") == (fd,), f"compress child must inherit the fence FD; got {seen.get('compress')}"
+
+
+# ===================================================================== seam 3: reconciliation <-> transport
+
+def test_published_touched_set_reaches_reconciliation(tmp_path):
+    """A path/key the transport publishes is recorded on the mutation writer and reaches the reconciler
+    — transport cannot record nothing yet still publish a clean anchor."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP)
+        reconciled = []
+
+        def fake_model(ctx, rid, dest, label, annex, cfg, *, mutation_writer=None, **kw):
+            assert mutation_writer is not None, "run() must pass the mutation writer into fetch_model"
+            mutation_writer.record_touched(label, paths=["must/model.safetensors"], keys=["KEY-must"])
+            return {"repo_id": rid, "files": 1, "skipped": 0, "bytes": 1}
+
+        def fake_reconcile(_con, label, dest, annex, paths, keys):
+            reconciled.append((label, tuple(paths), tuple(keys)))
+
+        with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+             mock.patch.object(fetch, "_reconcile_touched", side_effect=fake_reconcile, create=True), \
+             mock.patch.object(fetch, "fetch_model", side_effect=fake_model), \
+             mock.patch.object(fetch, "_is_annex", return_value=False), \
+             mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+            fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+        assert ("drive-00", ("must/model.safetensors",), ("KEY-must",)) in reconciled, \
+            f"the published touched path/key must reach reconciliation; saw {reconciled}"
+
+
+def test_touched_reconciliation_fails_closed_on_missing_physical_path(tmp_path):
+    """A recorded touched path with a durable row but NO bytes on disk fails closed — reconciliation
+    validates physical presence, not just the catalog row."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+        con.execute("INSERT INTO models(repo_id) VALUES('must')")
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('must','model.safetensors',5,'safetensors')")
+        con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                    "orig_bytes,stored_bytes,compressed) VALUES('must','model.safetensors',"
+                    "'model.safetensors','must/model.safetensors','drive-00',5,5,0)")
+        # durable row present, but the published bytes are absent at dest
+        assert hasattr(fetch, "_reconcile_touched"), "PR-03b must add fetch._reconcile_touched"
+        try:
+            fetch._reconcile_touched(con, "drive-00", tmp_path, False, ["must/model.safetensors"], [])
+            raise AssertionError("reconciliation must fail closed when the published bytes are absent")
+        except dm.DriveMutationRefused as exc:
+            assert exc.code == "DRIVE_RECONCILIATION_REQUIRED", exc.code
+
+
+# ===================================================================== seam 4: writability-probe ordering
+
+def test_replica_writability_probe_runs_after_both_generations_committed(tmp_path):
+    """The replica's MUTATING writability probe runs only after BOTH source+target dirty generations
+    are committed (presence is checked non-mutatingly before the fence; the write probe is fenced)."""
+    with _catalog(tmp_path) as con:
+        task, archive_path, library = _replica_setup(con, tmp_path)
+        probe = sqlite3.connect(str(db.DB_PATH))
+        seen = []
+
+        def dest_writable(_p):
+            seen.append(probe.execute(
+                "SELECT count(*) FROM drive_dirty_generations "
+                "WHERE drive_label IN ('drive-00','drive-04')").fetchone()[0])
+            return True
+
+        try:
+            with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+                 mock.patch.object(fetch.register, "archive_path", side_effect=archive_path), \
+                 mock.patch.object(fetch.register, "library_root", return_value=library), \
+                 mock.patch.object(fetch, "_dest_writable", side_effect=dest_writable), \
+                 mock.patch.object(fetch, "_annex_key_on_uuid", return_value=True), \
+                 mock.patch.object(fetch.subprocess, "run",
+                                   return_value=subprocess.CompletedProcess([], 0, "", "")):
+                fetch.run_replica_tasks([task], ctx=fetch.RunCtx(con=con))
+        finally:
+            probe.close()
+        assert seen, "replica must run a mutating writability probe"
+        assert all(n == 2 for n in seen), \
+            f"the mutating _dest_writable probe must run only after BOTH dirty generations commit; saw {seen}"
+
+
+def test_run_error_path_writability_probe_runs_inside_the_batch_envelope(tmp_path):
+    """run()'s error-path drive-writability probe runs inside the batch envelope (dirty generation
+    already committed), not before it."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP)
+        probe = sqlite3.connect(str(db.DB_PATH))
+        seen = []
+
+        def dest_writable(_p):
+            seen.append(probe.execute("SELECT count(*) FROM drive_dirty_generations "
+                                      "WHERE drive_label='drive-00'").fetchone()[0])
+            return True
+
+        def boom(ctx, rid, dest, label, annex, cfg, **kw):
+            raise RuntimeError("write failed mid-batch")
+
+        try:
+            with mock.patch.object(fetch, "_observe_drive", side_effect=_observe_from_rows(con), create=True), \
+                 mock.patch.object(fetch, "fetch_model", side_effect=boom), \
+                 mock.patch.object(fetch, "_is_annex", return_value=False), \
+                 mock.patch.object(fetch, "_dest_writable", side_effect=dest_writable), \
+                 mock.patch.object(fetch, "_event"), \
+                 mock.patch.object(fetch.wishlist, "compression", return_value={"threads": 1}):
+                fetch.run(ctx=fetch.RunCtx(con=con), **_run_kwargs(dest=tmp_path))
+        finally:
+            probe.close()
+        assert seen, "run() error path must probe drive writability"
+        assert all(n == 1 for n in seen), \
+            f"the error-path _dest_writable probe must run inside the batch envelope; saw {seen}"
 
 
 def main():

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import fcntl
 import inspect
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -433,18 +434,28 @@ def test_touched_reconciliation_validates_recorded_set_narrowly(tmp_path):
     an unrelated (untouched) durable row + file on the same drive is ignored (no full-drive scan)."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00")
-        assert hasattr(fetch, "_reconcile_touched"), \
-            "PR-03b must add a narrow touched-set reconciler (fetch._reconcile_touched)"
+        # durable facts for the touched path (archived FK -> files -> models); FK enforcement is ON,
+        # so the parents must exist or the inserts IntegrityError before the narrowing is exercised.
+        con.execute("INSERT INTO models(repo_id) VALUES('must')")
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('must','model.safetensors',5,'safetensors')")
         (tmp_path / "must").mkdir()
         (tmp_path / "must" / "model.safetensors").write_bytes(b"bytes")
         con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
                     "orig_bytes,stored_bytes,compressed) VALUES('must','model.safetensors',"
                     "'model.safetensors','must/model.safetensors','drive-00',5,5,0)")
-        (tmp_path / "other").mkdir()                       # decoy a NARROW reconciler must never inspect
+        # a decoy unrelated durable row + file that a NARROW reconciler must never inspect
+        con.execute("INSERT INTO models(repo_id) VALUES('decoy')")
+        con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                    "VALUES('decoy','x.bin',1,'other')")
+        (tmp_path / "other").mkdir()
         (tmp_path / "other" / "x.bin").write_bytes(b"z")
         con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
                     "orig_bytes,stored_bytes,compressed) VALUES('decoy','x.bin','x.bin',"
                     "'other/x.bin','drive-00',1,1,0)")
+        # guard AFTER setup so the FK-correct fixture is exercised even while this stays RED at Gate-1
+        assert hasattr(fetch, "_reconcile_touched"), \
+            "PR-03b must add a narrow touched-set reconciler (fetch._reconcile_touched)"
         fetch._reconcile_touched(con, "drive-00", tmp_path, False, ["must/model.safetensors"], [])
 
 
@@ -519,9 +530,11 @@ def main():
     passed, failed = [], []
     for name, fn in tests:
         db_globals = (db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR)
+        tmp = None
         try:
             if "tmp_path" in inspect.signature(fn).parameters:
-                fn(Path(tempfile.mkdtemp(prefix="mark-03b-")))
+                tmp = Path(tempfile.mkdtemp(prefix="mark-03b-"))
+                fn(tmp)
             else:
                 fn()
             passed.append(name)
@@ -531,6 +544,8 @@ def main():
             print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
         finally:
             db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = db_globals
+            if tmp is not None:                  # the standalone runner cleans its own temp trees
+                shutil.rmtree(tmp, ignore_errors=True)
     print(f"\n{len(passed)} passed, {len(failed)} failed")
     if failed:
         raise SystemExit(1)

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -85,7 +85,7 @@ def test_worker_gated(tmp_path):
 
 def _monitored_writes(result: dict, outcome: str = "exited", rc: int = 0):
     """A _run_monitored stand-in that writes `result` to the child's result file, then returns `outcome`."""
-    def side_effect(cmd, progress, stall_secs, should_stop):
+    def side_effect(cmd, progress, stall_secs, should_stop, **_kw):
         req = json.loads(cmd[-1])
         Path(req["result"]).write_text(json.dumps(result))
         return {"outcome": outcome, "rc": rc, "stderr": ""}
@@ -193,7 +193,7 @@ def test_download_progress_probe_measures_nested_incomplete(tmp_path):
     (nested_dir / "abc.incomplete").write_bytes(b"x" * 4096)
     seen = {}
 
-    def side_effect(cmd, progress, stall_secs, should_stop):
+    def side_effect(cmd, progress, stall_secs, should_stop, **_kw):
         seen["bytes"] = progress()
         req = json.loads(cmd[-1])
         out = tmp_path / "out.bin"


### PR DESCRIPTION
Merges into `fix/placement-capacity-hardening` (never `main`). Wires the existing Fill / download / compression / annex / replica transport through the merged catalog-v3 **physical-mutation envelope** (`drive_fence` + `drive_mutation`), with monitored and git children inheriting the held drive-fence FDs. Implements RFC-002 / DEC-049 placement-capacity hardening, slice 2 (#35-B).

**Status:** implementation complete and reviewer-approved. CI green (`test 3.10`/`3.12`, `e2e`, Greptile 5/5); no outstanding findings on head `0077508`.

## What this does
- **Envelope around both executors** — `run()` wraps each per-drive batch and `run_replica_tasks()` wraps each (source, target) pair in `drive_mutation(...)`: dirty the generation before allocation, run the transport, reconcile the touched set, publish the clean anchor on success; any failure leaves the generation durably dirty with no anchor.
- **Inherited fence FDs to every mutating child** — the writer exposes the actually-held `child_fence_fds`, threaded through `fetch_model(mutation_writer=…)` to download / compression (`_run_monitored`), `annex add` / `annex metadata`, remote config, the git sync tail, and both replica source/target children. Read-only `lookupkey` is deliberately excluded. The flock survives parent death via the inherited open-file-description.
- **Live identity proof** — `_observe_drive` / `_live_drive_evidence` derive the fingerprint from live volume facts (`register.probe_fs_uuid`/`annex_uuid`/`serial` + `statvfs`); an unproven or mismatched identity is a typed `DRIVE_IDENTITY_UNPROVEN` refusal.
- **Per-path reconciliation invariant** (`_reconcile_touched`) — for each touched path: raw ⇒ durable row + physical file; annex ⇒ a non-null durable `archived.annex_key` that agrees with a writer-recorded key **and** is proven the exact key present (target-uuid `whereis` or the path's own `lookupkey`). Null / mismatched / unprovable ⇒ `DRIVE_RECONCILIATION_REQUIRED`, generation stays dirty.
- **Explicit-remote sync boundary** — the primary map sync names only `drive_label`; the replica map sync names only `source` + `target`; both inside the fences.
- **`fetch_events` outcome fix** — the schema-forbidden `outcome="terminal"` is corrected to the allowed `"error"` carrying the typed code in `detail` (no migration).

## Production surface (3 files)
- `modelark/fetch.py` — the transport ↔ envelope seam (the visible diff is inflated by loop-indentation from the two `with` wraps; the real logic delta is smaller).
- `modelark/drive_mutation.py` — `_Writer.child_fence_fds`; an `ExitStack` releases the controller fence after the dirty-generation commit while the drive fences span body + reconciliation + anchor.
- `modelark/register.py` — `probe_fs_uuid` / `probe_annex_uuid` / `probe_serial` (Linux-only; degrade to `None` off-platform).

## Tests
- `tests/test_transport_fence.py` — new 27-test contract: Gate-0 rulings R1–R7, the five reviewer seams, and the reconciliation regression cases (unresolvable dest, probe-timeout containment, the annex-key invariant across null/mismatched/unprovable, worktree-symlink-free replica presence, unmounted observe). All green.
- `tests/test_drive_mutation_envelope.py` — the PR-03a dormancy guard is inverted into a wiring guard: only `fetch.py` may import the envelope, and it must.
- `tests/test_replan.py` — `_passthru_mutation` bypasses the envelope for the transport-logic characterization tests.
- `tests/test_compress_isolation.py` / `tests/test_hash_repair.py` / `tests/test_watchdog.py` — mock signatures widened to absorb `inherit_fds`; no logic change.

## Scope / accepted residual
The legacy `run_replica` **CLI** copy path is intentionally **not** enveloped — it has no production caller and remains deferred (reviewer-accepted). The fill-executor replica path (`run_replica_tasks`) **is** enveloped. No registration/recovery, admission cutover, sessions, transport-policy rewrite, or other legacy-path expansion.

## Safety
Synthetic proven drives, temp trees, fakes, and throwaway real subprocesses only — no live service / catalog / drive touched. The local `.gitignore` change was never staged or committed. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCUcZdiUBs8sF2GbLvf49Q
