### PR TITLE
PR-03c1 (#35-B): drive identity bootstrap + first anchor + sessionless recovery

### DIFF
--- a/modelark/cli.py
+++ b/modelark/cli.py
@@ -470,12 +470,16 @@ def cmd_drive_list(args):
 def cmd_drive_reconcile(args):
     from datetime import datetime, timezone
 
-    from modelark import drive_bootstrap
+    from modelark import drive_bootstrap, drive_mutation
     con = db.connect()
     try:
         r = drive_bootstrap.reconcile_drive(
             con, args.label, now=datetime.now(timezone.utc).isoformat(sep=" "),
             dedicated=args.dedicated, accept_drift=args.accept_drift)
+    except drive_mutation.DriveMutationRefused as exc:
+        # an offline/failed/unproven drive is an EXPECTED reconciliation outcome, not a crash: surface the
+        # typed refusal as a clean operator message (the restore/hash-repair convention), not a traceback.
+        raise SystemExit(f"drive reconcile failed: {exc.code}") from exc
     finally:
         con.close()
     free = f"  free={r.anchor_free_bytes}" if r.anchor_free_bytes is not None else ""

--- a/modelark/cli.py
+++ b/modelark/cli.py
@@ -467,6 +467,21 @@ def cmd_drive_list(args):
               f"{str(d['health'] or '-'):8} {free}/{cap} free  {d['physical_location'] or ''}")
 
 
+def cmd_drive_reconcile(args):
+    from datetime import datetime, timezone
+
+    from modelark import drive_bootstrap
+    con = db.connect()
+    try:
+        r = drive_bootstrap.reconcile_drive(
+            con, args.label, now=datetime.now(timezone.utc).isoformat(sep=" "),
+            dedicated=args.dedicated, accept_drift=args.accept_drift)
+    finally:
+        con.close()
+    free = f"  free={r.anchor_free_bytes}" if r.anchor_free_bytes is not None else ""
+    print(f"{args.label}: {r.outcome}  epoch={r.identity_epoch} generation={r.generation}{free}")
+
+
 def main(argv=None):
     p = argparse.ArgumentParser(prog="modelark", description="Catalog & verify open model weights.")
     p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
@@ -632,6 +647,15 @@ def main(argv=None):
     reg.set_defaults(func=cmd_drive_register)
     dl = drsub.add_parser("list", help="list registered drives")
     dl.set_defaults(func=cmd_drive_list)
+    rec = drsub.add_parser("reconcile",
+                           help="bootstrap identity + first clean anchor, or recover a dirty generation")
+    rec.add_argument("label", help="the registered drive label to reconcile")
+    rec.add_argument("--dedicated", action="store_true",
+                     help="assert dedicated local storage no unsupported writer may modify (grants "
+                          "dedicated_local authority); omit for shared/NAS/unfenceable storage → unknown")
+    rec.add_argument("--accept-drift", dest="accept_drift", action="store_true",
+                     help="accept an above-tolerance free-space drift and re-anchor after full reconciliation")
+    rec.set_defaults(func=cmd_drive_reconcile)
 
     args = p.parse_args(argv)
     if args.data_dir is not None or args.state_dir is not None:

--- a/modelark/cli.py
+++ b/modelark/cli.py
@@ -470,13 +470,13 @@ def cmd_drive_list(args):
 def cmd_drive_reconcile(args):
     from datetime import datetime, timezone
 
-    from modelark import drive_bootstrap, drive_mutation
+    from modelark import drive_bootstrap
     con = db.connect()
     try:
         r = drive_bootstrap.reconcile_drive(
             con, args.label, now=datetime.now(timezone.utc).isoformat(sep=" "),
             dedicated=args.dedicated, accept_drift=args.accept_drift)
-    except drive_mutation.DriveMutationRefused as exc:
+    except drive_bootstrap.DriveMutationRefused as exc:
         # an offline/failed/unproven drive is an EXPECTED reconciliation outcome, not a crash: surface the
         # typed refusal as a clean operator message (the restore/hash-repair convention), not a traceback.
         raise SystemExit(f"drive reconcile failed: {exc.code}") from exc

--- a/modelark/drive_bootstrap.py
+++ b/modelark/drive_bootstrap.py
@@ -1,0 +1,257 @@
+"""Drive identity bootstrap + first clean anchor + sessionless dirty recovery (RFC-002 / DEC-049 #35-B,
+PR-03c1) — the smallest usable predecessor to the #35-C admission-authority cutover.
+
+A neutral module: it depends only on the low-level catalog-v3 primitives (``drive_fence``,
+``drive_mutation``, ``register``, ``capacity_evidence``) and NEVER on the transport module ``fetch`` —
+so there is no ``register -> fetch`` / ``register -> drive_bootstrap`` ownership cycle, and no broad
+transport refactor. The physical-mutation envelope PR-03a/03b built is inert until a drive carries a
+proven identity + ``dedicated_local`` authority; ``reconcile_drive`` is what establishes them.
+
+One operator operation, ``drive reconcile <label>`` (``reconcile_drive``), covers, under the controller +
+drive fences and committed in ONE short transaction (identity evidence + dirty generation + clean anchor
++ authority, atomically — a crash before that commit leaves the drive unknown and anchorless):
+
+  * bootstrap        — a drive with no persisted identity: prove it, full-inventory reconcile, open
+                       generation 1, publish the first anchor storing the RAW observed free.
+  * refresh          — a currently-clean anchored drive at the same identity/capacity whose free has
+                       drifted only WITHIN the versioned diagnostic tolerance: advance a generation and
+                       re-anchor the fresh raw free.  Above tolerance -> DRIVE_FREE_DRIFT unless
+                       ``accept_drift`` re-anchors after a full reconciliation under a distinct
+                       ``accept-drift`` operation code.
+  * epoch transition — same identity, CHANGED filesystem capacity: reset the namespace to
+                       (new epoch, generation 1) and re-anchor.
+  * recovery         — a dirty generation with no anchor and NO owner session (sessionless): reconcile
+                       and republish THAT generation's anchor via the (epoch, generation) CAS.
+
+``dedicated_local`` is an explicit operator/policy assertion of exclusivity (``dedicated=True``), never
+derivable from identity probes; without it the drive stays a valid ``unknown`` identity, and a
+``dedicated=False`` reconcile never downgrades an already-authoritative drive (a typed refusal —
+revocation is a separate lifecycle).  A different identity under an existing label refuses before any
+mutation.  Session-attributed recovery and label reuse/retirement are out of scope (#39, DEF-029).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from modelark import capacity_evidence, drive_fence, register
+from modelark import drive_mutation as dm
+from modelark.core import db
+
+# The diagnostic free-drift tolerance is one filesystem allocation unit plus this bounded metadata
+# allowance. It is DIAGNOSTIC ONLY — it gates refresh-vs-refuse; the anchor always stores the raw
+# observed free, so the tolerance is never extra capacity headroom.
+_DRIFT_METADATA_ALLOWANCE_BYTES = 1 << 20               # v1: 1 MiB
+
+
+@dataclass(frozen=True)
+class Inventory:
+    """A bounded, report-only full reconciliation of a drive against its catalogued claims."""
+    present: list                                        # [(repo_id, rfilename)] proven present
+    missing: list                                        # [(repo_id, rfilename)] absent/unprovable claims
+    debris: list = field(default_factory=list)           # recognized staging/.incomplete/tmp relpaths
+    extra: list = field(default_factory=list)            # unexplained extra relpaths (reported, not deleted)
+
+    @property
+    def complete(self) -> bool:
+        return not self.missing
+
+
+@dataclass(frozen=True)
+class Reconciliation:
+    """The operator-visible outcome of ``reconcile_drive``."""
+    outcome: str                                         # bootstrapped|refreshed|drift_accepted|
+    identity_epoch: int                                  #   epoch_advanced|recovered|unknown_no_authority
+    generation: int
+    anchor_free_bytes: int | None
+    inventory: Inventory | None = None
+
+
+def free_drift_tolerance_v1(alloc_unit_bytes: int) -> int:
+    """Versioned diagnostic free-drift tolerance: one filesystem allocation unit + a bounded metadata
+    allowance. NEVER capacity headroom — it only gates whether a refresh re-anchors or refuses."""
+    return alloc_unit_bytes + _DRIFT_METADATA_ALLOWANCE_BYTES
+
+
+# ---- physical-evidence seams (isolated so the fenced/atomic logic above stays testable) -------------
+
+def _alloc_unit(dest) -> int:
+    """The filesystem allocation unit (statvfs f_frsize) backing the drift tolerance."""
+    return os.statvfs(dest).f_frsize
+
+
+def _live_observation(con, label: str) -> dm.Observation:
+    """Fenced live observation: prove the drive's identity from the CURRENT volume (fs/annex/serial +
+    filesystem capacity), never the persisted row, and read its live free/capacity. Identity is unproven
+    when the drive is absent or exposes neither an fs nor an annex UUID. (Mirrors fetch._observe_drive
+    without importing the transport module.)"""
+    path = register.archive_path(con, label)
+    if path is None:
+        return dm.Observation(False, None, None, None, "", "")
+    try:
+        st = os.statvfs(path)
+    except OSError:                                       # unmounted/vanished mid-probe -> unknown, not error
+        return dm.Observation(False, None, None, None, "", "")
+    fs_uuid = register.probe_fs_uuid(path)
+    annex_uuid = register.probe_annex_uuid(path)
+    if not (fs_uuid or annex_uuid):
+        return dm.Observation(False, None, None, None, "", "")
+    capacity = st.f_blocks * st.f_frsize
+    fingerprint = capacity_evidence.identity_fingerprint_v1(
+        fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=register.probe_serial(path),
+        filesystem_capacity_bytes=capacity)
+    proof = json.dumps({"v": 1, "fs_uuid": fs_uuid, "annex_uuid": annex_uuid,
+                        "serial": register.probe_serial(path)}, sort_keys=True, separators=(",", ":"))
+    return dm.Observation(True, st.f_bavail * st.f_frsize, capacity, fingerprint, proof, proof)
+
+
+def _annex_key_present(dest, key: str, *, target_uuid) -> bool:
+    """Prove an annex key is physically present on the drive (its uuid appears in ``whereis``). The
+    worktree symlink is NOT the proof — ``git annex copy --to`` deposits the object without one."""
+    if not (key and target_uuid):
+        return False
+    try:
+        out = subprocess.run(["git", "-C", str(dest), "annex", "whereis", "--key", key],
+                             capture_output=True, text=True, check=False)
+    except OSError:
+        return False
+    return out.returncode == 0 and target_uuid in out.stdout
+
+
+_DEBRIS_SUFFIXES = (".incomplete", ".tmp")
+
+
+def _is_debris(relpath: str) -> bool:
+    """Recognize known staging/partial/temporary debris (never counted as a catalogued copy)."""
+    name = relpath.rsplit("/", 1)[-1]
+    return name.endswith(_DEBRIS_SUFFIXES) or name.startswith(".modelark-probe")
+
+
+def _walk_files(root: Path):
+    for p in root.rglob("*"):
+        if p.is_file() and ".git" not in p.parts:
+            yield p
+
+
+def _inventory(con, label: str, dest) -> Inventory:
+    """Full, bounded, report-only reconciliation of a drive against every catalogued claim: prove each
+    raw/annex copy present, recognize debris, and report unexplained extra content WITHOUT deleting it
+    (the final free observation accounts for its bytes). An unprovable/absent claim is never counted
+    present — it lands in ``missing`` and blocks a clean anchor."""
+    dest = Path(dest)
+    target_uuid = (con.execute("SELECT annex_uuid FROM drives WHERE drive_label=?",
+                               [label]).fetchone() or [None])[0]
+    present, missing = [], []
+    claimed = set()
+    for repo_id, rfilename, annex_key, relpath in con.execute(
+            "SELECT repo_id, rfilename, annex_key, repo_id || '/' || stored_relpath "
+            "FROM archived WHERE drive_label=?", [label]).fetchall():
+        claimed.add(relpath)
+        proven = (_annex_key_present(dest, annex_key, target_uuid=target_uuid) if annex_key
+                  else (dest / relpath).exists())
+        (present if proven else missing).append((repo_id, rfilename))
+    debris, extra = [], []
+    for path in _walk_files(dest):
+        rel = path.relative_to(dest).as_posix()
+        if _is_debris(rel):
+            debris.append(rel)
+        elif rel not in claimed:
+            extra.append(rel)
+    return Inventory(present, missing, debris, extra)
+
+
+def _require_complete_inventory(con, label: str, dest) -> Inventory:
+    inv = _inventory(con, label, dest)
+    if inv.missing:                                      # an unproved catalogued copy leaves it dirty
+        raise dm.DriveMutationRefused("DRIVE_RECONCILIATION_REQUIRED", drive=label, missing=len(inv.missing))
+    return inv
+
+
+# ---- the single operator operation ------------------------------------------------------------------
+
+def reconcile_drive(con, label: str, *, now, dedicated: bool = False, accept_drift: bool = False,
+                    blocking: bool = True) -> Reconciliation:
+    """Bootstrap / refresh / epoch-transition / recover one drive under the controller + drive fences,
+    committing identity evidence + generation + anchor + authority atomically. See the module docstring
+    for the full contract; raises a typed ``dm.DriveMutationRefused`` for every fail-closed path."""
+    p_epoch, p_gen, p_fp, p_cap, p_auth = dm._drive_facts(con, label)
+    try:
+        with drive_fence.hold_controller(db.DB_PATH, blocking=blocking):
+            obs = _live_observation(con, label)          # derive the live identity under the controller
+            if not obs.identity_proven:
+                raise dm.DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
+            live_fp = obs.fingerprint
+            if p_fp is not None and live_fp != p_fp:     # a different identity under an existing label
+                raise dm.DriveMutationRefused("DRIVE_IDENTITY_MISMATCH", drive=label,
+                                              persisted=p_fp, live=live_fp)
+            if not dedicated:                            # exclusivity is an explicit assertion, not a probe
+                if p_auth == "dedicated_local":
+                    raise dm.DriveMutationRefused("DRIVE_AUTHORITY_DOWNGRADE_REFUSED", drive=label)
+                return Reconciliation("unknown_no_authority", p_epoch, p_gen, None)
+            with drive_fence.hold_drives_sorted([(live_fp, p_epoch)], blocking=blocking):
+                obs = _live_observation(con, label)      # re-prove identity under the drive fence
+                if not obs.identity_proven or obs.fingerprint != live_fp:
+                    raise dm.DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
+                dest = register.archive_path(con, label)
+                return _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, obs, now,
+                                          accept_drift)
+    except drive_fence.FenceUnavailable as exc:
+        raise dm.DriveMutationRefused("DRIVE_FENCE_UNAVAILABLE", **exc.evidence) from exc
+
+
+def _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, obs, now, accept_drift):
+    live_cap, live_free = obs.filesystem_capacity, obs.free_bytes
+
+    if p_fp is None:                                     # (A) bootstrap: establish the identity + first anchor
+        _require_complete_inventory(con, label, dest)
+
+        def _body():
+            con.execute("UPDATE drives SET identity_epoch=?, filesystem_capacity_bytes=?, "
+                        "identity_fingerprint=?, write_authority='dedicated_local' WHERE drive_label=?",
+                        [p_epoch, live_cap, obs.fingerprint, label])
+            gen = dm._advance_one(con, label, "bootstrap")           # generation 0 -> 1
+            dm._publish_anchor_locked(con, label, p_epoch, gen, obs, now)
+            return gen
+        return Reconciliation("bootstrapped", p_epoch, dm._immediate(con, _body), live_free)
+
+    if live_cap != p_cap:                                # (D) capacity-epoch transition: reset the namespace
+        _require_complete_inventory(con, label, dest)
+        new_epoch = p_epoch + 1
+
+        def _body():
+            con.execute("UPDATE drives SET identity_epoch=?, filesystem_capacity_bytes=?, "
+                        "write_generation=0 WHERE drive_label=?", [new_epoch, live_cap, label])
+            gen = dm._advance_one(con, label, "epoch")               # 0 -> 1 under the new epoch
+            dm._publish_anchor_locked(con, label, new_epoch, gen, obs, now)
+            return gen
+        return Reconciliation("epoch_advanced", new_epoch, dm._immediate(con, _body), live_free)
+
+    if not dm._generation_is_clean(con, label, p_epoch, p_gen, p_fp, live_cap, "dedicated_local"):
+        # (B) sessionless dirty recovery — republish THIS generation's anchor (session-attributed = #39)
+        owner = con.execute("SELECT owner_session_id FROM drive_dirty_generations "
+                            "WHERE drive_label=? AND identity_epoch=? AND generation=?",
+                            [label, p_epoch, p_gen]).fetchone()
+        if owner is not None and owner[0] is not None:
+            raise dm.DriveMutationRefused("DRIVE_RECOVERY_SESSION_ACTIVE", drive=label)
+        _require_complete_inventory(con, label, dest)
+        dm.publish_clean_anchor(con, label, p_epoch, p_gen, obs, now)
+        return Reconciliation("recovered", p_epoch, p_gen, live_free)
+
+    # (C) refresh of a currently-clean anchored drive — drift-gated
+    last_free = con.execute("SELECT anchor_free_bytes FROM drive_clean_anchors WHERE drive_label=? "
+                           "AND identity_epoch=? AND generation=?", [label, p_epoch, p_gen]).fetchone()[0]
+    drifted = abs(live_free - last_free) > free_drift_tolerance_v1(_alloc_unit(dest))
+    if drifted and not accept_drift:
+        raise dm.DriveMutationRefused("DRIVE_FREE_DRIFT", drive=label, anchored=last_free, observed=live_free)
+    _require_complete_inventory(con, label, dest)
+    op = "accept-drift" if drifted else "reconcile"
+
+    def _body():
+        gen = dm._advance_one(con, label, op)                        # clean -> generation + 1
+        dm._publish_anchor_locked(con, label, p_epoch, gen, obs, now)
+        return gen
+    return Reconciliation("drift_accepted" if drifted else "refreshed", p_epoch,
+                          dm._immediate(con, _body), live_free)

--- a/modelark/drive_bootstrap.py
+++ b/modelark/drive_bootstrap.py
@@ -39,6 +39,11 @@ from modelark import capacity_evidence, drive_fence, register
 from modelark import drive_mutation as dm
 from modelark.core import db
 
+# Re-export the typed refusal so operator entry points (the `drive reconcile` CLI) can translate it to a
+# clean message via THIS module, without importing the fenced envelope directly — keeping the envelope
+# importer set limited to the reviewed owners (see test_envelope_wired_only_into_reviewed_transport).
+DriveMutationRefused = dm.DriveMutationRefused
+
 # The diagnostic free-drift tolerance is one filesystem allocation unit plus this bounded metadata
 # allowance. DIAGNOSTIC ONLY — it gates refresh-vs-refuse; the anchor always stores the raw observed
 # free, so the tolerance is never extra capacity headroom.

--- a/modelark/drive_bootstrap.py
+++ b/modelark/drive_bootstrap.py
@@ -3,31 +3,29 @@ PR-03c1) — the smallest usable predecessor to the #35-C admission-authority cu
 
 A neutral module: it depends only on the low-level catalog-v3 primitives (``drive_fence``,
 ``drive_mutation``, ``register``, ``capacity_evidence``) and NEVER on the transport module ``fetch`` —
-so there is no ``register -> fetch`` / ``register -> drive_bootstrap`` ownership cycle, and no broad
-transport refactor. The physical-mutation envelope PR-03a/03b built is inert until a drive carries a
-proven identity + ``dedicated_local`` authority; ``reconcile_drive`` is what establishes them.
+so there is no ``register -> fetch`` / ``register -> drive_bootstrap`` ownership cycle and no transport
+refactor. The physical-mutation envelope PR-03a/03b built is inert until a drive carries a proven
+identity + ``dedicated_local`` authority; ``reconcile_drive`` is what establishes them.
 
-One operator operation, ``drive reconcile <label>`` (``reconcile_drive``), covers, under the controller +
-drive fences and committed in ONE short transaction (identity evidence + dirty generation + clean anchor
-+ authority, atomically — a crash before that commit leaves the drive unknown and anchorless):
+Real-evidence contract (the identity fingerprint deliberately folds ``filesystem_capacity_bytes`` in, so
+a resize changes the fingerprint):
 
-  * bootstrap        — a drive with no persisted identity: prove it, full-inventory reconcile, open
-                       generation 1, publish the first anchor storing the RAW observed free.
-  * refresh          — a currently-clean anchored drive at the same identity/capacity whose free has
-                       drifted only WITHIN the versioned diagnostic tolerance: advance a generation and
-                       re-anchor the fresh raw free.  Above tolerance -> DRIVE_FREE_DRIFT unless
-                       ``accept_drift`` re-anchors after a full reconciliation under a distinct
-                       ``accept-drift`` operation code.
-  * epoch transition — same identity, CHANGED filesystem capacity: reset the namespace to
-                       (new epoch, generation 1) and re-anchor.
-  * recovery         — a dirty generation with no anchor and NO owner session (sessionless): reconcile
-                       and republish THAT generation's anchor via the (epoch, generation) CAS.
+  * STABLE identity is the filesystem/annex UUID pair (serial is supporting evidence). Every decision —
+    mismatch refusal, adopt, epoch transition — compares the stable identity, NOT the capacity-bearing
+    fingerprint. A migrated row (fingerprint NULL) is adopted only when the live stable identity equals
+    every persisted non-null UUID; different media under an existing label refuses (DEF-029 reuse stays
+    deferred).
+  * A capacity change on the SAME stable identity is a capacity-epoch transition: it holds BOTH the old
+    ``(fingerprint, epoch)`` and the prospective new ``(fingerprint, epoch+1)`` drive fences, and persists
+    the NEW fingerprint + capacity + epoch + generation 1 + anchor atomically.
+  * Every anchor is published from a FRESH post-inventory observation taken under the held drive fences;
+    a drive that vanishes or changes identity/capacity during inventory leaves no anchor.
 
-``dedicated_local`` is an explicit operator/policy assertion of exclusivity (``dedicated=True``), never
-derivable from identity probes; without it the drive stays a valid ``unknown`` identity, and a
-``dedicated=False`` reconcile never downgrades an already-authoritative drive (a typed refusal —
-revocation is a separate lifecycle).  A different identity under an existing label refuses before any
-mutation.  Session-attributed recovery and label reuse/retirement are out of scope (#39, DEF-029).
+``reconcile_drive`` runs under the controller + drive fences and commits identity evidence + dirty
+generation + clean anchor + authority in ONE short transaction (a crash before it leaves the drive
+unknown and anchorless). ``dedicated_local`` is an explicit operator assertion (``dedicated=True``),
+never a probe result; ``dedicated=False`` persists nothing and refuses to downgrade an authoritative
+drive. Session-attributed recovery and label reuse/retirement are out of scope (#39, DEF-029).
 """
 from __future__ import annotations
 
