### PR TITLE
PR-03c2: non-Fill mutation closure — readiness check + restore guard + register guard

### DIFF
--- a/modelark/fill.py
+++ b/modelark/fill.py
@@ -7,6 +7,7 @@ next graph.  Both CLI and portal call :func:`execute`.
 """
 from __future__ import annotations
 
+import os
 import secrets
 import shutil
 import time
@@ -15,7 +16,6 @@ from pathlib import Path
 
 from modelark import capacity, fetch, plan, reconcile, register
 
-_PROBE_NAME = ".modelark-write-probe"
 _MAX_TASK_ATTEMPTS = 2
 _GATED_DECISION_TIMEOUT = 5 * 60
 
@@ -37,23 +37,19 @@ def _mounted(ctx, label: str) -> tuple[bool, bool]:
 
 
 def _writable(ctx, label: str) -> bool:
-    """A mount is usable only after a write/read/delete probe succeeds."""
+    """A cheap, NON-MUTATING readiness check: the drive resolves to a mounted archive directory that
+    statvfs's and is readable. It performs no probe write/unlink and no identity subprocess — authoritative
+    identity proof and real write access are established inside the mutation envelope (post-dirty)."""
     with ctx.lock:
         path = register.archive_path(ctx.con, label)
     if path is None:
         return False
-    probe = Path(path) / _PROBE_NAME
+    path = Path(path)
     try:
-        probe.write_bytes(b"modelark")
-        ok = probe.read_bytes() == b"modelark"
-        probe.unlink()
-        return ok
+        os.statvfs(path)
     except OSError:
-        try:
-            probe.unlink()
-        except OSError:
-            pass
         return False
+    return path.is_dir() and os.access(path, os.R_OK)
 
 
 def _await_drive(ctx, label: str, poll_secs: float) -> bool:

--- a/modelark/fill.py
+++ b/modelark/fill.py
@@ -61,7 +61,7 @@ def _await_drive(ctx, label: str, poll_secs: float) -> bool:
         return True
     if mounted and _writable(ctx, label):
         return True
-    reason = "insert it" if not mounted else "mounted but not writable (I/O error) — re-seat it"
+    reason = "insert it" if not mounted else "mounted but not ready/readable (I/O error) — re-seat it"
     ctx.on_progress({
         "phase": "awaiting-drive", "awaiting_drive": label,
         "say": f"⏳ drive {label}: {reason} — the fill continues once it's writable.",

--- a/modelark/register.py
+++ b/modelark/register.py
@@ -338,6 +338,17 @@ def _add_to_active_plan(con, label: str) -> str:
     return ap["plan_id"]
 
 
+def _guard_existing_label(con, label: str) -> None:
+    """Refuse (re-)registering a label that already owns a drive row, BEFORE any physical, remote, or
+    catalog mutation. A blunt existing-label guard — never an identity comparison, refresh, or reuse:
+    collision-safe re-registration and retirement are the deferred lifecycle workflow (DEF-029)."""
+    if con.execute("SELECT 1 FROM drives WHERE drive_label=?", [label]).fetchone():
+        raise RuntimeError(
+            f"drive label '{label}' is already registered — re-registration is not supported here. "
+            f"Use the drive lifecycle workflow (identity-aware re-registration / retirement, DEF-029) "
+            f"to change or replace an existing drive.")
+
+
 def register_drive(dev: str, label: str, mount: str | None = None,
                    format_fs: str | None = None, location: str | None = None,
                    library: str | None = None, dry_run: bool = False,
@@ -348,6 +359,11 @@ def register_drive(dev: str, label: str, mount: str | None = None,
     redundancy is the array's, integrity is our sha256 + canary, so SMART is skipped.
     `skip_smart` (INC-002) registers a drive whose USB bridge won't pass SMART with an
     'unchecked' verdict — an explicit operator override; verify health externally."""
+    con = db.connect()
+    try:
+        _guard_existing_label(con, label)      # before SMART, dry-run, or any physical/remote/catalog mutation
+    finally:
+        con.close()
     if confirm_format and not format_fs:
         raise ValueError("--confirm-format is valid only together with --format")
     if format_fs and not osplat.BLOCKDEV_OPS_SUPPORTED:
@@ -490,6 +506,11 @@ def register_nas(remote: str = "nas", label: str = "drive-99", role: str = "repl
     librarian target. No SMART/mkfs — the special remote already receives content via
     `git annex copy --to <remote>`. Reads its uuid + directory from the map repo config, and
     the free/total from the mount the directory lives on (DEC-006, DEC-014)."""
+    con = db.connect()
+    try:
+        _guard_existing_label(con, label)      # before library/remote inspection or the catalog upsert
+    finally:
+        con.close()
     lib = library_root()
     uuid = _git(lib, "config", f"remote.{remote}.annex-uuid", check=False)
     directory = _git(lib, "config", f"remote.{remote}.annex-directory", check=False)

--- a/modelark/restore.py
+++ b/modelark/restore.py
@@ -47,12 +47,16 @@ def _run_annex(archive: Path, *args: str) -> subprocess.CompletedProcess:
         return subprocess.CompletedProcess(args, 127, "", str(exc))
 
 
-def _annex_content(archive: Path, row: dict, stored: Path) -> tuple[Path | None, bool, str]:
-    """Return readable content, asking git-annex to retrieve a dropped blob when possible."""
+def _annex_content(archive: Path, row: dict, stored: Path, *, may_mutate: bool) -> tuple[Path | None, bool, str]:
+    """Return readable content, asking git-annex to retrieve a dropped blob when that retrieval would not
+    mutate an authoritative drive. Local content is always returned as-is (no mutation)."""
     if stored.exists():
         return stored, False, "available"
     if not (archive / ".git").exists():
         return None, False, "recorded blob is missing (archive is not a git-annex checkout)"
+    if not may_mutate:
+        return (None, False, "recorded copy is dropped and retrieval is refused: it would mutate an "
+                "authoritative (dedicated_local) drive and invalidate its clean anchor")
 
     rel = stored.relative_to(archive).as_posix()
     result = _run_annex(archive, "get", "--", rel)
@@ -140,6 +144,14 @@ def _rows(con, repo_id: str) -> dict[str, list[dict]]:
     return grouped
 
 
+def _may_mutate(con, drive: str) -> bool:
+    """Retrieval may mutate a drive UNLESS it is authoritative (write_authority='dedicated_local'): an
+    authoritative drive holds a clean anchor that a git-annex get would invalidate. A missing/unknown
+    drive row is non-authoritative (no anchor to protect), so retrieval is allowed there."""
+    row = con.execute("SELECT write_authority FROM drives WHERE drive_label=?", [drive]).fetchone()
+    return not (row and row[0] == "dedicated_local")
+
+
 def restore_repo(con, repo_id: str, output_root: str | Path) -> dict:
     """Restore one repo below ``output_root`` and return an operator-facing summary.
 
@@ -207,7 +219,8 @@ def restore_repo(con, repo_id: str, output_root: str | Path) -> dict:
                     attempts.append(f"{drive}: {exc}")
                     continue
                 stored = Path(archive) / Path(*repo_rel.parts) / Path(*stored_rel.parts)
-                source, retrieved, source_detail = _annex_content(Path(archive), row, stored)
+                source, retrieved, source_detail = _annex_content(
+                    Path(archive), row, stored, may_mutate=_may_mutate(con, drive))
                 if source is None:
                     attempts.append(f"{drive}: {source_detail}")
                     continue

--- a/tests/test_register_safety.py
+++ b/tests/test_register_safety.py
@@ -73,7 +73,7 @@ def test_existing_label_guard_refuses_only_an_existing_label():
         assert "existing" in str(exc).lower(), exc
 
 
-def test_register_drive_refuses_existing_label_before_any_mutation(tmp_path):
+def test_register_drive_refuses_existing_label_before_any_mutation():
     """register_drive refuses an already-registered label BEFORE the dry-run preview and before any
     physical/remote/catalog mutation (SMART/mkfs/mount/clone/upsert) — re-registration can never silently
     rewrite the row."""

--- a/tests/test_register_safety.py
+++ b/tests/test_register_safety.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import stat
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
 from modelark import register
+from modelark.core import db
 
 
 def _cp(stdout="", returncode=0, stderr=""):
@@ -46,6 +49,63 @@ def _must_refuse(topology, message, **kwargs):
         raise AssertionError("unsafe target must be refused")
     except RuntimeError as exc:
         assert message in str(exc), exc
+
+
+# ---- PR-03c2: a blunt existing-label guard shared by both registration entry points -------------
+
+def _mem():
+    con = sqlite3.connect(":memory:", isolation_level=None)
+    for statement in db._statements(db.SCHEMA_PATH.read_text()):
+        con.execute(statement)
+    return con
+
+
+def test_existing_label_guard_refuses_only_an_existing_label():
+    """One tiny private guard refuses a label that already owns a `drives` row and passes a fresh one —
+    a blunt existing-label check with NO identity comparison or lifecycle behavior (DEF-029 owns reuse)."""
+    con = _mem()
+    con.execute("INSERT INTO drives(drive_label) VALUES('existing')")
+    register._guard_existing_label(con, "fresh")                     # an unused label -> no refusal
+    try:
+        register._guard_existing_label(con, "existing")
+        raise AssertionError("an already-registered label must be refused")
+    except RuntimeError as exc:
+        assert "existing" in str(exc).lower(), exc
+
+
+def test_register_drive_refuses_existing_label_before_any_mutation(tmp_path):
+    """register_drive refuses an already-registered label BEFORE the dry-run preview and before any
+    physical/remote/catalog mutation (SMART/mkfs/mount/clone/upsert) — re-registration can never silently
+    rewrite the row."""
+    con = _mem()
+    con.execute("INSERT INTO drives(drive_label) VALUES('existing')")
+    with mock.patch.object(register.db, "connect", return_value=con), \
+         mock.patch.object(register, "_transport", return_value="usb"), \
+         mock.patch.object(register, "smart_baseline") as smart, \
+         mock.patch.object(register, "_mkfs") as mkfs:
+        try:
+            register.register_drive(dev="/dev/fake", label="existing", dry_run=True)
+            raise AssertionError("an existing label must be refused, even for --dry-run")
+        except RuntimeError as exc:
+            assert "existing" in str(exc).lower(), exc
+    smart.assert_not_called()
+    mkfs.assert_not_called()
+
+
+def test_register_nas_refuses_existing_label():
+    """register_nas shares the same guard — it must not upsert over an existing label's row, which could
+    transfer an authoritative local drive's claims to a special remote."""
+    con = _mem()
+    con.execute("INSERT INTO drives(drive_label) VALUES('existing')")
+    with mock.patch.object(register.db, "connect", return_value=con), \
+         mock.patch.object(register, "library_root", return_value=Path("/fake/lib")), \
+         mock.patch.object(register, "_git", return_value="x"), \
+         mock.patch.object(register, "_add_to_active_plan", return_value="ark"):
+        try:
+            register.register_nas(label="existing")
+            raise AssertionError("an existing label must be refused")
+        except RuntimeError as exc:
+            assert "existing" in str(exc).lower(), exc
 
 
 def test_unmounted_plain_disk_is_accepted():

--- a/tests/test_replan.py
+++ b/tests/test_replan.py
@@ -2,7 +2,8 @@
 half-empty NAS, and a mounted-but-dead drive getting its whole assignment silently skipped).
 
 Covers:
-  • _writable          — probes real writability (mounted != healthy); OSError → False.
+  • _writable          — a CHEAP, NON-MUTATING readiness check (mount + statvfs + readability); no probe
+                         write/unlink (real writeability is proven inside the mutation envelope, post-dirty).
   • _await_drive       — a mounted-but-UNWRITABLE drive is awaited, never accepted (no silent skip).
   • execute() re-plan  — the primary tier re-plans each pass, fills the priority drive first, then
                          advances, then does replica copy #2, and TERMINATES (GATE-C ok).
@@ -31,16 +32,21 @@ def _passthru_mutation(*_a, **_k):
 
 # ---- the write-probe --------------------------------------------------------------------------
 
-def test_writable_probe(tmp_path):
+def test_readiness_check_is_read_only(tmp_path):
+    """PR-03c2: _writable is a cheap, NON-MUTATING readiness check — mount resolution + statvfs +
+    directory readability, never a probe write/read/unlink (real writeability is proven inside the
+    mutation envelope, post-dirty). It keeps its boolean signature."""
     ctx = fetch.RunCtx(con=None)
-    with mock.patch.object(fill.register, "archive_path", side_effect=lambda con, l: tmp_path):
-        assert fill._writable(ctx, "drive-00") is True                 # real writable dir
-        assert not (tmp_path / fill._PROBE_NAME).exists(), "probe file must be cleaned up"
-    missing = tmp_path / "gone" / "deeper"                             # parent absent → write raises → False
-    with mock.patch.object(fill.register, "archive_path", side_effect=lambda con, l: missing):
-        assert fill._writable(ctx, "drive-00") is False
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    with mock.patch.object(fill.register, "archive_path", side_effect=lambda con, l: archive), \
+         mock.patch.object(Path, "write_bytes", side_effect=AssertionError("readiness must not write a probe")), \
+         mock.patch.object(Path, "unlink", side_effect=AssertionError("readiness must not unlink a probe")):
+        assert fill._writable(ctx, "drive-00") is True                 # ready dir — no probe written/removed
     with mock.patch.object(fill.register, "archive_path", side_effect=lambda con, l: None):