@@ -42,8 +40,8 @@ from modelark import drive_mutation as dm
 from modelark.core import db
 
 # The diagnostic free-drift tolerance is one filesystem allocation unit plus this bounded metadata
-# allowance. It is DIAGNOSTIC ONLY — it gates refresh-vs-refuse; the anchor always stores the raw
-# observed free, so the tolerance is never extra capacity headroom.
+# allowance. DIAGNOSTIC ONLY — it gates refresh-vs-refuse; the anchor always stores the raw observed
+# free, so the tolerance is never extra capacity headroom.
 _DRIFT_METADATA_ALLOWANCE_BYTES = 1 << 20               # v1: 1 MiB
 
 
@@ -58,6 +56,27 @@ class Inventory:
     @property
     def complete(self) -> bool:
         return not self.missing
+
+
+@dataclass(frozen=True)
+class _LiveEvidence:
+    """One consistent snapshot of a drive's live volume (probed once, so identity/capacity/free never
+    disagree within a decision): the stable identifiers, capacity/free, allocation unit, and the
+    composite identity fingerprint."""
+    path: str | None
+    fs_uuid: str | None
+    annex_uuid: str | None
+    serial: str | None
+    capacity: int | None
+    free: int | None
+    alloc_unit: int | None
+    fingerprint: str | None
+    proven: bool
+
+    def observation(self) -> dm.Observation:
+        proof = json.dumps({"v": 1, "fs_uuid": self.fs_uuid, "annex_uuid": self.annex_uuid,
+                            "serial": self.serial}, sort_keys=True, separators=(",", ":"))
+        return dm.Observation(self.proven, self.free, self.capacity, self.fingerprint, proof, proof)
 
 
 @dataclass(frozen=True)
@@ -76,36 +95,28 @@ def free_drift_tolerance_v1(alloc_unit_bytes: int) -> int:
     return alloc_unit_bytes + _DRIFT_METADATA_ALLOWANCE_BYTES
 
 
-# ---- physical-evidence seams (isolated so the fenced/atomic logic above stays testable) -------------
+# ---- physical-evidence seams (isolated so the fenced/atomic logic below stays testable) -------------
 
-def _alloc_unit(dest) -> int:
-    """The filesystem allocation unit (statvfs f_frsize) backing the drift tolerance."""
-    return os.statvfs(dest).f_frsize
-
-
-def _live_observation(con, label: str) -> dm.Observation:
-    """Fenced live observation: prove the drive's identity from the CURRENT volume (fs/annex/serial +
-    filesystem capacity), never the persisted row, and read its live free/capacity. Identity is unproven
-    when the drive is absent or exposes neither an fs nor an annex UUID. (Mirrors fetch._observe_drive
-    without importing the transport module.)"""
+def _live_evidence(con, label: str) -> _LiveEvidence:
+    """Probe the CURRENT volume once and return a consistent evidence snapshot. Identity is unproven when
+    the drive is absent/unmounted or exposes neither an fs nor an annex UUID."""
     path = register.archive_path(con, label)
     if path is None:
-        return dm.Observation(False, None, None, None, "", "")
+        return _LiveEvidence(None, None, None, None, None, None, None, None, False)
     try:
         st = os.statvfs(path)
-    except OSError:                                       # unmounted/vanished mid-probe -> unknown, not error
-        return dm.Observation(False, None, None, None, "", "")
+    except OSError:                                      # unmounted/vanished mid-probe -> unknown, not error
+        return _LiveEvidence(str(path), None, None, None, None, None, None, None, False)
     fs_uuid = register.probe_fs_uuid(path)
     annex_uuid = register.probe_annex_uuid(path)
+    serial = register.probe_serial(path)                 # probed ONCE, reused for fingerprint + proof
     if not (fs_uuid or annex_uuid):
-        return dm.Observation(False, None, None, None, "", "")
+        return _LiveEvidence(str(path), fs_uuid, annex_uuid, serial, None, None, None, None, False)
     capacity = st.f_blocks * st.f_frsize
     fingerprint = capacity_evidence.identity_fingerprint_v1(
-        fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=register.probe_serial(path),
-        filesystem_capacity_bytes=capacity)
-    proof = json.dumps({"v": 1, "fs_uuid": fs_uuid, "annex_uuid": annex_uuid,
-                        "serial": register.probe_serial(path)}, sort_keys=True, separators=(",", ":"))
-    return dm.Observation(True, st.f_bavail * st.f_frsize, capacity, fingerprint, proof, proof)
+        fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=serial, filesystem_capacity_bytes=capacity)
+    return _LiveEvidence(str(path), fs_uuid, annex_uuid, serial, capacity,
+                         st.f_bavail * st.f_frsize, st.f_frsize, fingerprint, True)
 
 
 def _annex_key_present(dest, key: str, *, target_uuid) -> bool:
@@ -137,10 +148,10 @@ def _walk_files(root: Path):
 
 
 def _inventory(con, label: str, dest) -> Inventory:
-    """Full, bounded, report-only reconciliation of a drive against every catalogued claim: prove each
-    raw/annex copy present, recognize debris, and report unexplained extra content WITHOUT deleting it
-    (the final free observation accounts for its bytes). An unprovable/absent claim is never counted
-    present — it lands in ``missing`` and blocks a clean anchor."""
+    """Full, bounded, report-only reconciliation against every catalogued claim: prove each raw/annex
+    copy present, recognize debris, and report unexplained extra content WITHOUT deleting it (the final
+    free observation accounts for its bytes). An unprovable/absent claim is never counted present — it
+    lands in ``missing`` and blocks a clean anchor."""
     dest = Path(dest)
     target_uuid = (con.execute("SELECT annex_uuid FROM drives WHERE drive_label=?",
                                [label]).fetchone() or [None])[0]
@@ -172,64 +183,97 @@ def _require_complete_inventory(con, label: str, dest) -> Inventory:
 
 # ---- the single operator operation ------------------------------------------------------------------
 
+def _persisted(con, label: str):
+    row = con.execute(
+        "SELECT identity_epoch, write_generation, identity_fingerprint, filesystem_capacity_bytes, "
+        "write_authority, fs_uuid, annex_uuid FROM drives WHERE drive_label=?", [label]).fetchone()
+    if row is None:
+        raise dm.DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
+    return row
+
+
+def _stable_identity_matches(ev: _LiveEvidence, persisted_fs, persisted_annex) -> bool:
+    """The live stable identity must equal every persisted non-null filesystem/annex UUID. Serial is
+    only supporting evidence and never on its own admits or rejects."""
+    if persisted_fs is not None and ev.fs_uuid != persisted_fs:
+        return False
+    if persisted_annex is not None and ev.annex_uuid != persisted_annex:
+        return False
+    return True
+
+
 def reconcile_drive(con, label: str, *, now, dedicated: bool = False, accept_drift: bool = False,
                     blocking: bool = True) -> Reconciliation:
     """Bootstrap / refresh / epoch-transition / recover one drive under the controller + drive fences,
     committing identity evidence + generation + anchor + authority atomically. See the module docstring
     for the full contract; raises a typed ``dm.DriveMutationRefused`` for every fail-closed path."""
-    p_epoch, p_gen, p_fp, p_cap, p_auth = dm._drive_facts(con, label)
     try:
         with drive_fence.hold_controller(db.DB_PATH, blocking=blocking):
-            obs = _live_observation(con, label)          # derive the live identity under the controller
-            if not obs.identity_proven:
+            p_epoch, p_gen, p_fp, p_cap, p_auth, p_fs, p_annex = _persisted(con, label)   # facts UNDER controller
+            ev = _live_evidence(con, label)
+            if not ev.proven:
                 raise dm.DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
-            live_fp = obs.fingerprint
-            if p_fp is not None and live_fp != p_fp:     # a different identity under an existing label
+            if not _stable_identity_matches(ev, p_fs, p_annex):      # different media under an existing label
                 raise dm.DriveMutationRefused("DRIVE_IDENTITY_MISMATCH", drive=label,
-                                              persisted=p_fp, live=live_fp)
+                                              persisted=(p_fs, p_annex), live=(ev.fs_uuid, ev.annex_uuid))
             if not dedicated:                            # exclusivity is an explicit assertion, not a probe
                 if p_auth == "dedicated_local":
                     raise dm.DriveMutationRefused("DRIVE_AUTHORITY_DOWNGRADE_REFUSED", drive=label)
                 return Reconciliation("unknown_no_authority", p_epoch, p_gen, None)
-            with drive_fence.hold_drives_sorted([(live_fp, p_epoch)], blocking=blocking):
-                obs = _live_observation(con, label)      # re-prove identity under the drive fence
-                if not obs.identity_proven or obs.fingerprint != live_fp:
-                    raise dm.DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
+            # A capacity change on the same stable identity transitions the epoch and changes the
+            # fingerprint, so hold BOTH the old and the prospective new (fingerprint, epoch) drive fences.
+            transition = p_fp is not None and ev.capacity != p_cap
+            keyed = ([(p_fp, p_epoch), (ev.fingerprint, p_epoch + 1)] if transition
+                     else [(ev.fingerprint, p_epoch)])
+            with drive_fence.hold_drives_sorted(keyed, blocking=blocking):
                 dest = register.archive_path(con, label)
-                return _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, obs, now,
-                                          accept_drift)
+                return _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, ev, now,
+                                          accept_drift, transition)
     except drive_fence.FenceUnavailable as exc:
         raise dm.DriveMutationRefused("DRIVE_FENCE_UNAVAILABLE", **exc.evidence) from exc
 
 
-def _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, obs, now, accept_drift):
-    live_cap, live_free = obs.filesystem_capacity, obs.free_bytes
+def _final_observation(con, label: str, ev: _LiveEvidence) -> _LiveEvidence:
+    """A FRESH observation under the held drive fences after inventory. Refuse (no anchor) if the drive
+    vanished or its stable identity/capacity changed during inventory — the anchor must reflect the
+    final observed state, never the pre-inventory one."""
+    final = _live_evidence(con, label)
+    if not final.proven or final.fingerprint != ev.fingerprint or final.capacity != ev.capacity:
+        raise dm.DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
+    return final
 
-    if p_fp is None:                                     # (A) bootstrap: establish the identity + first anchor
+
+def _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, ev, now, accept_drift, transition):
+    if p_fp is None:                                     # (A) bootstrap: establish identity + first anchor
         _require_complete_inventory(con, label, dest)
+        final = _final_observation(con, label, ev)
+        obs = final.observation()
 
         def _body():
             con.execute("UPDATE drives SET identity_epoch=?, filesystem_capacity_bytes=?, "
                         "identity_fingerprint=?, write_authority='dedicated_local' WHERE drive_label=?",
-                        [p_epoch, live_cap, obs.fingerprint, label])
+                        [p_epoch, final.capacity, final.fingerprint, label])
             gen = dm._advance_one(con, label, "bootstrap")           # generation 0 -> 1
             dm._publish_anchor_locked(con, label, p_epoch, gen, obs, now)
             return gen
-        return Reconciliation("bootstrapped", p_epoch, dm._immediate(con, _body), live_free)
+        return Reconciliation("bootstrapped", p_epoch, dm._immediate(con, _body), final.free)
 
-    if live_cap != p_cap:                                # (D) capacity-epoch transition: reset the namespace
+    if transition:                                       # (D) capacity-epoch transition: reset the namespace
         _require_complete_inventory(con, label, dest)
+        final = _final_observation(con, label, ev)
+        obs = final.observation()
         new_epoch = p_epoch + 1
 
         def _body():
             con.execute("UPDATE drives SET identity_epoch=?, filesystem_capacity_bytes=?, "
-                        "write_generation=0 WHERE drive_label=?", [new_epoch, live_cap, label])
+                        "identity_fingerprint=?, write_generation=0 WHERE drive_label=?",
+                        [new_epoch, final.capacity, final.fingerprint, label])   # persist the NEW fingerprint
             gen = dm._advance_one(con, label, "epoch")               # 0 -> 1 under the new epoch
             dm._publish_anchor_locked(con, label, new_epoch, gen, obs, now)
             return gen
-        return Reconciliation("epoch_advanced", new_epoch, dm._immediate(con, _body), live_free)
+        return Reconciliation("epoch_advanced", new_epoch, dm._immediate(con, _body), final.free)
 
-    if not dm._generation_is_clean(con, label, p_epoch, p_gen, p_fp, live_cap, "dedicated_local"):
+    if not dm._generation_is_clean(con, label, p_epoch, p_gen, p_fp, p_cap, "dedicated_local"):
         # (B) sessionless dirty recovery — republish THIS generation's anchor (session-attributed = #39)
         owner = con.execute("SELECT owner_session_id FROM drive_dirty_generations "
                             "WHERE drive_label=? AND identity_epoch=? AND generation=?",
@@ -237,16 +281,20 @@ def _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, obs, now, 
         if owner is not None and owner[0] is not None:
             raise dm.DriveMutationRefused("DRIVE_RECOVERY_SESSION_ACTIVE", drive=label)
         _require_complete_inventory(con, label, dest)
-        dm.publish_clean_anchor(con, label, p_epoch, p_gen, obs, now)
-        return Reconciliation("recovered", p_epoch, p_gen, live_free)
+        final = _final_observation(con, label, ev)
+        dm.publish_clean_anchor(con, label, p_epoch, p_gen, final.observation(), now)
+        return Reconciliation("recovered", p_epoch, p_gen, final.free)
 
-    # (C) refresh of a currently-clean anchored drive — drift-gated
+    # (C) refresh of a currently-clean anchored drive — drift-gated on the first observation (refuse
+    # before the full inventory), then anchored from the fresh final observation
     last_free = con.execute("SELECT anchor_free_bytes FROM drive_clean_anchors WHERE drive_label=? "
                            "AND identity_epoch=? AND generation=?", [label, p_epoch, p_gen]).fetchone()[0]
-    drifted = abs(live_free - last_free) > free_drift_tolerance_v1(_alloc_unit(dest))
+    drifted = abs(ev.free - last_free) > free_drift_tolerance_v1(ev.alloc_unit)
     if drifted and not accept_drift:
-        raise dm.DriveMutationRefused("DRIVE_FREE_DRIFT", drive=label, anchored=last_free, observed=live_free)
+        raise dm.DriveMutationRefused("DRIVE_FREE_DRIFT", drive=label, anchored=last_free, observed=ev.free)
     _require_complete_inventory(con, label, dest)
+    final = _final_observation(con, label, ev)
+    obs = final.observation()
     op = "accept-drift" if drifted else "reconcile"
 
     def _body():
@@ -254,4 +302,4 @@ def _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, obs, now, 
         dm._publish_anchor_locked(con, label, p_epoch, gen, obs, now)
         return gen
     return Reconciliation("drift_accepted" if drifted else "refreshed", p_epoch,
-                          dm._immediate(con, _body), live_free)
+                          dm._immediate(con, _body), final.free)

--- a/tests/test_drive_bootstrap.py
+++ b/tests/test_drive_bootstrap.py
@@ -623,6 +623,23 @@ def test_single_drive_reconcile_command_covers_bootstrap_and_recovery(tmp_path):
     handler.assert_called_once()
 
 
+def test_cli_reconcile_translates_refusal_to_a_clean_exit(tmp_path):
+    """A typed reconciliation refusal (an offline/failed drive — the expected Drive-02 outcome, not a
+    programming failure) must surface as a clean SystemExit message, never a raw DriveMutationRefused
+    traceback — matching the CLI's restore/hash-repair error convention."""
+    from modelark import cli, drive_bootstrap
+    refusal = dm.DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive="drive-02")
+    with mock.patch.object(db, "connect", return_value=mock.Mock()), \
+         mock.patch.object(drive_bootstrap, "reconcile_drive", side_effect=refusal):
+        try:
+            cli.main(["drive", "reconcile", "drive-02", "--dedicated"])
+            raise AssertionError("a typed refusal must exit, not return silently")
+        except dm.DriveMutationRefused:
+            raise AssertionError("DriveMutationRefused leaked as a raw traceback instead of SystemExit")
+        except SystemExit as exc:
+            assert "drive reconcile failed" in str(exc.code), exc.code
+
+
 def test_migrated_drive_is_unknown_and_anchorless_until_reconcile(tmp_path):
     """GREEN floor (must stay true): registration/migration records a valid drive identity but NO write
     authority and NO clean anchor — only `drive reconcile` establishes them. This is the inert state the

--- a/tests/test_drive_bootstrap.py
+++ b/tests/test_drive_bootstrap.py
@@ -20,7 +20,7 @@ Binding reviewer corrections encoded here:
       crash before that commit leaves the drive unknown + anchorless. Bootstrap never calls the ordinary
       drive_mutation() envelope to dodge its NULL-fingerprint identity refusal.
   C4  same identity + unchanged capacity → refresh, same epoch; same identity + CHANGED capacity → an
-      explicit capacity-epoch transition (new epoch + fresh generation/anchor); a DIFFERENT identity
+      explicit capacity-epoch transition (new epoch, generation 1 + fresh anchor); a DIFFERENT identity
       under an existing label → refuse BEFORE any mutation (label reuse/retirement stays DEF-029).
       DRIFT RULE (#35): refreshing a currently-clean anchored drive advances to a fresh generation and
       re-anchors the RAW observed free ONLY when the free delta is within the versioned diagnostic
@@ -42,7 +42,7 @@ deferred to #39; label reuse / retirement / dependency-aware replacement to DEF-
 Proposed production API surfaced by these tests (for Gate-1 review; names are the contract to confirm):
   * new NEUTRAL module modelark/drive_bootstrap.py (no register→fetch / register→drive_bootstrap cycle):
       - reconcile_drive(con, label, *, now, dedicated=False, accept_drift=False, blocking=True) -> Reconciliation
-        (report attrs: .outcome in {bootstrapped, refreshed, epoch_advanced, recovered,
+        (report attrs: .outcome in {bootstrapped, refreshed, drift_accepted, epoch_advanced, recovered,
          unknown_no_authority}, .identity_epoch, .generation, .anchor_free_bytes | None, .inventory);
         raises dm.DriveMutationRefused with DRIVE_IDENTITY_UNPROVEN / DRIVE_IDENTITY_MISMATCH /
         DRIVE_AUTHORITY_DOWNGRADE_REFUSED / DRIVE_FREE_DRIFT / DRIVE_RECOVERY_SESSION_ACTIVE /
@@ -429,7 +429,7 @@ def test_refresh_above_drift_tolerance_reanchors_with_accept_drift(tmp_path):
         anchor = con.execute("SELECT anchor_free_bytes FROM drive_clean_anchors WHERE drive_label='drive-00' "
                             "AND identity_epoch=1 AND generation=2").fetchone()
         assert anchor == (drifted_free,), f"the accepted anchor must store the observed free: {anchor}"
-        assert report.identity_epoch == 1, report
+        assert report.identity_epoch == 1 and report.outcome == "drift_accepted", report
 
 
 def test_same_identity_changed_capacity_advances_epoch_and_reanchors(tmp_path):
@@ -444,12 +444,12 @@ def test_same_identity_changed_capacity_advances_epoch_and_reanchors(tmp_path):
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
             report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
-        row = con.execute("SELECT identity_epoch,filesystem_capacity_bytes FROM drives "
+        row = con.execute("SELECT identity_epoch,write_generation,filesystem_capacity_bytes FROM drives "
                           "WHERE drive_label='drive-00'").fetchone()
-        assert row == (2, 2000), row
-        new = con.execute("SELECT anchor_free_bytes,filesystem_capacity_bytes FROM drive_clean_anchors "
-                          "WHERE drive_label='drive-00' AND identity_epoch=2").fetchone()
-        assert new == (1900, 2000), new
+        assert row == (2, 1, 2000), f"an epoch transition resets the namespace to (epoch 2, generation 1): {row}"
+        new = con.execute("SELECT generation,anchor_free_bytes,filesystem_capacity_bytes FROM "
+                          "drive_clean_anchors WHERE drive_label='drive-00' AND identity_epoch=2").fetchone()
+        assert new == (1, 1900, 2000), f"epoch 2's first anchor must be generation 1: {new}"
         assert report.outcome == "epoch_advanced" and report.identity_epoch == 2, report
 
 

--- a/tests/test_drive_bootstrap.py
+++ b/tests/test_drive_bootstrap.py
@@ -11,6 +11,9 @@ Binding reviewer corrections encoded here:
       statvfs AVAILABLE bytes (metadata/reserve/clone/annex overhead ⇒ free < capacity), never capacity.
   C2  write_authority=dedicated_local is an explicit operator/policy assertion of exclusivity, NOT
       derivable from identity probes; without it (shared/NAS/unfenceable) the drive stays `unknown`.
+      A dedicated=False reconcile persists NO catalog-v3 authoritative evidence (fingerprint, capacity,
+      authority all stay unset; no epoch/generation/anchor), and must NEVER downgrade an already
+      dedicated_local drive — that is a typed policy refusal; authority revocation is a separate lifecycle.
   C3  ONE atomic bootstrap: controller fence → derive live identity + lock key → drive fence + re-prove
       → bounded reconcile + final free observation with NO write txn → then a single short transaction
       persists identity evidence + bootstrap dirty generation + clean anchor + authority ATOMICALLY. A
@@ -35,7 +38,8 @@ Proposed production API surfaced by these tests (for Gate-1 review; names are th
         (report attrs: .outcome in {bootstrapped, refreshed, epoch_advanced, recovered,
          unknown_no_authority}, .identity_epoch, .generation, .anchor_free_bytes | None, .inventory);
         raises dm.DriveMutationRefused with DRIVE_IDENTITY_UNPROVEN / DRIVE_IDENTITY_MISMATCH /
-        DRIVE_RECOVERY_SESSION_ACTIVE / DRIVE_RECONCILIATION_REQUIRED / CLEAN_ANCHOR_CAS_FAILED.
+        DRIVE_AUTHORITY_DOWNGRADE_REFUSED / DRIVE_RECOVERY_SESSION_ACTIVE /
+        DRIVE_RECONCILIATION_REQUIRED / CLEAN_ANCHOR_CAS_FAILED.
       - _live_observation(con, label) -> dm.Observation  (fenced live identity/free evidence seam)
       - _inventory(con, label, dest) -> report with .present/.missing/.debris/.extra and .complete
       - _annex_key_present(dest, key, *, target_uuid) -> bool  (annex presence proof seam)
@@ -47,6 +51,7 @@ Disposable temp trees / synthetic drives / mocked physical seams only — never 
 from __future__ import annotations
 
 import importlib
+import shutil
 from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
@@ -178,9 +183,11 @@ def test_bootstrap_local_dedicated_establishes_identity_authority_and_anchor(tmp
 
 
 def test_bootstrap_without_dedicated_assertion_stays_unknown(tmp_path):
-    """C2: dedicated_local is an explicit exclusivity assertion — identity probes never prove it. Without
-    the assertion (shared/NAS/unfenceable) the drive stays a VALID `unknown` identity with NO anchor;
-    nothing silently upgrades it."""
+    """C2 + Issue-3 ruling: dedicated_local is an explicit exclusivity assertion — identity probes never
+    prove it. A dedicated=False reconcile persists NO catalog-v3 authoritative evidence: identity
+    fingerprint and filesystem capacity stay NULL, authority stays `unknown`, and no epoch/generation/
+    anchor is created. Live observations may be surfaced diagnostically in the report but are never
+    persisted as authority; the drive remains a valid `unknown` identity."""
     with _catalog(tmp_path) as con:
         _drive_row(con, "drive-00", capacity=1000)
         bs = _bootstrap()
@@ -188,10 +195,36 @@ def test_bootstrap_without_dedicated_assertion_stays_unknown(tmp_path):
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
             report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=False)
-        authority = con.execute("SELECT write_authority FROM drives WHERE drive_label='drive-00'").fetchone()[0]
-        assert authority == "unknown", "no probe set may upgrade authority to dedicated_local"
+        row = con.execute("SELECT identity_fingerprint,filesystem_capacity_bytes,write_authority,"
+                          "identity_epoch,write_generation FROM drives WHERE drive_label='drive-00'").fetchone()
+        assert row == (None, None, "unknown", 1, 0), \
+            f"dedicated=False must persist no authoritative evidence (fingerprint/capacity/authority): {row}"
+        assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
         assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
         assert report.anchor_free_bytes is None, report
+
+
+def test_dedicated_false_refuses_to_downgrade_an_authoritative_drive(tmp_path):
+    """Issue-3 boundary: a dedicated=False reconcile against an ALREADY dedicated_local drive must refuse
+    with a typed policy/lifecycle result and leave every piece of evidence unchanged. Authority
+    revocation is a separate lifecycle operation, never a side effect of a non-dedicated reconcile."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=880)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            try:
+                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=False)
+                raise AssertionError("dedicated=False must not downgrade an authoritative drive")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_AUTHORITY_DOWNGRADE_REFUSED", exc.code
+        row = con.execute("SELECT identity_epoch,write_generation,identity_fingerprint,write_authority "
+                          "FROM drives WHERE drive_label='drive-00'").fetchone()
+        assert row == (1, 1, _FP, "dedicated_local"), f"authoritative evidence must be untouched: {row}"
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 1
 
 
 # =========================================================================== atomic bootstrap (C3 / R4)
@@ -312,7 +345,7 @@ def test_same_identity_same_capacity_refreshes_without_new_epoch(tmp_path):
         assert con.execute("SELECT identity_epoch FROM drives WHERE drive_label='drive-00'").fetchone()[0] == 1
         assert con.execute("SELECT count(DISTINCT identity_epoch) FROM drive_clean_anchors "
                            "WHERE drive_label='drive-00'").fetchone()[0] == 1, "no new epoch namespace"
-        assert report.identity_epoch == 1, report
+        assert report.identity_epoch == 1 and report.outcome == "refreshed", report
 
 
 def test_same_identity_changed_capacity_advances_epoch_and_reanchors(tmp_path):
@@ -378,6 +411,9 @@ def test_reconcile_recovers_sessionless_dirty_generation(tmp_path):
         anchor = con.execute("SELECT generation,anchor_free_bytes FROM drive_clean_anchors "
                             "WHERE drive_label='drive-00'").fetchone()
         assert anchor == (1, 870), anchor
+        assert con.execute("SELECT identity_fingerprint,write_authority FROM drives "
+                          "WHERE drive_label='drive-00'").fetchone() == (_FP, "dedicated_local"), \
+            "recovery must not downgrade identity/authority during the anchor CAS"
         assert report.outcome == "recovered", report
 
 
@@ -429,6 +465,13 @@ def test_single_drive_reconcile_command_covers_bootstrap_and_recovery(tmp_path):
         "PR-03c1 must add a single `drive reconcile <label>` command (cli.cmd_drive_reconcile)"
     assert not hasattr(cli, "cmd_drive_bootstrap") and not hasattr(cli, "cmd_drive_recover"), \
         "bootstrap and recovery are one `drive reconcile` operation, not a command family"
+    # wiring is checked at the PARSER level; the real op is never executed (the handler is mocked)
+    with mock.patch.object(cli, "cmd_drive_reconcile") as handler:
+        try:
+            cli.main(["drive", "reconcile", "drive-00"])      # argparse binds func to the mocked handler
+        except SystemExit as exc:                             # 'invalid choice: reconcile' => not wired
+            raise AssertionError(f"`drive reconcile <label>` is not wired into argparse (SystemExit {exc.code})")
+    handler.assert_called_once()
 
 
 # ================================================================================= GREEN characterization
@@ -450,15 +493,20 @@ if __name__ == "__main__":
     import tempfile
 
     saved = (db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR)
-    failures = 0
+    passed, failed = [], []
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):
+            tmp = Path(tempfile.mkdtemp(prefix="mark-03c1-"))
             try:
-                fn(Path(tempfile.mkdtemp()))
-                print(f"ok   {name}")
-            except Exception as exc:                     # noqa: BLE001 — script runner reports, never aborts
-                failures += 1
-                print(f"FAIL {name}: {exc}")
+                fn(tmp)
+                passed.append(name)
+                print(f"PASS  {name}")
+            except Exception as exc:                     # noqa: BLE001 — Gate-1 wants the full red/green map
+                failed.append(name)
+                print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
             finally:
                 db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = saved