-        assert fill._writable(ctx, "drive-00") is False               # unmounted → False
+        assert fill._writable(ctx, "drive-00") is False               # unresolvable/unmounted → False
+    with mock.patch.object(fill.register, "archive_path", side_effect=lambda con, l: tmp_path / "gone"):
+        assert fill._writable(ctx, "drive-00") is False               # absent dir → statvfs fails → False
 
 
 # ---- _await_drive: never accept a mounted-but-dead drive ------------------------------------

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -106,6 +106,102 @@ def test_restore_asks_git_annex_for_dropped_content(tmp_path):
     ), calls
 
 
+# ---- PR-03c2: restore must not MUTATE an authoritative drive to retrieve a dropped blob ---------
+
+def _authoritative(con, label):
+    con.execute("INSERT INTO drives(drive_label, write_authority) VALUES(?, 'dedicated_local')", [label])
+
+
+def _unknown_drive(con, label):
+    con.execute("INSERT INTO drives(drive_label, write_authority) VALUES(?, 'unknown')", [label])
+
+
+def test_restore_suppresses_annex_get_on_an_authoritative_drive(tmp_path):
+    """A restore must not mutate an authoritative (dedicated_local) archive to fetch a dropped blob —
+    `git annex get` is suppressed even if the current generation is dirty. With no other recorded copy,
+    restore fails with ONE clear typed error rather than silently invalidating the drive's anchor."""
+    con = _mem()
+    repo, name, data = "org/model", "nested/config.json", b"from annex"
+    digest = _file(con, repo, name, data, "aux")
+    _authoritative(con, "drive-00")
+    archive = tmp_path / "drive"
+    (archive / ".git").mkdir(parents=True)                           # git-annex checkout, content DROPPED
+    _archived(con, repo, name, name, "drive-00", digest, False, f"SHA256E-s{len(data)}--{digest}.json")
+    calls = []
+
+    def annex(repo_path, *args):
+        calls.append(args)
+        if args[:2] == ("get", "--"):                                # today this retrieves; the guard forbids it
+            (archive / "org" / "model" / "nested").mkdir(parents=True, exist_ok=True)
+            (archive / "org" / "model" / name).write_bytes(data)
+            return subprocess.CompletedProcess(args, 0, "", "")
+        return subprocess.CompletedProcess(args, 1, "", "unexpected")
+
+    with mock.patch.object(restore.register, "archive_path", return_value=archive), \
+         mock.patch.object(restore, "_run_annex", side_effect=annex):
+        try:
+            restore.restore_repo(con, repo, tmp_path / "out")
+            raise AssertionError("retrieval that would mutate an authoritative drive must be refused")
+        except restore.RestoreError:
+            pass
+    assert not any(a and a[0] == "get" for a in calls), \
+        f"git annex get must be suppressed on an authoritative drive: {calls}"
+
+
+def test_restore_reads_local_content_on_an_authoritative_drive_unchanged(tmp_path):
+    """The guard suppresses only MUTATION: content already present on an authoritative drive restores
+    exactly as before, with no annex retrieval."""
+    con = _mem()
+    repo, name, data = "org/model", "nested/config.json", b"present locally"
+    digest = _file(con, repo, name, data, "aux")
+    _authoritative(con, "drive-00")
+    archive = tmp_path / "drive"
+    stored = archive / "org" / "model" / name
+    stored.parent.mkdir(parents=True)
+    stored.write_bytes(data)                                         # content LOCAL — no retrieval needed
+    _archived(con, repo, name, name, "drive-00", digest, False, f"SHA256E-s{len(data)}--{digest}.json")
+    calls = []
+    with mock.patch.object(restore.register, "archive_path", return_value=archive), \
+         mock.patch.object(restore, "_run_annex", side_effect=lambda *a: calls.append(a[1:])):
+        result = restore.restore_repo(con, repo, tmp_path / "out")
+    assert (tmp_path / "out" / "org" / "model" / name).read_bytes() == data
+    assert calls == [] and result["annex_retrievals"] == 0, f"local content needs no annex retrieval: {calls}"
+
+
+def test_restore_falls_back_from_authoritative_to_a_retrievable_copy(tmp_path):
+    """The authoritative copy (tried first, ORDER BY drive_label) is skipped rather than mutated, and the
+    recorded fallback copy on a non-authoritative drive — which has no anchor to invalidate — retrieves
+    normally, so restore completes."""
+    con = _mem()
+    repo, name, data = "org/model", "nested/config.json", b"fallback bytes"
+    digest = _file(con, repo, name, data, "aux")
+    _authoritative(con, "drive-00")                                  # tried first
+    _unknown_drive(con, "drive-01")
+    arch0, arch1 = tmp_path / "d0", tmp_path / "d1"
+    (arch0 / ".git").mkdir(parents=True)
+    (arch1 / ".git").mkdir(parents=True)
+    key = f"SHA256E-s{len(data)}--{digest}.json"
+    _archived(con, repo, name, name, "drive-00", digest, False, key)
+    _archived(con, repo, name, name, "drive-01", digest, False, key)
+    mounts = {"drive-00": arch0, "drive-01": arch1}
+    calls = []
+
+    def annex(repo_path, *args):
+        calls.append((Path(repo_path).name, args))
+        if args[:2] == ("get", "--") and Path(repo_path) == arch1:   # only the non-authoritative copy retrieves
+            (arch1 / "org" / "model" / "nested").mkdir(parents=True, exist_ok=True)
+            (arch1 / "org" / "model" / name).write_bytes(data)
+            return subprocess.CompletedProcess(args, 0, "", "")
+        return subprocess.CompletedProcess(args, 1, "", "unavailable")
+
+    with mock.patch.object(restore.register, "archive_path", side_effect=lambda c, d: mounts[d]), \
+         mock.patch.object(restore, "_run_annex", side_effect=annex):
+        restore.restore_repo(con, repo, tmp_path / "out")
+    assert (tmp_path / "out" / "org" / "model" / name).read_bytes() == data
+    assert not any(where == "d0" and args[0] == "get" for where, args in calls), \
+        f"the authoritative copy (drive-00 → d0) must not be retrieved by mutation: {calls}"
+
+
 def test_restore_real_git_annex_roundtrip(tmp_path):
     if shutil.which("git-annex") is None:
         return