-    print("all passed" if not failures else f"{failures} failing (expected RED at Gate 1)")
+                shutil.rmtree(tmp, ignore_errors=True)   # the standalone runner cleans its own temp trees
+    print(f"\n{len(passed)} passed, {len(failed)} failed")
+    if failed:
+        raise SystemExit(1)                              # a failing test MUST fail CI (set -e; python "$t")

--- a/tests/test_drive_bootstrap.py
+++ b/tests/test_drive_bootstrap.py
@@ -1,0 +1,464 @@
+"""PR-03c1 Gate-1 contract — drive identity BOOTSTRAP + first clean anchor + sessionless dirty RECOVERY
+(RFC-002 / DEC-049 issue #35-B residual; the smallest usable predecessor to the #35-C authority cutover).
+
+Tests-first, pinned BEFORE production. The change-contract tests are RED against the current tree (the
+neutral module + the `drive reconcile` command do not exist yet); one characterization test is GREEN now
+and must stay GREEN. The envelope that PR-03a/03b built is inert until a real drive is marked proven —
+this slice is what establishes that identity, so #35-C has an authority to cut over to.
+
+Binding reviewer corrections encoded here:
+  C1  a "trivial" first anchor skips full inventory but still stores the fenced post-preparation
+      statvfs AVAILABLE bytes (metadata/reserve/clone/annex overhead ⇒ free < capacity), never capacity.
+  C2  write_authority=dedicated_local is an explicit operator/policy assertion of exclusivity, NOT
+      derivable from identity probes; without it (shared/NAS/unfenceable) the drive stays `unknown`.
+  C3  ONE atomic bootstrap: controller fence → derive live identity + lock key → drive fence + re-prove
+      → bounded reconcile + final free observation with NO write txn → then a single short transaction
+      persists identity evidence + bootstrap dirty generation + clean anchor + authority ATOMICALLY. A
+      crash before that commit leaves the drive unknown + anchorless. Bootstrap never calls the ordinary
+      drive_mutation() envelope to dodge its NULL-fingerprint identity refusal.
+  C4  same identity + unchanged capacity → refresh, same epoch; same identity + CHANGED capacity → an
+      explicit capacity-epoch transition (new epoch + fresh generation/anchor); a DIFFERENT identity
+      under an existing label → refuse BEFORE any mutation (label reuse/retirement stays DEF-029).
+  C5  full reconciliation is bounded and report-only: catalogued raw+annex proven present; known
+      staging/.incomplete debris recognized; missing/unprovable claims never counted present (fail
+      closed, no anchor); unexplained extra reported and LEFT IN PLACE (the final free observation
+      accounts for its bytes). Completion is per-drive: offline/failed/shared drives stay valid
+      `unknown` identities — never required or fabricated into cleanliness (the Drive-02 case). ONE
+      operator op, `drive reconcile <label>`, covers migrated-drive bootstrap AND sessionless recovery.
+
+Session-attributed recovery (owner session/token, worker/child exclusion, fencing-token recovery) is
+deferred to #39; label reuse / retirement / dependency-aware replacement to DEF-029.
+
+Proposed production API surfaced by these tests (for Gate-1 review; names are the contract to confirm):
+  * new NEUTRAL module modelark/drive_bootstrap.py (no register→fetch / register→drive_bootstrap cycle):
+      - reconcile_drive(con, label, *, now, dedicated=False, blocking=True) -> Reconciliation
+        (report attrs: .outcome in {bootstrapped, refreshed, epoch_advanced, recovered,
+         unknown_no_authority}, .identity_epoch, .generation, .anchor_free_bytes | None, .inventory);
+        raises dm.DriveMutationRefused with DRIVE_IDENTITY_UNPROVEN / DRIVE_IDENTITY_MISMATCH /
+        DRIVE_RECOVERY_SESSION_ACTIVE / DRIVE_RECONCILIATION_REQUIRED / CLEAN_ANCHOR_CAS_FAILED.
+      - _live_observation(con, label) -> dm.Observation  (fenced live identity/free evidence seam)
+      - _inventory(con, label, dest) -> report with .present/.missing/.debris/.extra and .complete
+      - _annex_key_present(dest, key, *, target_uuid) -> bool  (annex presence proof seam)
+      - reuses drive_mutation._publish_anchor_locked for the anchor write inside its atomic bootstrap txn
+  * new CLI: a single `drive reconcile <label>` command -> cli.cmd_drive_reconcile (no command family)
+
+Disposable temp trees / synthetic drives / mocked physical seams only — never a live catalog/drive.
+"""
+from __future__ import annotations
+
+import importlib
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+from modelark.core import db
+from modelark import drive_mutation as dm
+from modelark import register
+
+_FP = "a" * 64
+_FP2 = "c" * 64
+
+
+try:
+    import pytest
+
+    @pytest.fixture(autouse=True)
+    def _isolate_db_globals():
+        saved = (db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR)
+        try:
+            yield
+        finally:
+            db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = saved
+except ImportError:                              # the plain script runner does not need pytest
+    pass
+
+
+@contextmanager
+def _catalog(tmp_path):
+    saved = (db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR)
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    db.STATE_DIR = tmp_path / "state"
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture must be a v3 catalog"
+    try:
+        yield con
+    finally:
+        con.close()
+        db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = saved
+
+
+def _bootstrap():
+    """Import the PR-03c1 neutral module, or fail RED with the reviewed reason (it does not exist yet)."""
+    try:
+        return importlib.import_module("modelark.drive_bootstrap")
+    except ModuleNotFoundError as exc:
+        raise AssertionError(
+            "PR-03c1 must add the neutral module modelark/drive_bootstrap.py exposing a single "
+            f"reconcile_drive(con, label, *, now, dedicated=...) bootstrap/recovery operation: {exc}")
+
+
+def _drive_row(con, label="drive-00", *, fs_uuid="fsid", annex_uuid="anx", serial="SER",
+               capacity=1000, free=940):
+    """A registered/migrated drive: topology + nominal capacity only, no proven identity/authority — the
+    valid `unknown` state a drive sits in until `drive reconcile` bootstraps it."""
+    con.execute("INSERT INTO drives(drive_label,fs_uuid,annex_uuid,serial,capacity_bytes,free_bytes) "
+                "VALUES(?,?,?,?,?,?)", [label, fs_uuid, annex_uuid, serial, capacity, free])
+
+
+def _proven_drive(con, label="drive-00", *, epoch=1, generation=0, fp=_FP, fscap=1000, free=900,
+                  annex_uuid="anx"):
+    con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes,identity_epoch,write_generation,"
+                "filesystem_capacity_bytes,identity_fingerprint,write_authority,annex_uuid) "
+                "VALUES(?,?,?,?,?,?,?, 'dedicated_local', ?)",
+                [label, fscap, free, epoch, generation, fscap, fp, annex_uuid])
+
+
+def _dirty_gen(con, label="drive-00", *, epoch=1, gen=1, op="reconcile", owner=None, token=None):
+    con.execute("INSERT INTO drive_dirty_generations(drive_label,identity_epoch,generation,operation_code,"
+                "owner_session_id,owner_fencing_token) VALUES(?,?,?,?,?,?)",
+                [label, epoch, gen, op, owner, token])
+
+
+def _anchor(con, label="drive-00", *, epoch=1, gen=1, free=900, fscap=1000, fp=_FP,
+            now="2026-01-01 00:00:00"):
+    con.execute("INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,anchor_free_bytes,"
+                "filesystem_capacity_bytes,identity_fingerprint,write_authority,identity_proof,fence_proof,"
+                "observed_at) VALUES(?,?,?,?,?,?, 'dedicated_local','proof','fence', ?)",
+                [label, epoch, gen, free, fscap, fp, now])
+
+
+def _catalogued(con, repo, rfile, *, size=5):
+    con.execute("INSERT OR IGNORE INTO models(repo_id) VALUES(?)", [repo])
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) VALUES(?,?,?, 'safetensors')",
+                [repo, rfile, size])
+
+
+def _archived(con, repo, rfile, relpath, label, *, annex_key=None, compressed=0):
+    con.execute("INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
+                "orig_bytes,stored_bytes,compressed,annex_key) VALUES(?,?,?,?,?,?,?,?,?)",
+                [repo, rfile, relpath, relpath, label, 5, 5, compressed, annex_key])
+
+
+def _obs(*, fp=_FP, capacity=1000, free=940, proven=True):
+    return dm.Observation(identity_proven=proven, free_bytes=free, filesystem_capacity=capacity,
+                          fingerprint=fp, identity_proof="live-proof", fence_proof="fence-proof")
+
+
+def _clean_inv(**kw):
+    """A mocked full-inventory report with nothing missing (an anchor may publish)."""
+    fields = dict(present=[], missing=[], debris=[], extra=[], complete=True)
+    fields.update(kw)
+    return mock.Mock(**fields)
+
+
+# =========================================================== identity establishment + write authority (C1,C2)
+
+def test_bootstrap_local_dedicated_establishes_identity_authority_and_anchor(tmp_path):
+    """R1+C1+C2+C3: a local drive bootstrapped WITH the dedicated_local assertion persists proven
+    identity, dedicated_local authority, and a first clean anchor whose free is the OBSERVED
+    post-preparation statvfs available (strictly < capacity), in one atomic step."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-00", capacity=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=940)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+        row = con.execute("SELECT identity_epoch,write_generation,filesystem_capacity_bytes,"
+                          "identity_fingerprint,write_authority FROM drives WHERE drive_label='drive-00'"
+                          ).fetchone()
+        assert row == (1, 1, 1000, _FP, "dedicated_local"), row
+        anchor = con.execute("SELECT identity_epoch,generation,anchor_free_bytes,filesystem_capacity_bytes,"
+                             "write_authority FROM drive_clean_anchors WHERE drive_label='drive-00'"
+                             ).fetchone()
+        assert anchor == (1, 1, 940, 1000, "dedicated_local"), anchor
+        assert anchor[2] < anchor[3], "the anchor free must be the observed available, never capacity"
+        assert report.outcome == "bootstrapped" and report.anchor_free_bytes == 940, report
+
+
+def test_bootstrap_without_dedicated_assertion_stays_unknown(tmp_path):
+    """C2: dedicated_local is an explicit exclusivity assertion — identity probes never prove it. Without
+    the assertion (shared/NAS/unfenceable) the drive stays a VALID `unknown` identity with NO anchor;
+    nothing silently upgrades it."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-00", capacity=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=940)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=False)
+        authority = con.execute("SELECT write_authority FROM drives WHERE drive_label='drive-00'").fetchone()[0]
+        assert authority == "unknown", "no probe set may upgrade authority to dedicated_local"
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+        assert report.anchor_free_bytes is None, report
+
+
+# =========================================================================== atomic bootstrap (C3 / R4)
+
+def test_bootstrap_final_transaction_is_atomic(tmp_path):
+    """C3/R4: identity evidence, the bootstrap dirty generation, the clean anchor, and dedicated_local
+    authority are persisted in ONE transaction — a crash at anchor publication rolls ALL of them back,
+    leaving the drive unknown and anchorless (never a half-established identity)."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-00", capacity=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=940)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"), \
+             mock.patch.object(dm, "_publish_anchor_locked", side_effect=RuntimeError("crash at publish")):
+            try:
+                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+            except Exception:
+                pass                                     # the crash is expected; the invariant is the rollback
+        row = con.execute("SELECT identity_epoch,write_generation,identity_fingerprint,write_authority "
+                          "FROM drives WHERE drive_label='drive-00'").fetchone()
+        assert row == (1, 0, None, "unknown"), f"a crash before commit must leave the drive untouched: {row}"
+        assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+
+
+def test_bootstrap_does_not_route_through_the_ordinary_envelope(tmp_path):
+    """C3: bootstrap must NOT call drive_mutation.drive_mutation() to work around its NULL-fingerprint
+    identity refusal — it is its own fenced, atomic operation."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-00", capacity=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=940)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"), \
+             mock.patch.object(dm, "drive_mutation") as envelope:
+            bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+        envelope.assert_not_called()
+
+
+# ======================================================= bounded full-inventory reconciliation (C5)
+
+def test_inventory_proves_raw_and_annex_content_present(tmp_path):
+    """C5: a populated drive reconciles when every catalogued claim is proven present — a raw file on the
+    worktree and an annex object proven by key (no worktree symlink required)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", annex_uuid="anx")
+        _catalogued(con, "repo", "raw.bin")
+        _catalogued(con, "repo", "blob.gguf")
+        _archived(con, "repo", "raw.bin", "raw.bin", "drive-00", compressed=0)
+        _archived(con, "repo", "blob.gguf", "blob.gguf", "drive-00", annex_key="KEY-1")
+        dest = tmp_path / "mount"
+        (dest / "repo").mkdir(parents=True)
+        (dest / "repo" / "raw.bin").write_bytes(b"bytes")            # raw present; annex proven by key
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_annex_key_present", return_value=True):
+            inv = bs._inventory(con, "drive-00", dest)
+        assert set(inv.present) >= {("repo", "raw.bin"), ("repo", "blob.gguf")}, inv.present
+        assert not inv.missing and inv.complete, inv.missing
+
+
+def test_inventory_fails_closed_on_missing_or_unprovable_claim(tmp_path):
+    """C5: a catalogued raw file that is absent, or an annex claim whose key cannot be proven, is NEVER
+    counted present — it lands in `missing` and blocks completion (so no anchor publishes)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+        _catalogued(con, "repo", "gone.bin")
+        _catalogued(con, "repo", "blob.gguf")
+        _archived(con, "repo", "gone.bin", "gone.bin", "drive-00", compressed=0)         # raw, file ABSENT
+        _archived(con, "repo", "blob.gguf", "blob.gguf", "drive-00", annex_key="KEY-1")  # annex, unprovable
+        dest = tmp_path / "mount"
+        (dest / "repo").mkdir(parents=True)                                              # no files written
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_annex_key_present", return_value=False):
+            inv = bs._inventory(con, "drive-00", dest)
+        assert ("repo", "gone.bin") in inv.missing and ("repo", "blob.gguf") in inv.missing, inv.missing
+        assert not inv.complete, "an unprovable/absent archived claim must never count as present"
+
+
+def test_inventory_reports_extra_and_debris_without_deleting(tmp_path):
+    """C5: known staging/.incomplete debris is recognized (not counted archived) and unexplained extra
+    content is REPORTED but LEFT IN PLACE — reconciliation never auto-deletes; the final free observation
+    accounts for those bytes."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00")
+        _catalogued(con, "repo", "raw.bin")
+        _archived(con, "repo", "raw.bin", "raw.bin", "drive-00", compressed=0)
+        dest = tmp_path / "mount"
+        (dest / "repo").mkdir(parents=True)
+        (dest / "repo" / "raw.bin").write_bytes(b"bytes")                 # the one catalogued file
+        debris = dest / "repo" / "raw.bin.incomplete"
+        debris.write_bytes(b"partial")                                    # known debris
+        extra = dest / "repo" / "mystery.bin"
+        extra.write_bytes(b"unexplained")                                 # unexplained extra
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_annex_key_present", return_value=True):
+            inv = bs._inventory(con, "drive-00", dest)
+        assert ("repo", "raw.bin") in inv.present and inv.complete, inv
+        assert any("incomplete" in str(d) for d in inv.debris), inv.debris
+        assert any("mystery.bin" in str(x) for x in inv.extra), inv.extra
+        assert debris.exists() and extra.exists(), "reconciliation must NOT delete debris or extra content"
+
+
+# ================================================================= capacity-epoch handling (C4)
+
+def test_same_identity_same_capacity_refreshes_without_new_epoch(tmp_path):
+    """C4: re-reconciling the same identity at unchanged capacity refreshes evidence WITHOUT advancing
+    the capacity epoch."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=880)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+        assert con.execute("SELECT identity_epoch FROM drives WHERE drive_label='drive-00'").fetchone()[0] == 1
+        assert con.execute("SELECT count(DISTINCT identity_epoch) FROM drive_clean_anchors "
+                           "WHERE drive_label='drive-00'").fetchone()[0] == 1, "no new epoch namespace"
+        assert report.identity_epoch == 1, report
+
+
+def test_same_identity_changed_capacity_advances_epoch_and_reanchors(tmp_path):
+    """C4: same identity + a DIFFERENT filesystem capacity is an explicit capacity-epoch transition — a
+    new epoch with a fresh generation and anchor (not a silent same-epoch refresh, and not DEF-029)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=2000, free=1900)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+        row = con.execute("SELECT identity_epoch,filesystem_capacity_bytes FROM drives "
+                          "WHERE drive_label='drive-00'").fetchone()
+        assert row == (2, 2000), row
+        new = con.execute("SELECT anchor_free_bytes,filesystem_capacity_bytes FROM drive_clean_anchors "
+                          "WHERE drive_label='drive-00' AND identity_epoch=2").fetchone()
+        assert new == (1900, 2000), new
+        assert report.outcome == "epoch_advanced" and report.identity_epoch == 2, report
+
+
+def test_different_identity_under_existing_label_refuses_before_mutation(tmp_path):
+    """C4: a different underlying identity under an existing label must REFUSE before any format/clone/
+    remote/catalog mutation — durable byte claims are never silently rebound to new media (label reuse
+    and retirement stay DEF-029)."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP2, capacity=1000)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            try:
+                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+                raise AssertionError("a different identity under an existing label must refuse")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_IDENTITY_MISMATCH", exc.code
+        row = con.execute("SELECT identity_epoch,write_generation,identity_fingerprint FROM drives "
+                          "WHERE drive_label='drive-00'").fetchone()
+        assert row == (1, 1, _FP), f"the original identity must be untouched by a refused mismatch: {row}"
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 1
+
+
+# ===================================================== sessionless dirty recovery, same command (R3 / C5)
+
+def test_reconcile_recovers_sessionless_dirty_generation(tmp_path):
+    """R3: a dirty generation with no anchor and NO owner session (sessionless) is recovered by
+    `drive reconcile` — it reconciles and republishes THAT generation's anchor via the (epoch,generation)
+    CAS, without opening a new generation."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1, owner=None)          # dirty, sessionless, no anchor
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=870)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+        assert con.execute("SELECT write_generation FROM drives WHERE drive_label='drive-00'").fetchone()[0] == 1, \
+            "recovery republishes the existing generation; it does not open a new one"
+        anchor = con.execute("SELECT generation,anchor_free_bytes FROM drive_clean_anchors "
+                            "WHERE drive_label='drive-00'").fetchone()
+        assert anchor == (1, 870), anchor
+        assert report.outcome == "recovered", report
+
+
+def test_reconcile_refuses_a_live_session_dirty_generation(tmp_path):
+    """R3 boundary: a dirty generation attributed to a live session (owner fields set) is NOT recovered
+    here — sessionless recovery refuses and defers session-attributed recovery to #39."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1, owner="sess-1", token=1)     # live / attributed
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            try:
+                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+                raise AssertionError("a session-attributed dirty generation must not be recovered here (#39)")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_RECOVERY_SESSION_ACTIVE", exc.code
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+
+
+# ================================================================ completion semantics + single command (C5)
+
+def test_offline_drive_stays_valid_unknown_and_is_not_fabricated_clean(tmp_path):
+    """C5 completion: a drive whose live identity cannot be proven (offline/failed — the Drive-02 case)
+    stays a VALID registered identity with unknown evidence. reconcile fails closed and fabricates no
+    anchor; a drive is never required or forced into cleanliness to complete the fleet."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-02")
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_observation", return_value=_obs(proven=False)), \
+             mock.patch.object(register, "archive_path", return_value=None):
+            try:
+                bs.reconcile_drive(con, "drive-02", now="2026-07-22 12:00:00", dedicated=True)
+                raise AssertionError("an unprovable/offline drive must fail closed, not fabricate an anchor")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_IDENTITY_UNPROVEN", exc.code
+        row = con.execute("SELECT identity_fingerprint,write_authority FROM drives "
+                          "WHERE drive_label='drive-02'").fetchone()
+        assert row == (None, "unknown"), f"an offline drive stays a valid unknown identity: {row}"
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+
+
+def test_single_drive_reconcile_command_covers_bootstrap_and_recovery(tmp_path):
+    """C5: exactly ONE operator command — `drive reconcile <label>` — covers migrated-drive bootstrap and
+    sessionless dirty recovery. There is no family of bootstrap/recover commands."""
+    from modelark import cli
+    assert hasattr(cli, "cmd_drive_reconcile"), \
+        "PR-03c1 must add a single `drive reconcile <label>` command (cli.cmd_drive_reconcile)"
+    assert not hasattr(cli, "cmd_drive_bootstrap") and not hasattr(cli, "cmd_drive_recover"), \
+        "bootstrap and recovery are one `drive reconcile` operation, not a command family"
+
+
+# ================================================================================= GREEN characterization
+
+def test_migrated_drive_is_unknown_and_anchorless_until_reconcile(tmp_path):
+    """GREEN floor (must stay true): registration/migration records a valid drive identity but NO write
+    authority and NO clean anchor — only `drive reconcile` establishes them. This is the inert state the
+    already-wired Fill envelope refuses today, and exactly what PR-03c1 changes."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-00")
+        row = con.execute("SELECT identity_fingerprint,write_authority,write_generation "
+                          "FROM drives WHERE drive_label='drive-00'").fetchone()
+        assert row == (None, "unknown", 0), row
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors WHERE drive_label='drive-00'"
+                           ).fetchone()[0] == 0
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    saved = (db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR)
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn(Path(tempfile.mkdtemp()))
+                print(f"ok   {name}")
+            except Exception as exc:                     # noqa: BLE001 — script runner reports, never aborts
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+            finally:
+                db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = saved
+    print("all passed" if not failures else f"{failures} failing (expected RED at Gate 1)")

--- a/tests/test_drive_bootstrap.py
+++ b/tests/test_drive_bootstrap.py
@@ -1,61 +1,33 @@
-"""PR-03c1 Gate-1 contract — drive identity BOOTSTRAP + first clean anchor + sessionless dirty RECOVERY
+"""PR-03c1 contract — drive identity BOOTSTRAP + first clean anchor + sessionless dirty RECOVERY
 (RFC-002 / DEC-049 issue #35-B residual; the smallest usable predecessor to the #35-C authority cutover).
 
-Tests-first, pinned BEFORE production. The change-contract tests are RED against the current tree (the
-neutral module + the `drive reconcile` command do not exist yet); one characterization test is GREEN now
-and must stay GREEN. The envelope that PR-03a/03b built is inert until a real drive is marked proven —
-this slice is what establishes that identity, so #35-C has an authority to cut over to.
+The regressions here are written against REAL disk evidence, not a single fake fingerprint: the identity
+fingerprint folds ``filesystem_capacity_bytes`` in, so every decision compares the STABLE identity
+(fs/annex UUID) — never the capacity-bearing fingerprint — and a capacity change is an explicit epoch
+transition that holds both the old and prospective-new drive fences and persists the new fingerprint.
+Anchors are published from a FRESH post-inventory observation, so a drive changing during inventory
+leaves no anchor.
 
-Binding reviewer corrections encoded here:
-  C1  a "trivial" first anchor skips full inventory but still stores the fenced post-preparation
-      statvfs AVAILABLE bytes (metadata/reserve/clone/annex overhead ⇒ free < capacity), never capacity.
-  C2  write_authority=dedicated_local is an explicit operator/policy assertion of exclusivity, NOT
-      derivable from identity probes; without it (shared/NAS/unfenceable) the drive stays `unknown`.
-      A dedicated=False reconcile persists NO catalog-v3 authoritative evidence (fingerprint, capacity,
-      authority all stay unset; no epoch/generation/anchor), and must NEVER downgrade an already
-      dedicated_local drive — that is a typed policy refusal; authority revocation is a separate lifecycle.
-  C3  ONE atomic bootstrap: controller fence → derive live identity + lock key → drive fence + re-prove
-      → bounded reconcile + final free observation with NO write txn → then a single short transaction
-      persists identity evidence + bootstrap dirty generation + clean anchor + authority ATOMICALLY. A
-      crash before that commit leaves the drive unknown + anchorless. Bootstrap never calls the ordinary
-      drive_mutation() envelope to dodge its NULL-fingerprint identity refusal.
-  C4  same identity + unchanged capacity → refresh, same epoch; same identity + CHANGED capacity → an
-      explicit capacity-epoch transition (new epoch, generation 1 + fresh anchor); a DIFFERENT identity
-      under an existing label → refuse BEFORE any mutation (label reuse/retirement stays DEF-029).
-      DRIFT RULE (#35): refreshing a currently-clean anchored drive advances to a fresh generation and
-      re-anchors the RAW observed free ONLY when the free delta is within the versioned diagnostic
-      tolerance (one filesystem allocation unit + a bounded metadata allowance — diagnostic only, NEVER
-      capacity headroom). An above-tolerance delta is a typed DRIVE_FREE_DRIFT refusal (old generation/
-      anchor unchanged) unless --accept-drift is given, which re-anchors after a full reconciliation under
-      a distinct 'accept-drift' operation code. Bootstrap and dirty-generation recovery have no prior
-      clean anchor to compare and are exempt from the drift check.
-  C5  full reconciliation is bounded and report-only: catalogued raw+annex proven present; known
-      staging/.incomplete debris recognized; missing/unprovable claims never counted present (fail
-      closed, no anchor); unexplained extra reported and LEFT IN PLACE (the final free observation
-      accounts for its bytes). Completion is per-drive: offline/failed/shared drives stay valid
-      `unknown` identities — never required or fabricated into cleanliness (the Drive-02 case). ONE
-      operator op, `drive reconcile <label>`, covers migrated-drive bootstrap AND sessionless recovery.
+Encoded invariants:
+  * bootstrap establishes proven identity + dedicated_local authority + a first anchor storing the RAW
+    post-preparation observed free (< capacity);
+  * dedicated_local is an explicit assertion (never a probe result): dedicated=False persists no
+    authoritative evidence and refuses to downgrade an authoritative drive;
+  * a migrated row (fingerprint NULL) is adopted only when the live stable identity equals the persisted
+    fs/annex UUID — different media under an existing label refuses (DEF-029 reuse deferred);
+  * one atomic bootstrap transaction (a crash before it leaves the drive unknown/anchorless), never a
+    route through the ordinary drive_mutation envelope;
+  * bounded, report-only full reconciliation (present/debris/missing/extra) that never auto-deletes and
+    never counts an unproved copy present; offline drives stay valid unknown (Drive-02 not fabricated);
+  * drift-gated refresh: within the versioned diagnostic tolerance re-anchor the fresh free; above
+    tolerance -> DRIVE_FREE_DRIFT unless --accept-drift re-anchors under a distinct op code;
+  * capacity change -> epoch transition to (new_epoch, generation 1) persisting the new fingerprint;
+  * sessionless dirty recovery republishes the existing generation's anchor (session-attributed = #39);
+  * the anchor uses the FINAL observation; a changed/unproven final observation publishes no anchor.
 
-Session-attributed recovery (owner session/token, worker/child exclusion, fencing-token recovery) is
-deferred to #39; label reuse / retirement / dependency-aware replacement to DEF-029.
-
-Proposed production API surfaced by these tests (for Gate-1 review; names are the contract to confirm):
-  * new NEUTRAL module modelark/drive_bootstrap.py (no register→fetch / register→drive_bootstrap cycle):
-      - reconcile_drive(con, label, *, now, dedicated=False, accept_drift=False, blocking=True) -> Reconciliation
-        (report attrs: .outcome in {bootstrapped, refreshed, drift_accepted, epoch_advanced, recovered,
-         unknown_no_authority}, .identity_epoch, .generation, .anchor_free_bytes | None, .inventory);
-        raises dm.DriveMutationRefused with DRIVE_IDENTITY_UNPROVEN / DRIVE_IDENTITY_MISMATCH /
-        DRIVE_AUTHORITY_DOWNGRADE_REFUSED / DRIVE_FREE_DRIFT / DRIVE_RECOVERY_SESSION_ACTIVE /
-        DRIVE_RECONCILIATION_REQUIRED / CLEAN_ANCHOR_CAS_FAILED.
-      - _live_observation(con, label) -> dm.Observation  (fenced live identity/free evidence seam)
-      - _inventory(con, label, dest) -> report with .present/.missing/.debris/.extra and .complete
-      - _annex_key_present(dest, key, *, target_uuid) -> bool  (annex presence proof seam)
-      - _alloc_unit(dest) -> int  (filesystem allocation unit feeding the drift tolerance seam)
-      - free_drift_tolerance_v1(alloc_unit_bytes) -> int  (versioned diagnostic tolerance = one allocation
-        unit + a bounded metadata allowance; NEVER capacity headroom — the anchor stores the raw free)
-      - reuses drive_mutation._publish_anchor_locked for the anchor write inside its atomic bootstrap txn
-  * new CLI: a single `drive reconcile <label> [--accept-drift]` command -> cli.cmd_drive_reconcile
-    (no command family)
+Proposed production API (the names are the contract to confirm): modelark/drive_bootstrap.py exposing
+reconcile_drive(con, label, *, now, dedicated=False, accept_drift=False), the seams _live_evidence /
+_inventory / _annex_key_present, free_drift_tolerance_v1, and a single `drive reconcile <label>` command.
 
 Disposable temp trees / synthetic drives / mocked physical seams only — never a live catalog/drive.
 """
@@ -68,11 +40,13 @@ from pathlib import Path
 from unittest import mock
 
 from modelark.core import db
+from modelark import capacity_evidence
+from modelark import drive_fence
 from modelark import drive_mutation as dm
 from modelark import register
 
 _FP = "a" * 64
-_FP2 = "c" * 64
+_FS, _ANX, _SER = "fs-uuid-1", "annex-uuid-1", "serial-1"
 
 
 try:
@@ -105,29 +79,30 @@ def _catalog(tmp_path):
 
 
 def _bootstrap():
-    """Import the PR-03c1 neutral module, or fail RED with the reviewed reason (it does not exist yet)."""
+    """Import the PR-03c1 neutral module, or fail with the reviewed reason (implementation follows the
+    Gate-1 contract)."""
     try:
         return importlib.import_module("modelark.drive_bootstrap")
     except ModuleNotFoundError as exc:
         raise AssertionError(
             "PR-03c1 must add the neutral module modelark/drive_bootstrap.py exposing a single "
-            f"reconcile_drive(con, label, *, now, dedicated=...) bootstrap/recovery operation: {exc}")
+            f"reconcile_drive(con, label, *, now, dedicated=..., accept_drift=...) operation: {exc}")
 
 
-def _drive_row(con, label="drive-00", *, fs_uuid="fsid", annex_uuid="anx", serial="SER",
+def _drive_row(con, label="drive-00", *, fs_uuid=_FS, annex_uuid=_ANX, serial=_SER,
                capacity=1000, free=940):
-    """A registered/migrated drive: topology + nominal capacity only, no proven identity/authority — the
-    valid `unknown` state a drive sits in until `drive reconcile` bootstraps it."""
+    """A registered/migrated drive: topology + stable identifiers + nominal capacity only, no proven
+    identity/authority — the valid `unknown` state until `drive reconcile` bootstraps it."""
     con.execute("INSERT INTO drives(drive_label,fs_uuid,annex_uuid,serial,capacity_bytes,free_bytes) "
                 "VALUES(?,?,?,?,?,?)", [label, fs_uuid, annex_uuid, serial, capacity, free])
 
 
 def _proven_drive(con, label="drive-00", *, epoch=1, generation=0, fp=_FP, fscap=1000, free=900,
-                  annex_uuid="anx"):
+                  fs_uuid=_FS, annex_uuid=_ANX):
     con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes,identity_epoch,write_generation,"
-                "filesystem_capacity_bytes,identity_fingerprint,write_authority,annex_uuid) "
-                "VALUES(?,?,?,?,?,?,?, 'dedicated_local', ?)",
-                [label, fscap, free, epoch, generation, fscap, fp, annex_uuid])
+                "filesystem_capacity_bytes,identity_fingerprint,write_authority,fs_uuid,annex_uuid) "
+                "VALUES(?,?,?,?,?,?,?, 'dedicated_local', ?,?)",
+                [label, fscap, free, epoch, generation, fscap, fp, fs_uuid, annex_uuid])
 
 
 def _dirty_gen(con, label="drive-00", *, epoch=1, gen=1, op="reconcile", owner=None, token=None):
@@ -156,31 +131,39 @@ def _archived(con, repo, rfile, relpath, label, *, annex_key=None, compressed=0)
                 [repo, rfile, relpath, relpath, label, 5, 5, compressed, annex_key])
 
 
-def _obs(*, fp=_FP, capacity=1000, free=940, proven=True):
-    return dm.Observation(identity_proven=proven, free_bytes=free, filesystem_capacity=capacity,
-                          fingerprint=fp, identity_proof="live-proof", fence_proof="fence-proof")
+def _ev(*, fp=_FP, fs_uuid=_FS, annex_uuid=_ANX, serial=_SER, capacity=1000, free=940,
+        alloc_unit=4096, proven=True):
+    """A mocked live-evidence snapshot; .observation() yields a real dm.Observation for the anchor."""
+    ev = mock.Mock(fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=serial, capacity=capacity,
+                   free=free, alloc_unit=alloc_unit, fingerprint=fp, proven=proven)
+    ev.observation.return_value = dm.Observation(proven, free, capacity, fp, "proof", "proof")
+    return ev
 
 
 def _clean_inv(**kw):
-    """A mocked full-inventory report with nothing missing (an anchor may publish)."""
     fields = dict(present=[], missing=[], debris=[], extra=[], complete=True)
     fields.update(kw)
     return mock.Mock(**fields)
 
 
-# =========================================================== identity establishment + write authority (C1,C2)
+def _real_fp(capacity):
+    return capacity_evidence.identity_fingerprint_v1(
+        fs_uuid=_FS, annex_uuid=_ANX, serial=_SER, filesystem_capacity_bytes=capacity)
+
+
+# =========================================================== identity establishment + write authority
 
 def test_bootstrap_local_dedicated_establishes_identity_authority_and_anchor(tmp_path):
-    """R1+C1+C2+C3: a local drive bootstrapped WITH the dedicated_local assertion persists proven
-    identity, dedicated_local authority, and a first clean anchor whose free is the OBSERVED
-    post-preparation statvfs available (strictly < capacity), in one atomic step."""
+    """A local drive bootstrapped WITH the dedicated_local assertion persists proven identity,
+    dedicated_local authority, and a first clean anchor whose free is the observed post-preparation
+    available (strictly < capacity), in one atomic step."""
     with _catalog(tmp_path) as con:
         _drive_row(con, "drive-00", capacity=1000)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=940)), \
+        with mock.patch.object(bs, "_live_evidence", return_value=_ev(fp=_FP, capacity=1000, free=940)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
-            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
         row = con.execute("SELECT identity_epoch,write_generation,filesystem_capacity_bytes,"
                           "identity_fingerprint,write_authority FROM drives WHERE drive_label='drive-00'"
                           ).fetchone()
@@ -194,41 +177,39 @@ def test_bootstrap_local_dedicated_establishes_identity_authority_and_anchor(tmp
 
 
 def test_bootstrap_without_dedicated_assertion_stays_unknown(tmp_path):
-    """C2 + Issue-3 ruling: dedicated_local is an explicit exclusivity assertion — identity probes never
-    prove it. A dedicated=False reconcile persists NO catalog-v3 authoritative evidence: identity
-    fingerprint and filesystem capacity stay NULL, authority stays `unknown`, and no epoch/generation/
-    anchor is created. Live observations may be surfaced diagnostically in the report but are never
-    persisted as authority; the drive remains a valid `unknown` identity."""
+    """dedicated_local is an explicit exclusivity assertion — a dedicated=False reconcile persists NO
+    catalog-v3 authoritative evidence (fingerprint/capacity NULL, authority unknown, no epoch/generation/
+    anchor). The drive remains a valid `unknown` identity."""
     with _catalog(tmp_path) as con:
         _drive_row(con, "drive-00", capacity=1000)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=940)), \
+        with mock.patch.object(bs, "_live_evidence", return_value=_ev(fp=_FP, capacity=1000, free=940)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
-            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=False)
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=False)
         row = con.execute("SELECT identity_fingerprint,filesystem_capacity_bytes,write_authority,"
                           "identity_epoch,write_generation FROM drives WHERE drive_label='drive-00'").fetchone()
         assert row == (None, None, "unknown", 1, 0), \
-            f"dedicated=False must persist no authoritative evidence (fingerprint/capacity/authority): {row}"
+            f"dedicated=False must persist no authoritative evidence: {row}"
         assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
         assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
         assert report.anchor_free_bytes is None and report.outcome == "unknown_no_authority", report
 
 
 def test_dedicated_false_refuses_to_downgrade_an_authoritative_drive(tmp_path):
-    """Issue-3 boundary: a dedicated=False reconcile against an ALREADY dedicated_local drive must refuse
-    with a typed policy/lifecycle result and leave every piece of evidence unchanged. Authority
-    revocation is a separate lifecycle operation, never a side effect of a non-dedicated reconcile."""
+    """A dedicated=False reconcile against an ALREADY dedicated_local drive refuses with a typed
+    policy/lifecycle result and leaves every piece of evidence unchanged (revocation is a separate
+    lifecycle operation, never a side effect)."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
         _dirty_gen(con, "drive-00", epoch=1, gen=1)
         _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=880)), \