### PR DESCRIPTION
Merges into `fix/placement-capacity-hardening` (never `main`). **PR-03c2** — the minimal non-Fill mutation closure. Implementation complete (Gate 2).

Three small guard/replacement seams (three production files + focused tests; no new module/command/schema):

- **`fill.py` readiness** — `_writable` is now a cheap, **non-mutating** readiness check: `archive_path` resolves + `os.statvfs` + directory readability (`is_dir` + `R_OK`). No probe write/unlink, no identity subprocess; the dead `_PROBE_NAME` is removed. Real writeability and authoritative identity proof stay inside the mutation envelope (post-dirty).
- **`restore.py` guard** — `_annex_content(..., may_mutate=…)` suppresses `git annex get` on an authoritative (`write_authority='dedicated_local'`) drive **even if the generation is dirty**; a missing/unknown drive row is non-authoritative and may retrieve. `restore_repo` derives `may_mutate` per drive via `_may_mutate()`; local-present content restores unchanged, the recorded-copy fallback continues, and a fully-unretrievable set yields one aggregated `RestoreError`.
- **`register.py` guard** — one private `_guard_existing_label(con, label)` refuses an already-registered label; `register_drive` and `register_nas` both call it **first** — before SMART, dry-run, library/remote inspection, or any mutation. Blunt existing-label guard only; identity comparison / refresh / reuse / retirement remain **DEF-029**.

## Validation
Seam files 51 passed (6 Gate-1 change-contract tests now GREEN + preserve + pre-existing); full suite **362 passed**; `ruff check modelark scripts tests` clean; the three seam files exit 0 as CI scripts.

## Non-goals held
No restore envelope; no auto-reconcile after registration; no session recovery/tokens; no replacement/retirement/label-reuse; no admission cutover; no touching verifier/hash-repair/reset/legacy-replica. One PR; one Greptile pass at this gate.

## Safety
Synthetic catalogs, temp trees, and mocked physical/annex seams only — no live service/catalog/drive touched. The local `.gitignore` change was never staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCUcZdiUBs8sF2GbLvf49Q