+        with mock.patch.object(bs, "_live_evidence", return_value=_ev(fp=_FP, capacity=1000, free=880)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
             try:
-                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=False)
+                bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=False)
                 raise AssertionError("dedicated=False must not downgrade an authoritative drive")
             except dm.DriveMutationRefused as exc:
                 assert exc.code == "DRIVE_AUTHORITY_DOWNGRADE_REFUSED", exc.code
@@ -238,21 +219,66 @@ def test_dedicated_false_refuses_to_downgrade_an_authoritative_drive(tmp_path):
         assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 1
 
 
-# =========================================================================== atomic bootstrap (C3 / R4)
+def test_migrated_label_refuses_different_stable_identity(tmp_path):
+    """Regression (defect 2): a migrated row (identity_fingerprint NULL) still carries the registered
+    fs/annex UUID. Bootstrap must compare the LIVE stable identity against those before granting
+    authority — different media under an existing label (a replacement disk in Drive-02's slot) is a
+    typed DRIVE_IDENTITY_MISMATCH with no evidence mutation. Label reuse stays deferred (DEF-029)."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-02", fs_uuid=_FS, annex_uuid=_ANX)         # migrated: fp NULL, fs/annex set
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_evidence",
+                               return_value=_ev(fs_uuid="OTHER-fs", annex_uuid="OTHER-annex")), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            try:
+                bs.reconcile_drive(con, "drive-02", now="2026-07-23 12:00:00", dedicated=True)
+                raise AssertionError("different live media under an existing label must refuse")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_IDENTITY_MISMATCH", exc.code
+        row = con.execute("SELECT identity_fingerprint,write_authority FROM drives "
+                          "WHERE drive_label='drive-02'").fetchone()
+        assert row == (None, "unknown"), f"a refused mismatch must not adopt the replacement: {row}"
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+
+
+def test_different_identity_on_a_proven_drive_refuses_before_mutation(tmp_path):
+    """A proven drive whose LIVE stable identity no longer matches the persisted fs/annex refuses before
+    any mutation — durable claims are never silently rebound to new media."""
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
+        bs = _bootstrap()
+        with mock.patch.object(bs, "_live_evidence",
+                               return_value=_ev(fs_uuid="OTHER-fs", annex_uuid="OTHER-annex")), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            try:
+                bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
+                raise AssertionError("a different stable identity under an existing label must refuse")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_IDENTITY_MISMATCH", exc.code
+        assert con.execute("SELECT identity_epoch,write_generation,identity_fingerprint FROM drives "
+                          "WHERE drive_label='drive-00'").fetchone() == (1, 1, _FP)
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 1
+
+
+# =========================================================================== atomic bootstrap + envelope
 
 def test_bootstrap_final_transaction_is_atomic(tmp_path):
-    """C3/R4: identity evidence, the bootstrap dirty generation, the clean anchor, and dedicated_local
-    authority are persisted in ONE transaction — a crash at anchor publication rolls ALL of them back,
-    leaving the drive unknown and anchorless (never a half-established identity)."""
+    """Identity evidence, the bootstrap dirty generation, the clean anchor, and dedicated_local authority
+    are persisted in ONE transaction — a crash at anchor publication rolls ALL of them back, leaving the
+    drive unknown and anchorless (never a half-established identity)."""
     with _catalog(tmp_path) as con:
         _drive_row(con, "drive-00", capacity=1000)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=940)), \
+        with mock.patch.object(bs, "_live_evidence", return_value=_ev(fp=_FP, capacity=1000, free=940)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"), \
              mock.patch.object(dm, "_publish_anchor_locked", side_effect=RuntimeError("crash at publish")):
             try:
-                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+                bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
             except Exception:
                 pass                                     # the crash is expected; the invariant is the rollback
         row = con.execute("SELECT identity_epoch,write_generation,identity_fingerprint,write_authority "
@@ -263,33 +289,73 @@ def test_bootstrap_final_transaction_is_atomic(tmp_path):
 
 
 def test_bootstrap_does_not_route_through_the_ordinary_envelope(tmp_path):
-    """C3: bootstrap must NOT call drive_mutation.drive_mutation() to work around its NULL-fingerprint
+    """Bootstrap must NOT call drive_mutation.drive_mutation() to work around its NULL-fingerprint
     identity refusal — it is its own fenced, atomic operation."""
     with _catalog(tmp_path) as con:
         _drive_row(con, "drive-00", capacity=1000)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=940)), \
+        with mock.patch.object(bs, "_live_evidence", return_value=_ev(fp=_FP, capacity=1000, free=940)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"), \
              mock.patch.object(dm, "drive_mutation") as envelope:
-            bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+            bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
         envelope.assert_not_called()
 
 
-# ======================================================= bounded full-inventory reconciliation (C5)
+# =============================================================== the anchor uses a FINAL observation
+
+def test_anchor_uses_the_final_post_inventory_observation(tmp_path):
+    """Regression (defect 3): the anchor must store the free from a FRESH observation taken AFTER
+    inventory, not the pre-inventory value. Sequential observations (pre=940, final=925) must anchor 925."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-00", capacity=1000)
+        bs = _bootstrap()
+        pre, final = _ev(fp=_FP, capacity=1000, free=940), _ev(fp=_FP, capacity=1000, free=925)
+        with mock.patch.object(bs, "_live_evidence", side_effect=[pre, final]), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
+        anchored = con.execute("SELECT anchor_free_bytes FROM drive_clean_anchors "
+                              "WHERE drive_label='drive-00'").fetchone()[0]
+        assert anchored == 925 and report.anchor_free_bytes == 925, \
+            f"the anchor must use the final observed free (925), not the pre-inventory 940: {anchored}"
+
+
+def test_final_observation_unproven_leaves_no_anchor(tmp_path):
+    """Regression (defect 3): if the drive vanishes or its identity changes DURING inventory, the fresh
+    final observation is unproven and the whole operation fails closed — no anchor, no identity mutation."""
+    with _catalog(tmp_path) as con:
+        _drive_row(con, "drive-00", capacity=1000)
+        bs = _bootstrap()
+        pre, final = _ev(fp=_FP, capacity=1000, free=940), _ev(proven=False)
+        with mock.patch.object(bs, "_live_evidence", side_effect=[pre, final]), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            try:
+                bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
+                raise AssertionError("an unproven final observation must publish no anchor")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_IDENTITY_UNPROVEN", exc.code
+        row = con.execute("SELECT identity_fingerprint,write_authority FROM drives "
+                          "WHERE drive_label='drive-00'").fetchone()
+        assert row == (None, "unknown"), row
+        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
+
+
+# ======================================================= bounded full-inventory reconciliation
 
 def test_inventory_proves_raw_and_annex_content_present(tmp_path):
-    """C5: a populated drive reconciles when every catalogued claim is proven present — a raw file on the
-    worktree and an annex object proven by key (no worktree symlink required)."""
+    """A populated drive reconciles when every catalogued claim is proven — a raw file on the worktree
+    and an annex object proven by key (no worktree symlink required)."""
     with _catalog(tmp_path) as con:
-        _proven_drive(con, "drive-00", annex_uuid="anx")
+        _proven_drive(con, "drive-00")
         _catalogued(con, "repo", "raw.bin")
         _catalogued(con, "repo", "blob.gguf")
         _archived(con, "repo", "raw.bin", "raw.bin", "drive-00", compressed=0)
         _archived(con, "repo", "blob.gguf", "blob.gguf", "drive-00", annex_key="KEY-1")
         dest = tmp_path / "mount"
         (dest / "repo").mkdir(parents=True)
-        (dest / "repo" / "raw.bin").write_bytes(b"bytes")            # raw present; annex proven by key
+        (dest / "repo" / "raw.bin").write_bytes(b"bytes")
         bs = _bootstrap()
         with mock.patch.object(bs, "_annex_key_present", return_value=True):
             inv = bs._inventory(con, "drive-00", dest)
@@ -298,16 +364,16 @@ def test_inventory_proves_raw_and_annex_content_present(tmp_path):
 
 
 def test_inventory_fails_closed_on_missing_or_unprovable_claim(tmp_path):
-    """C5: a catalogued raw file that is absent, or an annex claim whose key cannot be proven, is NEVER
+    """A catalogued raw file that is absent, or an annex claim whose key cannot be proven, is never
     counted present — it lands in `missing` and blocks completion (so no anchor publishes)."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00")
         _catalogued(con, "repo", "gone.bin")
         _catalogued(con, "repo", "blob.gguf")
-        _archived(con, "repo", "gone.bin", "gone.bin", "drive-00", compressed=0)         # raw, file ABSENT
-        _archived(con, "repo", "blob.gguf", "blob.gguf", "drive-00", annex_key="KEY-1")  # annex, unprovable
+        _archived(con, "repo", "gone.bin", "gone.bin", "drive-00", compressed=0)
+        _archived(con, "repo", "blob.gguf", "blob.gguf", "drive-00", annex_key="KEY-1")
         dest = tmp_path / "mount"
-        (dest / "repo").mkdir(parents=True)                                              # no files written
+        (dest / "repo").mkdir(parents=True)
         bs = _bootstrap()
         with mock.patch.object(bs, "_annex_key_present", return_value=False):
             inv = bs._inventory(con, "drive-00", dest)
@@ -316,20 +382,19 @@ def test_inventory_fails_closed_on_missing_or_unprovable_claim(tmp_path):
 
 
 def test_inventory_reports_extra_and_debris_without_deleting(tmp_path):
-    """C5: known staging/.incomplete debris is recognized (not counted archived) and unexplained extra
-    content is REPORTED but LEFT IN PLACE — reconciliation never auto-deletes; the final free observation
-    accounts for those bytes."""
+    """Known staging/.incomplete debris is recognized (not counted archived) and unexplained extra
+    content is REPORTED but LEFT IN PLACE — reconciliation never auto-deletes."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00")
         _catalogued(con, "repo", "raw.bin")
         _archived(con, "repo", "raw.bin", "raw.bin", "drive-00", compressed=0)
         dest = tmp_path / "mount"
         (dest / "repo").mkdir(parents=True)
-        (dest / "repo" / "raw.bin").write_bytes(b"bytes")                 # the one catalogued file
+        (dest / "repo" / "raw.bin").write_bytes(b"bytes")
         debris = dest / "repo" / "raw.bin.incomplete"
-        debris.write_bytes(b"partial")                                    # known debris
+        debris.write_bytes(b"partial")
         extra = dest / "repo" / "mystery.bin"
-        extra.write_bytes(b"unexplained")                                 # unexplained extra
+        extra.write_bytes(b"unexplained")
         bs = _bootstrap()
         with mock.patch.object(bs, "_annex_key_present", return_value=True):
             inv = bs._inventory(con, "drive-00", dest)
@@ -339,13 +404,11 @@ def test_inventory_reports_extra_and_debris_without_deleting(tmp_path):
         assert debris.exists() and extra.exists(), "reconciliation must NOT delete debris or extra content"
 
 
-# ================================================================= capacity-epoch handling (C4)
+# ================================================================= drift-gated refresh + tolerance
 
 def test_free_drift_tolerance_v1_is_alloc_unit_plus_bounded_metadata(tmp_path):
-    """#35 drift tolerance is versioned and DIAGNOSTIC-ONLY: one filesystem allocation unit plus a bounded
-    metadata allowance — never extra capacity headroom (the anchor always stores the raw observed free;
-    the tolerance only gates refresh-vs-refuse). One representative formula is pinned here, not a
-    filesystem-policy framework."""
+    """The drift tolerance is versioned and DIAGNOSTIC-ONLY: one filesystem allocation unit plus a bounded
+    metadata allowance — never capacity headroom. One representative formula is pinned."""
     bs = _bootstrap()
     allowance = 1 << 20                                        # v1: a 1 MiB bounded metadata allowance
     assert bs.free_drift_tolerance_v1(4096) == 4096 + allowance
@@ -353,49 +416,45 @@ def test_free_drift_tolerance_v1_is_alloc_unit_plus_bounded_metadata(tmp_path):
 
 
 def test_within_tolerance_refresh_reanchors_generation_2_with_fresh_free(tmp_path):
-    """C4 + #35 drift rule: re-reconciling the same identity at unchanged capacity, when the observed free
-    has drifted only WITHIN the versioned tolerance, refreshes without a new epoch by advancing to
-    generation 2 and storing the fresh RAW observed free (a no-op refresh that keeps stale free evidence
-    is not allowed)."""
+    """A same-identity/same-capacity refresh whose free drifted only WITHIN the tolerance advances to
+    generation 2 and re-anchors the fresh raw free (a no-op refresh keeping stale free is not allowed)."""
     cap, anchored_free = 8_000_000_000_000, 4_000_000_000_000
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=cap, free=anchored_free)
         _dirty_gen(con, "drive-00", epoch=1, gen=1)
         _anchor(con, "drive-00", epoch=1, gen=1, free=anchored_free, fscap=cap)
         bs = _bootstrap()
-        fresh_free = anchored_free - (bs.free_drift_tolerance_v1(4096) - 1)   # drifted, strictly BELOW tolerance
-        with mock.patch.object(bs, "_live_observation",
-                               return_value=_obs(fp=_FP, capacity=cap, free=fresh_free)), \
+        fresh = anchored_free - (bs.free_drift_tolerance_v1(4096) - 1)          # drifted, strictly BELOW tolerance
+        with mock.patch.object(bs, "_live_evidence",
+                               return_value=_ev(fp=_FP, capacity=cap, free=fresh, alloc_unit=4096)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
-             mock.patch.object(bs, "_alloc_unit", return_value=4096), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
-            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
         assert con.execute("SELECT identity_epoch,write_generation FROM drives WHERE drive_label='drive-00'"
                            ).fetchone() == (1, 2), "same epoch, advanced to a fresh generation 2"
         anchor = con.execute("SELECT anchor_free_bytes FROM drive_clean_anchors WHERE drive_label='drive-00' "
                             "AND identity_epoch=1 AND generation=2").fetchone()
-        assert anchor == (fresh_free,), f"generation 2 must store the fresh raw observed free: {anchor}"
+        assert anchor == (fresh,), f"generation 2 must store the fresh raw observed free: {anchor}"
         assert report.identity_epoch == 1 and report.outcome == "refreshed", report
 
 
 def test_refresh_above_drift_tolerance_refuses_without_acceptance(tmp_path):
-    """#35 drift rule: a free delta ABOVE the versioned tolerance on a currently-clean anchored drive is a
-    typed DRIVE_FREE_DRIFT refusal without --accept-drift — the old generation and anchor are left
-    unchanged, so a real capacity loss can never be silently re-anchored away."""
+    """A free delta ABOVE the tolerance on a currently-clean anchored drive is a typed DRIVE_FREE_DRIFT
+    refusal without --accept-drift — the old generation/anchor are unchanged (real capacity loss is never
+    silently re-anchored away)."""
     cap, anchored_free = 8_000_000_000_000, 4_000_000_000_000
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=cap, free=anchored_free)
         _dirty_gen(con, "drive-00", epoch=1, gen=1)
         _anchor(con, "drive-00", epoch=1, gen=1, free=anchored_free, fscap=cap)
         bs = _bootstrap()
-        drifted_free = anchored_free - (bs.free_drift_tolerance_v1(4096) + 1)   # strictly ABOVE tolerance
-        with mock.patch.object(bs, "_live_observation",
-                               return_value=_obs(fp=_FP, capacity=cap, free=drifted_free)), \
+        drifted = anchored_free - (bs.free_drift_tolerance_v1(4096) + 1)        # strictly ABOVE tolerance
+        with mock.patch.object(bs, "_live_evidence",
+                               return_value=_ev(fp=_FP, capacity=cap, free=drifted, alloc_unit=4096)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
-             mock.patch.object(bs, "_alloc_unit", return_value=4096), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
             try:
-                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+                bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
                 raise AssertionError("above-tolerance free drift must refuse without --accept-drift")
             except dm.DriveMutationRefused as exc:
                 assert exc.code == "DRIVE_FREE_DRIFT", exc.code
@@ -406,90 +465,98 @@ def test_refresh_above_drift_tolerance_refuses_without_acceptance(tmp_path):
 
 
 def test_refresh_above_drift_tolerance_reanchors_with_accept_drift(tmp_path):
-    """#35 drift rule: with --accept-drift, an above-tolerance free delta re-anchors AFTER a successful
-    full reconciliation — a fresh generation 2 + anchor storing the observed free, recorded under a
-    DISTINCT dirty-generation operation code ('accept-drift') so the acceptance is auditable."""
+    """With --accept-drift, an above-tolerance delta re-anchors AFTER a full reconciliation — a fresh
+    generation 2 + anchor storing the observed free, under a DISTINCT 'accept-drift' operation code."""
     cap, anchored_free = 8_000_000_000_000, 4_000_000_000_000
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=cap, free=anchored_free)
         _dirty_gen(con, "drive-00", epoch=1, gen=1)
         _anchor(con, "drive-00", epoch=1, gen=1, free=anchored_free, fscap=cap)
         bs = _bootstrap()
-        drifted_free = anchored_free - (bs.free_drift_tolerance_v1(4096) + 1)   # above tolerance, but accepted
-        with mock.patch.object(bs, "_live_observation",
-                               return_value=_obs(fp=_FP, capacity=cap, free=drifted_free)), \
+        drifted = anchored_free - (bs.free_drift_tolerance_v1(4096) + 1)        # above tolerance, but accepted
+        with mock.patch.object(bs, "_live_evidence",
+                               return_value=_ev(fp=_FP, capacity=cap, free=drifted, alloc_unit=4096)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
-             mock.patch.object(bs, "_alloc_unit", return_value=4096), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
-            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00",
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00",
                                         dedicated=True, accept_drift=True)
         gen2 = con.execute("SELECT operation_code FROM drive_dirty_generations WHERE drive_label='drive-00' "
                           "AND identity_epoch=1 AND generation=2").fetchone()
         assert gen2 == ("accept-drift",), f"drift acceptance must use a distinct operation code: {gen2}"
         anchor = con.execute("SELECT anchor_free_bytes FROM drive_clean_anchors WHERE drive_label='drive-00' "
                             "AND identity_epoch=1 AND generation=2").fetchone()
-        assert anchor == (drifted_free,), f"the accepted anchor must store the observed free: {anchor}"
+        assert anchor == (drifted,), f"the accepted anchor must store the observed free: {anchor}"
         assert report.identity_epoch == 1 and report.outcome == "drift_accepted", report
 
 
+# ================================================================ capacity-epoch transition (real evidence)
+
 def test_same_identity_changed_capacity_advances_epoch_and_reanchors(tmp_path):
-    """C4: same identity + a DIFFERENT filesystem capacity is an explicit capacity-epoch transition — a
-    new epoch with a fresh generation and anchor (not a silent same-epoch refresh, and not DEF-029)."""
+    """Regression (defect 1): the fingerprint folds capacity in, so a resize necessarily changes the
+    fingerprint while the STABLE identity (fs/annex) is unchanged. That is recognized as the same drive
+    and transitions the capacity epoch: a new epoch, generation 1, the NEW fingerprint persisted, and a
+    matching anchor — with real old/new fingerprints, not one fake value shared across capacities."""
+    old_fp, new_fp = _real_fp(1000), _real_fp(2000)
+    assert old_fp != new_fp, "a capacity change must change the composite fingerprint"
     with _catalog(tmp_path) as con:
-        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _proven_drive(con, "drive-00", fp=old_fp, epoch=1, generation=1, fscap=1000)
         _dirty_gen(con, "drive-00", epoch=1, gen=1)
-        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000, fp=old_fp)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=2000, free=1900)), \
+        with mock.patch.object(bs, "_live_evidence",
+                               return_value=_ev(fp=new_fp, capacity=2000, free=1900)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
-            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
-        row = con.execute("SELECT identity_epoch,write_generation,filesystem_capacity_bytes FROM drives "
-                          "WHERE drive_label='drive-00'").fetchone()
-        assert row == (2, 1, 2000), f"an epoch transition resets the namespace to (epoch 2, generation 1): {row}"
-        new = con.execute("SELECT generation,anchor_free_bytes,filesystem_capacity_bytes FROM "
-                          "drive_clean_anchors WHERE drive_label='drive-00' AND identity_epoch=2").fetchone()
-        assert new == (1, 1900, 2000), f"epoch 2's first anchor must be generation 1: {new}"
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
+        row = con.execute("SELECT identity_epoch,write_generation,filesystem_capacity_bytes,identity_fingerprint "
+                          "FROM drives WHERE drive_label='drive-00'").fetchone()
+        assert row == (2, 1, 2000, new_fp), f"the transition must persist (epoch 2, gen 1, new fp): {row}"
+        new = con.execute("SELECT generation,anchor_free_bytes,filesystem_capacity_bytes,identity_fingerprint "
+                          "FROM drive_clean_anchors WHERE drive_label='drive-00' AND identity_epoch=2").fetchone()
+        assert new == (1, 1900, 2000, new_fp), f"epoch 2's first anchor must be generation 1 + new fp: {new}"
         assert report.outcome == "epoch_advanced" and report.identity_epoch == 2, report
 
 
-def test_different_identity_under_existing_label_refuses_before_mutation(tmp_path):
-    """C4: a different underlying identity under an existing label must REFUSE before any format/clone/
-    remote/catalog mutation — durable byte claims are never silently rebound to new media (label reuse
-    and retirement stay DEF-029)."""
-    with _catalog(tmp_path) as con:
-        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
-        _dirty_gen(con, "drive-00", epoch=1, gen=1)
-        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
-        bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP2, capacity=1000)), \
-             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
-             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
-            try:
-                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
-                raise AssertionError("a different identity under an existing label must refuse")
-            except dm.DriveMutationRefused as exc:
-                assert exc.code == "DRIVE_IDENTITY_MISMATCH", exc.code
-        row = con.execute("SELECT identity_epoch,write_generation,identity_fingerprint FROM drives "
-                          "WHERE drive_label='drive-00'").fetchone()
-        assert row == (1, 1, _FP), f"the original identity must be untouched by a refused mismatch: {row}"
-        assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 1
+def test_epoch_transition_holds_both_old_and_new_epoch_fences(tmp_path):
+    """The transition must acquire BOTH the persisted old (fingerprint, epoch) fence and the prospective
+    new (fingerprint, epoch+1) fence: an existing writer holding EITHER makes the transition refuse with
+    DRIVE_FENCE_UNAVAILABLE and change nothing."""
+    old_fp, new_fp = _real_fp(1000), _real_fp(2000)
+    for held in ((old_fp, 1), (new_fp, 2)):
+        with _catalog(tmp_path / f"e{held[1]}") as con:
+            _proven_drive(con, "drive-00", fp=old_fp, epoch=1, generation=1, fscap=1000)
+            _dirty_gen(con, "drive-00", epoch=1, gen=1)
+            _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000, fp=old_fp)
+            bs = _bootstrap()
+            with mock.patch.object(bs, "_live_evidence",
+                                   return_value=_ev(fp=new_fp, capacity=2000, free=1900)), \
+                 mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+                 mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"), \
+                 drive_fence.hold_drives_sorted([held]):          # an existing writer holds one of the fences
+                try:
+                    bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00",
+                                       dedicated=True, blocking=False)
+                    raise AssertionError(f"transition must refuse while {held} is held")
+                except dm.DriveMutationRefused as exc:
+                    assert exc.code == "DRIVE_FENCE_UNAVAILABLE", (held, exc.code)
+            assert con.execute("SELECT identity_epoch FROM drives WHERE drive_label='drive-00'"
+                               ).fetchone()[0] == 1, "a fenced-out transition must change nothing"
 
 
-# ===================================================== sessionless dirty recovery, same command (R3 / C5)
+# ================================================================ sessionless dirty recovery
 
 def test_reconcile_recovers_sessionless_dirty_generation(tmp_path):
-    """R3: a dirty generation with no anchor and NO owner session (sessionless) is recovered by
-    `drive reconcile` — it reconciles and republishes THAT generation's anchor via the (epoch,generation)
-    CAS, without opening a new generation."""
+    """A dirty generation with no anchor and NO owner session is recovered — reconcile republishes THAT
+    generation's anchor via the (epoch, generation) CAS, without opening a new generation, and preserves
+    the identity/authority."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
-        _dirty_gen(con, "drive-00", epoch=1, gen=1, owner=None)          # dirty, sessionless, no anchor
+        _dirty_gen(con, "drive-00", epoch=1, gen=1, owner=None)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=870)), \
+        with mock.patch.object(bs, "_live_evidence", return_value=_ev(fp=_FP, capacity=1000, free=870)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
-            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
         assert con.execute("SELECT write_generation FROM drives WHERE drive_label='drive-00'").fetchone()[0] == 1, \
             "recovery republishes the existing generation; it does not open a new one"
         anchor = con.execute("SELECT generation,anchor_free_bytes FROM drive_clean_anchors "
@@ -502,54 +569,52 @@ def test_reconcile_recovers_sessionless_dirty_generation(tmp_path):
 
 
 def test_reconcile_refuses_a_live_session_dirty_generation(tmp_path):
-    """R3 boundary: a dirty generation attributed to a live session (owner fields set) is NOT recovered
-    here — sessionless recovery refuses and defers session-attributed recovery to #39."""
+    """A dirty generation attributed to a live session (owner fields set) is NOT recovered here —
+    sessionless recovery refuses and defers session-attributed recovery to #39."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
-        _dirty_gen(con, "drive-00", epoch=1, gen=1, owner="sess-1", token=1)     # live / attributed
+        _dirty_gen(con, "drive-00", epoch=1, gen=1, owner="sess-1", token=1)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000)), \
+        with mock.patch.object(bs, "_live_evidence", return_value=_ev(fp=_FP, capacity=1000, free=870)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
             try:
-                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+                bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
                 raise AssertionError("a session-attributed dirty generation must not be recovered here (#39)")
             except dm.DriveMutationRefused as exc:
                 assert exc.code == "DRIVE_RECOVERY_SESSION_ACTIVE", exc.code
         assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
 
 
-# ================================================================ completion semantics + single command (C5)
+# ================================================================ completion + single command + GREEN floor
 
 def test_offline_drive_stays_valid_unknown_and_is_not_fabricated_clean(tmp_path):
-    """C5 completion: a drive whose live identity cannot be proven (offline/failed — the Drive-02 case)
-    stays a VALID registered identity with unknown evidence. reconcile fails closed and fabricates no
-    anchor; a drive is never required or forced into cleanliness to complete the fleet."""
+    """A drive whose live identity cannot be proven (offline/failed — the Drive-02 case) stays a VALID
+    registered identity with unknown evidence; reconcile fails closed and fabricates no anchor."""
     with _catalog(tmp_path) as con:
         _drive_row(con, "drive-02")
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(proven=False)), \
+        with mock.patch.object(bs, "_live_evidence", return_value=_ev(proven=False)), \
              mock.patch.object(register, "archive_path", return_value=None):
             try:
-                bs.reconcile_drive(con, "drive-02", now="2026-07-22 12:00:00", dedicated=True)
+                bs.reconcile_drive(con, "drive-02", now="2026-07-23 12:00:00", dedicated=True)
                 raise AssertionError("an unprovable/offline drive must fail closed, not fabricate an anchor")
             except dm.DriveMutationRefused as exc:
                 assert exc.code == "DRIVE_IDENTITY_UNPROVEN", exc.code
-        row = con.execute("SELECT identity_fingerprint,write_authority FROM drives "
-                          "WHERE drive_label='drive-02'").fetchone()
-        assert row == (None, "unknown"), f"an offline drive stays a valid unknown identity: {row}"
+        assert con.execute("SELECT identity_fingerprint,write_authority FROM drives "
+                          "WHERE drive_label='drive-02'").fetchone() == (None, "unknown")
         assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
 
 
 def test_single_drive_reconcile_command_covers_bootstrap_and_recovery(tmp_path):
-    """C5: exactly ONE operator command — `drive reconcile <label>` — covers migrated-drive bootstrap and
-    sessionless dirty recovery. There is no family of bootstrap/recover commands."""
+    """Exactly ONE operator command — `drive reconcile <label>` — covers bootstrap and recovery, and it
+    is WIRED into argparse (checked at the parser level; the real op is never executed). No command
+    family."""
     from modelark import cli
     assert hasattr(cli, "cmd_drive_reconcile"), \
         "PR-03c1 must add a single `drive reconcile <label>` command (cli.cmd_drive_reconcile)"
     assert not hasattr(cli, "cmd_drive_bootstrap") and not hasattr(cli, "cmd_drive_recover"), \
         "bootstrap and recovery are one `drive reconcile` operation, not a command family"
-    # wiring is checked at the PARSER level; the real op is never executed (the handler is mocked)
     with mock.patch.object(cli, "cmd_drive_reconcile") as handler:
         try:
             cli.main(["drive", "reconcile", "drive-00"])      # argparse binds func to the mocked handler
@@ -557,8 +622,6 @@ def test_single_drive_reconcile_command_covers_bootstrap_and_recovery(tmp_path):
             raise AssertionError(f"`drive reconcile <label>` is not wired into argparse (SystemExit {exc.code})")
     handler.assert_called_once()
 
-
-# ================================================================================= GREEN characterization
 
 def test_migrated_drive_is_unknown_and_anchorless_until_reconcile(tmp_path):
     """GREEN floor (must stay true): registration/migration records a valid drive identity but NO write
@@ -585,12 +648,12 @@ if __name__ == "__main__":
                 fn(tmp)
                 passed.append(name)
                 print(f"PASS  {name}")
-            except Exception as exc:                     # noqa: BLE001 — Gate-1 wants the full red/green map
+            except Exception as exc:                     # noqa: BLE001 — full red/green map
                 failed.append(name)
                 print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
             finally:
                 db.CATALOG_DIR, db.DB_PATH, db.STATE_DIR = saved
-                shutil.rmtree(tmp, ignore_errors=True)   # the standalone runner cleans its own temp trees
+                shutil.rmtree(tmp, ignore_errors=True)
     print(f"\n{len(passed)} passed, {len(failed)} failed")
     if failed:
         raise SystemExit(1)                              # a failing test MUST fail CI (set -e; python "$t")

--- a/tests/test_drive_bootstrap.py
+++ b/tests/test_drive_bootstrap.py
@@ -22,6 +22,13 @@ Binding reviewer corrections encoded here:
   C4  same identity + unchanged capacity → refresh, same epoch; same identity + CHANGED capacity → an
       explicit capacity-epoch transition (new epoch + fresh generation/anchor); a DIFFERENT identity
       under an existing label → refuse BEFORE any mutation (label reuse/retirement stays DEF-029).
+      DRIFT RULE (#35): refreshing a currently-clean anchored drive advances to a fresh generation and
+      re-anchors the RAW observed free ONLY when the free delta is within the versioned diagnostic
+      tolerance (one filesystem allocation unit + a bounded metadata allowance — diagnostic only, NEVER
+      capacity headroom). An above-tolerance delta is a typed DRIVE_FREE_DRIFT refusal (old generation/
+      anchor unchanged) unless --accept-drift is given, which re-anchors after a full reconciliation under
+      a distinct 'accept-drift' operation code. Bootstrap and dirty-generation recovery have no prior
+      clean anchor to compare and are exempt from the drift check.
   C5  full reconciliation is bounded and report-only: catalogued raw+annex proven present; known
       staging/.incomplete debris recognized; missing/unprovable claims never counted present (fail
       closed, no anchor); unexplained extra reported and LEFT IN PLACE (the final free observation
@@ -34,17 +41,21 @@ deferred to #39; label reuse / retirement / dependency-aware replacement to DEF-
 
 Proposed production API surfaced by these tests (for Gate-1 review; names are the contract to confirm):
   * new NEUTRAL module modelark/drive_bootstrap.py (no register→fetch / register→drive_bootstrap cycle):
-      - reconcile_drive(con, label, *, now, dedicated=False, blocking=True) -> Reconciliation
+      - reconcile_drive(con, label, *, now, dedicated=False, accept_drift=False, blocking=True) -> Reconciliation
         (report attrs: .outcome in {bootstrapped, refreshed, epoch_advanced, recovered,
          unknown_no_authority}, .identity_epoch, .generation, .anchor_free_bytes | None, .inventory);
         raises dm.DriveMutationRefused with DRIVE_IDENTITY_UNPROVEN / DRIVE_IDENTITY_MISMATCH /
-        DRIVE_AUTHORITY_DOWNGRADE_REFUSED / DRIVE_RECOVERY_SESSION_ACTIVE /
+        DRIVE_AUTHORITY_DOWNGRADE_REFUSED / DRIVE_FREE_DRIFT / DRIVE_RECOVERY_SESSION_ACTIVE /
         DRIVE_RECONCILIATION_REQUIRED / CLEAN_ANCHOR_CAS_FAILED.
       - _live_observation(con, label) -> dm.Observation  (fenced live identity/free evidence seam)
       - _inventory(con, label, dest) -> report with .present/.missing/.debris/.extra and .complete
       - _annex_key_present(dest, key, *, target_uuid) -> bool  (annex presence proof seam)
+      - _alloc_unit(dest) -> int  (filesystem allocation unit feeding the drift tolerance seam)
+      - free_drift_tolerance_v1(alloc_unit_bytes) -> int  (versioned diagnostic tolerance = one allocation
+        unit + a bounded metadata allowance; NEVER capacity headroom — the anchor stores the raw free)
       - reuses drive_mutation._publish_anchor_locked for the anchor write inside its atomic bootstrap txn
-  * new CLI: a single `drive reconcile <label>` command -> cli.cmd_drive_reconcile (no command family)
+  * new CLI: a single `drive reconcile <label> [--accept-drift]` command -> cli.cmd_drive_reconcile
+    (no command family)
 
 Disposable temp trees / synthetic drives / mocked physical seams only — never a live catalog/drive.
 """
@@ -201,7 +212,7 @@ def test_bootstrap_without_dedicated_assertion_stays_unknown(tmp_path):
             f"dedicated=False must persist no authoritative evidence (fingerprint/capacity/authority): {row}"
         assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
         assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
-        assert report.anchor_free_bytes is None, report
+        assert report.anchor_free_bytes is None and report.outcome == "unknown_no_authority", report
 
 
 def test_dedicated_false_refuses_to_downgrade_an_authoritative_drive(tmp_path):
@@ -330,22 +341,95 @@ def test_inventory_reports_extra_and_debris_without_deleting(tmp_path):
 
 # ================================================================= capacity-epoch handling (C4)
 
-def test_same_identity_same_capacity_refreshes_without_new_epoch(tmp_path):
-    """C4: re-reconciling the same identity at unchanged capacity refreshes evidence WITHOUT advancing
-    the capacity epoch."""
+def test_free_drift_tolerance_v1_is_alloc_unit_plus_bounded_metadata(tmp_path):
+    """#35 drift tolerance is versioned and DIAGNOSTIC-ONLY: one filesystem allocation unit plus a bounded
+    metadata allowance — never extra capacity headroom (the anchor always stores the raw observed free;
+    the tolerance only gates refresh-vs-refuse). One representative formula is pinned here, not a
+    filesystem-policy framework."""
+    bs = _bootstrap()
+    allowance = 1 << 20                                        # v1: a 1 MiB bounded metadata allowance
+    assert bs.free_drift_tolerance_v1(4096) == 4096 + allowance
+    assert bs.free_drift_tolerance_v1(65536) == 65536 + allowance
+
+
+def test_within_tolerance_refresh_reanchors_generation_2_with_fresh_free(tmp_path):
+    """C4 + #35 drift rule: re-reconciling the same identity at unchanged capacity, when the observed free
+    has drifted only WITHIN the versioned tolerance, refreshes without a new epoch by advancing to
+    generation 2 and storing the fresh RAW observed free (a no-op refresh that keeps stale free evidence
+    is not allowed)."""
+    cap, anchored_free = 8_000_000_000_000, 4_000_000_000_000
     with _catalog(tmp_path) as con:
-        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=cap, free=anchored_free)
         _dirty_gen(con, "drive-00", epoch=1, gen=1)
-        _anchor(con, "drive-00", epoch=1, gen=1, free=900, fscap=1000)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=anchored_free, fscap=cap)
         bs = _bootstrap()
-        with mock.patch.object(bs, "_live_observation", return_value=_obs(fp=_FP, capacity=1000, free=880)), \
+        fresh_free = anchored_free - (bs.free_drift_tolerance_v1(4096) - 1)   # drifted, strictly BELOW tolerance
+        with mock.patch.object(bs, "_live_observation",
+                               return_value=_obs(fp=_FP, capacity=cap, free=fresh_free)), \
              mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(bs, "_alloc_unit", return_value=4096), \
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
             report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
-        assert con.execute("SELECT identity_epoch FROM drives WHERE drive_label='drive-00'").fetchone()[0] == 1
-        assert con.execute("SELECT count(DISTINCT identity_epoch) FROM drive_clean_anchors "
-                           "WHERE drive_label='drive-00'").fetchone()[0] == 1, "no new epoch namespace"
+        assert con.execute("SELECT identity_epoch,write_generation FROM drives WHERE drive_label='drive-00'"
+                           ).fetchone() == (1, 2), "same epoch, advanced to a fresh generation 2"
+        anchor = con.execute("SELECT anchor_free_bytes FROM drive_clean_anchors WHERE drive_label='drive-00' "
+                            "AND identity_epoch=1 AND generation=2").fetchone()
+        assert anchor == (fresh_free,), f"generation 2 must store the fresh raw observed free: {anchor}"
         assert report.identity_epoch == 1 and report.outcome == "refreshed", report
+
+
+def test_refresh_above_drift_tolerance_refuses_without_acceptance(tmp_path):
+    """#35 drift rule: a free delta ABOVE the versioned tolerance on a currently-clean anchored drive is a
+    typed DRIVE_FREE_DRIFT refusal without --accept-drift — the old generation and anchor are left
+    unchanged, so a real capacity loss can never be silently re-anchored away."""
+    cap, anchored_free = 8_000_000_000_000, 4_000_000_000_000
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=cap, free=anchored_free)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=anchored_free, fscap=cap)
+        bs = _bootstrap()
+        drifted_free = anchored_free - (bs.free_drift_tolerance_v1(4096) + 1)   # strictly ABOVE tolerance
+        with mock.patch.object(bs, "_live_observation",
+                               return_value=_obs(fp=_FP, capacity=cap, free=drifted_free)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(bs, "_alloc_unit", return_value=4096), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            try:
+                bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00", dedicated=True)
+                raise AssertionError("above-tolerance free drift must refuse without --accept-drift")
+            except dm.DriveMutationRefused as exc:
+                assert exc.code == "DRIVE_FREE_DRIFT", exc.code
+        assert con.execute("SELECT write_generation FROM drives WHERE drive_label='drive-00'").fetchone()[0] == 1
+        anchors = con.execute("SELECT identity_epoch,generation,anchor_free_bytes FROM drive_clean_anchors "
+                            "WHERE drive_label='drive-00'").fetchall()
+        assert anchors == [(1, 1, anchored_free)], f"the old generation/anchor must be unchanged: {anchors}"
+
+
+def test_refresh_above_drift_tolerance_reanchors_with_accept_drift(tmp_path):
+    """#35 drift rule: with --accept-drift, an above-tolerance free delta re-anchors AFTER a successful
+    full reconciliation — a fresh generation 2 + anchor storing the observed free, recorded under a
+    DISTINCT dirty-generation operation code ('accept-drift') so the acceptance is auditable."""
+    cap, anchored_free = 8_000_000_000_000, 4_000_000_000_000
+    with _catalog(tmp_path) as con:
+        _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=cap, free=anchored_free)
+        _dirty_gen(con, "drive-00", epoch=1, gen=1)
+        _anchor(con, "drive-00", epoch=1, gen=1, free=anchored_free, fscap=cap)
+        bs = _bootstrap()
+        drifted_free = anchored_free - (bs.free_drift_tolerance_v1(4096) + 1)   # above tolerance, but accepted
+        with mock.patch.object(bs, "_live_observation",
+                               return_value=_obs(fp=_FP, capacity=cap, free=drifted_free)), \
+             mock.patch.object(bs, "_inventory", return_value=_clean_inv()), \
+             mock.patch.object(bs, "_alloc_unit", return_value=4096), \
+             mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
+            report = bs.reconcile_drive(con, "drive-00", now="2026-07-22 12:00:00",
+                                        dedicated=True, accept_drift=True)
+        gen2 = con.execute("SELECT operation_code FROM drive_dirty_generations WHERE drive_label='drive-00' "
+                          "AND identity_epoch=1 AND generation=2").fetchone()
+        assert gen2 == ("accept-drift",), f"drift acceptance must use a distinct operation code: {gen2}"
+        anchor = con.execute("SELECT anchor_free_bytes FROM drive_clean_anchors WHERE drive_label='drive-00' "
+                            "AND identity_epoch=1 AND generation=2").fetchone()
+        assert anchor == (drifted_free,), f"the accepted anchor must store the observed free: {anchor}"
+        assert report.identity_epoch == 1, report
 
 
 def test_same_identity_changed_capacity_advances_epoch_and_reanchors(tmp_path):

--- a/tests/test_drive_mutation_envelope.py
+++ b/tests/test_drive_mutation_envelope.py
@@ -611,14 +611,14 @@ def test_multi_drive_anchor_publish_is_all_or_nothing(tmp_path):
 # =========================================================================== wiring guard (PR-03b)
 
 def test_envelope_wired_only_into_reviewed_transport():
-    """PR-03b wires the envelope into exactly ONE reviewed production transport (modelark/fetch.py) and
-    nothing else. This supersedes the PR-03a dormancy guard: fetch.py MUST import the envelope, and no
-    other production module may (registration/recovery/operator paths are PR-03c; admission is #35-C).
-    Inspect import AST nodes so `import modelark.drive_fence` and `from modelark.drive_mutation import X`
-    are both caught."""
+    """The envelope + its fences may be imported ONLY by reviewed catalog-v3 owners, and each MUST be
+    wired: PR-03b's transport (modelark/fetch.py) and PR-03c1's registration/recovery/operator module
+    (modelark/drive_bootstrap.py, which reuses the same fenced primitives). No other production module
+    may import them (admission cutover is #35-C). Inspect import AST nodes so `import modelark.drive_fence`
+    and `from modelark.drive_mutation import X` are both caught."""
     root = Path(__file__).resolve().parent.parent / "modelark"
     envelope = {"drive_fence", "drive_mutation"}
-    allowed = {"fetch.py"}
+    allowed = {"fetch.py", "drive_bootstrap.py"}
     importers, offenders = set(), []
     for path in root.rglob("*.py"):
         if path.name in ("drive_fence.py", "drive_mutation.py"):
@@ -637,8 +637,10 @@ def test_envelope_wired_only_into_reviewed_transport():
                     offenders.append(f"{path.relative_to(root)}:{node.lineno}")
     assert offenders == [], f"only {sorted(allowed)} may import the envelope; found: {offenders}"
     assert "fetch.py" in importers, (
-        "PR-03b must wire the envelope into modelark/fetch.py (the reviewed transport); "
-        "the dormancy phase is over")
+        "PR-03b must wire the envelope into modelark/fetch.py (the reviewed transport)")
+    assert "drive_bootstrap.py" in importers, (
+        "PR-03c1 must reuse the fenced primitives in modelark/drive_bootstrap.py "
+        "(the reviewed registration/recovery/operator path)")
 
 
 def main():


### PR DESCRIPTION
Merges into `fix/placement-capacity-hardening` (never `main`). **PR-03c1** — the smallest usable predecessor to the #35-C admission-authority cutover: drive identity **bootstrap** + first clean **anchor** + **sessionless dirty recovery**. Implementation complete (Gate 2).

Context: the physical-mutation envelope (PR-03a/03b) was **inert in production** — nothing wrote a *proven* identity to the `drives` row, so every real drive stayed `identity_fingerprint=NULL` / `write_authority='unknown'` and the envelope refused it at entry. This slice establishes that identity, so #35-C has an authority to cut over to.

## Production
- **`modelark/drive_bootstrap.py`** (new, neutral) — depends only on the low-level catalog-v3 primitives (`drive_fence`, `drive_mutation`, `register`, `capacity_evidence`); **never imports `fetch`** → no `register → fetch` / `register → drive_bootstrap` ownership cycle, no transport refactor.
  - `reconcile_drive(con, label, *, now, dedicated=False, accept_drift=False)` runs under the controller + drive fences and commits **identity evidence + dirty generation + clean anchor + authority in ONE short transaction** (a crash before commit leaves the drive `unknown` and anchorless). It reuses `drive_mutation`'s locked primitives (`_advance_one`, `_publish_anchor_locked`, the `(epoch, generation)` CAS).
  - Paths: **bootstrap** (prove identity → full-inventory reconcile → first anchor storing the raw observed free); **refresh** of a currently-clean drive, **drift-gated** (within the versioned diagnostic tolerance → advance a generation + re-anchor the fresh free; above tolerance → typed `DRIVE_FREE_DRIFT` unless `--accept-drift` re-anchors after a full reconciliation under a distinct `accept-drift` op code); **epoch transition** on changed capacity (reset to `(new_epoch, generation 1)`); **sessionless recovery** (republish the existing dirty generation's anchor; an owner session → `DRIVE_RECOVERY_SESSION_ACTIVE`, deferred to #39).
  - `dedicated_local` is an explicit assertion, never a probe result; `dedicated=False` persists nothing and refuses to downgrade an authoritative drive (`DRIVE_AUTHORITY_DOWNGRADE_REFUSED`); a mismatched identity refuses before any mutation (`DRIVE_IDENTITY_MISMATCH`).
  - The drift tolerance (`free_drift_tolerance_v1`) is **versioned + diagnostic-only** (one filesystem allocation unit + a bounded metadata allowance), never capacity headroom.
- **`modelark/cli.py`** — one `drive reconcile <label> [--dedicated] [--accept-drift]` command.

## Tests
- `tests/test_drive_bootstrap.py` — the 19-test contract (bootstrap/authority/atomicity, full-inventory reconciliation, capacity-epoch, drift rule, sessionless recovery, CLI wiring) now all **GREEN**.
- `tests/test_drive_mutation_envelope.py` — the envelope import guard now allows **and requires** `drive_bootstrap.py` as the second reviewed importer of the fenced primitives.

## Validation
19/19 PR-03c1; full suite **351 passed**; `ruff check modelark scripts tests` clean; the `drive_bootstrap` script-runner exits 0.

## Scope / deferrals
Session-attributed recovery — owner session/token, worker/child exclusion, fencing-token recovery (**#39**); label reuse / retirement / dependency-aware replacement (**DEF-029**). The remaining non-Fill mutation closure (pre-envelope writability probe + guarded restore retrieval) is **03c2**.

## Safety
Synthetic drives, temp trees, and mocked physical seams only — no live service / catalog / drive touched. The local `.gitignore` change was never staged or committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCUcZdiUBs8sF2GbLvf49Q
