### PR TITLE
PR-05 (#36a): canonical requirements/candidates — pure core + reconcile façade

### DIFF
--- a/modelark/budgets.py
+++ b/modelark/budgets.py
@@ -1,0 +1,96 @@
+"""Shared pure budget seam for capacity planning and #36a candidate construction (RFC-002 / DEC-049).
+
+One budget truth. Both the legacy ``capacity`` tiered_v1 path and the canonical ``candidates`` core
+compute per-file durable/workspace budgets here, so they cannot drift. Pure: no SQLite, filesystem,
+configuration, clock, or network access — graph-affecting compression config and the observed float
+ratio are passed in as data by the impure shell (they are never read from ``wishlist`` here).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from modelark import archive_manifest, compress, streamznn
+
+# The estimate margin lives here (the single owner) and is re-exported by ``capacity`` for compatibility.
+EXPECTED_MARGIN = 1.08
+
+
+@dataclass(frozen=True)
+class FileBudget:
+    rfilename: str
+    guaranteed_durable: int
+    expected_durable: int
+    workspace_peak_guaranteed: int
+    workspace_peak_expected: int
+    evidence: str
+
+    def durable_for(self, guaranteed: bool) -> int:
+        return self.guaranteed_durable if guaranteed else self.expected_durable
+
+    def workspace_for(self, guaranteed: bool) -> int:
+        return self.workspace_peak_guaranteed if guaranteed else self.workspace_peak_expected
+
+
+@dataclass(frozen=True)
+class CandidateBudget:
+    guaranteed_durable: int
+    expected_durable: int
+    workspace_peak_guaranteed: int
+    workspace_peak_expected: int
+    file_budgets: tuple[FileBudget, ...]
+
+
+def expected_durable_bytes(item: archive_manifest.ManifestFile, ratio: float) -> int:
+    """Estimate-mode durable bytes: compressible float shards shrink by ``ratio``; all inflate by the
+    versioned safety margin. Identical to the legacy ``capacity._expected_file_bytes``."""
+    basis = item.size_bytes * ratio if item.storage_action == "compress" else item.size_bytes
+    return int(basis * EXPECTED_MARGIN)
+
+
+def file_budget(
+    item: archive_manifest.ManifestFile,
+    ratio: float,
+    compression_cfg,
+    *,
+    exact_source_bytes: int | None = None,
+    replica: bool = False,
+) -> FileBudget:
+    """One per-file budget for every mode:
+
+    * download (default): guaranteed = raw size, expected = ratio/margin estimate, workspace = the
+      codec's peak output cap chosen from the injected ``compression_cfg`` (direct ``cfg[...]`` access —
+      no invented defaults);
+    * replica with a proven exact source (``exact_source_bytes``): a copy transfers exactly the stored
+      bytes, so every field is that size and evidence is ``exact``;
+    * replica estimate (``replica=True``, source pending): every field is the ratio/margin estimate.
+    """
+    if exact_source_bytes is not None:
+        value = int(exact_source_bytes)
+        return FileBudget(item.rfilename, value, value, value, value, "exact")
+    if replica:
+        value = expected_durable_bytes(item, ratio)
+        return FileBudget(item.rfilename, value, value, value, value, "estimate")
+
+    expected = expected_durable_bytes(item, ratio)
+    workspace_g = workspace_e = 0
+    if item.storage_action == "compress":
+        codec = compress.plan_codec(item.size_bytes, dict(compression_cfg))
+        if codec != compress.CODEC_RAW:
+            output_cap = compress.codec_output_cap(
+                item.size_bytes, codec, stream_chunk_bytes=streamznn.DEFAULT_CHUNK
+            )
+            workspace_g = output_cap
+            workspace_e = max(0, item.size_bytes + output_cap - expected)
+    return FileBudget(item.rfilename, item.size_bytes, expected, workspace_g, workspace_e, "estimate")
+
+
+def aggregate(file_budgets) -> CandidateBudget:
+    """Roll per-file budgets into a task/candidate budget: durable sums, workspace peaks max."""
+    budgets = tuple(file_budgets)
+    return CandidateBudget(
+        guaranteed_durable=sum(item.guaranteed_durable for item in budgets),
+        expected_durable=sum(item.expected_durable for item in budgets),
+        workspace_peak_guaranteed=max((item.workspace_peak_guaranteed for item in budgets), default=0),
+        workspace_peak_expected=max((item.workspace_peak_expected for item in budgets), default=0),
+        file_budgets=budgets,
+    )

--- a/modelark/candidates.py
+++ b/modelark/candidates.py
@@ -1,0 +1,366 @@
+"""Pure requirement & candidate construction for placement approval (RFC-002 / DEC-049, issue #36a).
+
+The functional core. From an immutable :class:`PlannerInput` it derives, for every desired copy, either
+canonical proof that the copy is already satisfied or the full set of reusable-work alternatives — every
+verified finish-in-place partial and every policy-permitted fresh target — with exact reuse/provenance,
+exact missing-file identity, deterministic costs, and singular replica sources. It chooses nothing:
+feasibility, ranking, and target selection are #38.
+
+Pure: no SQLite, filesystem, configuration, clock, or network access. The impure shell
+(:func:`modelark.reconcile.capture_planner_input`) captures catalog facts in one consistent read
+transaction and freezes config/ratio into the input as data. Budgets come from the shared
+:mod:`modelark.budgets` seam so the legacy capacity path and this core cannot drift.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+
+from modelark import archive_manifest, budgets
+from modelark.budgets import CandidateBudget, FileBudget  # noqa: F401 — re-exported: one shared budget truth
+
+
+class RequirementKind(str, Enum):
+    PRIMARY = "primary"
+    PROTECTED_HOME = "protected_home"
+    PROTECTED_REPLICA = "protected_replica"
+
+
+class TaskKind(str, Enum):
+    FETCH = "fetch"
+    REPLICATE = "replicate"
+
+
+class ProofSource(str, Enum):
+    MANIFEST_SHA256 = "manifest_sha256"          # upstream LFS hash present and matched
+    ARCHIVED_ORIG_SHA256 = "archived_orig_sha256"  # hashless manifest bound by a non-null archived hash
+
+
+@dataclass(frozen=True)
+class DriveFact:
+    drive_label: str
+    role: str
+    raid_backed: bool
+    capacity_bytes: int
+    filesystem_capacity_bytes: int | None
+    identity_epoch: int
+    fs_uuid: str | None = None
+    annex_uuid: str | None = None
+    serial: str | None = None
+
+
+@dataclass(frozen=True)
+class ArchivedFileFact:
+    repo_id: str
+    drive_label: str
+    rfilename: str
+    orig_sha256: str | None
+    orig_bytes: int | None
+    stored_bytes: int | None
+    annex_key: str | None = None
+
+
+@dataclass(frozen=True)
+class CopyRequirement:
+    requirement_id: str
+    repo_id: str
+    kind: RequirementKind
+    eligible_drives: tuple[str, ...]
+    independent_of: str | None = None
+
+
+@dataclass(frozen=True)
+class RequirementGraph:
+    desired: tuple[CopyRequirement, ...]
+    requirement_set_hash: str
+
+
+@dataclass(frozen=True)
+class ReusableFile:
+    rfilename: str
+    size_bytes: int
+    bound_hash: str
+    proof_source: ProofSource
+
+
+@dataclass(frozen=True)
+class SourceIdentity:
+    """The exact drive a replica copies from. Singular per candidate: differing stored sizes/annex keys
+    across complete homes cannot share one exact budget, so each proven home yields its own candidate."""
+    drive_label: str
+    annex_key: str | None
+    orig_sha256: str | None
+
+
+@dataclass(frozen=True)
+class PendingHome:
+    """A replica source whose home target is not yet resolved; #38 resolves it to an exact drive."""
+    requirement_id: str
+
+
+@dataclass(frozen=True)
+class MovementCost:
+    transfer_bytes: int          # fetch: raw acquisition bytes; replica: stored transfer from its source
+
+
+@dataclass(frozen=True)
+class Candidate:
+    requirement_id: str
+    task_kind: TaskKind
+    target_drive: str
+    source: SourceIdentity | PendingHome | None
+    depends_on_requirement: str | None
+    reused_files: tuple[ReusableFile, ...]
+    missing_files: tuple[archive_manifest.ManifestFile, ...]
+    budget: CandidateBudget
+    movement_cost: MovementCost
+
+
+@dataclass(frozen=True)
+class SatisfiedCopy:
+    drive_label: str
+    reused_files: tuple[ReusableFile, ...]
+    source_identity: SourceIdentity | None
+
+
+@dataclass(frozen=True)
+class Satisfaction:
+    requirement_id: str
+    copies: tuple[SatisfiedCopy, ...]
+
+
+@dataclass(frozen=True)
+class DriftRow:
+    """A required-file archived row that cannot back canonical work: an unproven/mismatched row on a
+    policy-permitted target (its target is omitted, never silently overwritten), or a proven copy on a
+    non-eligible drive (no annex-to-annex relocation candidate). Preserved for operator visibility."""
+    requirement_id: str
+    drive_label: str
+    rfilename: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class CandidateSet:
+    satisfied: tuple[Satisfaction, ...]
+    by_requirement: tuple[tuple[str, tuple[Candidate, ...]], ...]
+    drift: tuple[DriftRow, ...]
+
+
+@dataclass(frozen=True)
+class PlannerInput:
+    plan_id: str
+    selection: tuple[str, ...]
+    manifests: tuple[tuple[str, tuple[archive_manifest.ManifestFile, ...]], ...]
+    numcopies: tuple[tuple[str, int], ...]
+    drives: tuple[DriveFact, ...]
+    archived: tuple[ArchivedFileFact, ...]
+    compression_cfg: tuple[tuple[str, object], ...]
+    float_ratio: float
+
+
+# ------------------------------------------------------------------------------------------------
+# Requirements
+# ------------------------------------------------------------------------------------------------
+def requirements(inp: PlannerInput) -> RequirementGraph:
+    """Desired copy set: numcopies<2 → one primary copy; numcopies≥2 → a protected home plus an
+    independent replica. Home eligibility is RAID-backed primaries, or (no-RAID fallback for this slice)
+    the single largest primary. Only repositories with a supported manifest yield requirements."""
+    by_label = {d.drive_label: d for d in inp.drives}
+    order = sorted(by_label)
+    primary = tuple(label for label in order if by_label[label].role == "primary")
+    raids = tuple(label for label in primary if by_label[label].raid_backed)
+    replicas = tuple(label for label in order if by_label[label].role == "replica")
+    fallback: tuple[str, ...] = ()
+    if not raids and primary:
+        fallback = (sorted(primary, key=lambda label: (-by_label[label].capacity_bytes, label))[0],)
+
+    numcopies = dict(inp.numcopies)
+    desired: list[CopyRequirement] = []
+    for repo, _manifest in inp.manifests:
+        if int(numcopies.get(repo, 1) or 1) < 2:
+            desired.append(CopyRequirement(f"primary:{repo}", repo, RequirementKind.PRIMARY, primary))
+            continue
+        home_id = f"protected_home:{repo}"
+        desired.append(CopyRequirement(home_id, repo, RequirementKind.PROTECTED_HOME, raids or fallback))
+        desired.append(CopyRequirement(
+            f"protected_replica:{repo}", repo, RequirementKind.PROTECTED_REPLICA, replicas,
+            independent_of=home_id))
+
+    desired.sort(key=lambda item: item.requirement_id)
+    return RequirementGraph(tuple(desired), _hash_requirements(desired))
+
+
+def _hash_requirements(desired) -> str:
+    payload = [
+        [item.requirement_id, item.repo_id, item.kind.value,
+         list(item.eligible_drives), item.independent_of]
+        for item in sorted(desired, key=lambda item: item.requirement_id)
+    ]
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ------------------------------------------------------------------------------------------------
+# Candidates
+# ------------------------------------------------------------------------------------------------
+def _proof(mf: archive_manifest.ManifestFile, row: ArchivedFileFact | None) -> str:
+    """Reuse-proof verdict for one required file on one drive: ``missing`` (no row → safe to fetch),
+    ``proven`` (provenance binds), or ``unproven`` (a row exists but its provenance does not bind)."""
+    if row is None:
+        return "missing"
+    if row.orig_bytes != mf.size_bytes:                       # size gate — both branches
+        return "unproven"
+    if mf.sha256 is not None:
+        return "proven" if row.orig_sha256 == mf.sha256 else "unproven"
+    return "proven" if row.orig_sha256 is not None else "unproven"  # hashless residual: any non-null hash
+
+
+def _reusable(mf: archive_manifest.ManifestFile, row: ArchivedFileFact) -> ReusableFile:
+    if mf.sha256 is not None:
+        return ReusableFile(mf.rfilename, mf.size_bytes, mf.sha256, ProofSource.MANIFEST_SHA256)
+    return ReusableFile(mf.rfilename, mf.size_bytes, row.orig_sha256, ProofSource.ARCHIVED_ORIG_SHA256)
+
+
+def _source_key(source) -> tuple[str, str]:
+    if isinstance(source, SourceIdentity):
+        return ("source", source.drive_label)
+    if isinstance(source, PendingHome):
+        return ("pending", source.requirement_id)
+    return ("", "")
+
+
+def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
+    manifests = dict(inp.manifests)
+    cfg = dict(inp.compression_cfg)
+    ratio = inp.float_ratio
+    eligible_all = {d.drive_label for d in inp.drives}
+    archived: dict[tuple[str, str], dict[str, ArchivedFileFact]] = {}
+    for row in inp.archived:
+        archived.setdefault((row.repo_id, row.drive_label), {})[row.rfilename] = row
+    reqs_by_id = {item.requirement_id: item for item in graph.desired}
+
+    satisfied: list[Satisfaction] = []
+    by_requirement: list[tuple[str, tuple[Candidate, ...]]] = []
+    drift: list[DriftRow] = []
+
+    for req in graph.desired:
+        manifest = manifests[req.repo_id]
+        eligible = req.eligible_drives
+
+        complete: list[tuple[str, tuple[ReusableFile, ...]]] = []
+        valid: list[tuple[str, tuple[ReusableFile, ...], tuple[archive_manifest.ManifestFile, ...]]] = []
+        for label in eligible:
+            rows = archived.get((req.repo_id, label), {})
+            reused: list[ReusableFile] = []
+            missing: list[archive_manifest.ManifestFile] = []
+            blocked = False
+            for mf in manifest:
+                verdict = _proof(mf, rows.get(mf.rfilename))
+                if verdict == "missing":
+                    missing.append(mf)
+                elif verdict == "proven":
+                    reused.append(_reusable(mf, rows[mf.rfilename]))
+                else:
+                    drift.append(DriftRow(req.requirement_id, label, mf.rfilename, "unproven_provenance"))
+                    blocked = True
+            if blocked:
+                continue                                   # target omitted — never overwrite an unproven row
+            reused_t = tuple(sorted(reused, key=lambda item: item.rfilename))
+            if missing:
+                valid.append((label, reused_t, tuple(sorted(missing, key=lambda item: item.rfilename))))
+            else:
+                complete.append((label, reused_t))
+
+        # Wrong-tier: a proven-complete copy on a non-eligible drive is drift, not a relocation candidate.
+        for label in sorted(eligible_all - set(eligible)):
+            rows = archived.get((req.repo_id, label), {})
+            if rows and all(_proof(mf, rows.get(mf.rfilename)) == "proven" for mf in manifest):
+                for mf in manifest:
+                    drift.append(DriftRow(req.requirement_id, label, mf.rfilename, "wrong_tier"))
+
+        if complete:
+            copies = tuple(
+                SatisfiedCopy(label, reused, None)
+                for label, reused in sorted(complete, key=lambda item: item[0])
+            )
+            satisfied.append(Satisfaction(req.requirement_id, copies))
+            continue
+
+        cands: list[Candidate] = []
+        sources = _home_sources(req, reqs_by_id, manifest, archived) \
+            if req.kind == RequirementKind.PROTECTED_REPLICA else ()
+        for label, reused, missing in valid:
+            if req.kind == RequirementKind.PROTECTED_REPLICA:
+                if sources:
+                    for source in sources:
+                        cands.append(_replica_candidate(req, label, reused, missing, source, cfg, ratio, archived))
+                else:
+                    pending = PendingHome(req.independent_of)
+                    cands.append(_replica_candidate(req, label, reused, missing, pending, cfg, ratio, archived))
+            else:
+                cands.append(_fetch_candidate(req, label, reused, missing, cfg, ratio))
+        if cands:
+            cands.sort(key=lambda c: (c.target_drive, _source_key(c.source), c.task_kind.value))
+            by_requirement.append((req.requirement_id, tuple(cands)))
+
+    satisfied.sort(key=lambda item: item.requirement_id)
+    by_requirement.sort(key=lambda item: item[0])
+    drift = sorted(set(drift), key=lambda item: (item.requirement_id, item.drive_label, item.rfilename, item.reason))
+    return CandidateSet(tuple(satisfied), tuple(by_requirement), tuple(drift))
+
+
+def _home_sources(req, reqs_by_id, manifest, archived) -> tuple[SourceIdentity, ...]:
+    home = reqs_by_id.get(req.independent_of)
+    if home is None:
+        return ()
+    sources: list[SourceIdentity] = []
+    for label in home.eligible_drives:
+        rows = archived.get((req.repo_id, label), {})
+        if rows and all(_proof(mf, rows.get(mf.rfilename)) == "proven" for mf in manifest):
+            key = orig = None
+            if len(manifest) == 1:                         # single-file convenience evidence
+                row = rows[manifest[0].rfilename]
+                key, orig = row.annex_key, row.orig_sha256
+            sources.append(SourceIdentity(label, key, orig))
+    return tuple(sorted(sources, key=lambda item: item.drive_label))
+
+
+def _fetch_candidate(req, target, reused, missing, cfg, ratio) -> Candidate:
+    file_budgets = tuple(budgets.file_budget(mf, ratio, cfg) for mf in missing)
+    budget = budgets.aggregate(file_budgets)
+    return Candidate(
+        requirement_id=req.requirement_id, task_kind=TaskKind.FETCH, target_drive=target,
+        source=None, depends_on_requirement=None, reused_files=reused, missing_files=missing,
+        budget=budget, movement_cost=MovementCost(budget.guaranteed_durable))
+
+
+def _replica_candidate(req, target, reused, missing, source, cfg, ratio, archived) -> Candidate:
+    if isinstance(source, SourceIdentity):
+        stored = archived.get((req.repo_id, source.drive_label), {})
+
+        def source_bytes(mf):
+            row = stored.get(mf.rfilename)
+            return int(row.stored_bytes) if row is not None and row.stored_bytes is not None else None
+
+        # Exact only when every missing file has a known positive stored size on the source; an unknown
+        # or zero stored size (unmeasured) falls back to the ratio/margin estimate, as the legacy path did.
+        exact = all((source_bytes(mf) or 0) > 0 or mf.size_bytes == 0 for mf in missing)
+        if exact:
+            file_budgets = tuple(
+                budgets.file_budget(mf, ratio, cfg, exact_source_bytes=source_bytes(mf) or 0)
+                for mf in missing
+            )
+        else:
+            file_budgets = tuple(budgets.file_budget(mf, ratio, cfg, replica=True) for mf in missing)
+        depends_on = None
+    else:                                                  # PendingHome
+        file_budgets = tuple(budgets.file_budget(mf, ratio, cfg, replica=True) for mf in missing)
+        depends_on = source.requirement_id
+    budget = budgets.aggregate(file_budgets)
+    return Candidate(
+        requirement_id=req.requirement_id, task_kind=TaskKind.REPLICATE, target_drive=target,
+        source=source, depends_on_requirement=depends_on, reused_files=reused, missing_files=missing,
+        budget=budget, movement_cost=MovementCost(budget.guaranteed_durable))

--- a/modelark/candidates.py
+++ b/modelark/candidates.py
@@ -143,10 +143,20 @@ class DriftRow:
 
 
 @dataclass(frozen=True)
+class BlockedRequirement:
+    """A desired requirement with no satisfying copy and no valid candidate: either no eligible tier at
+    all, or every eligible target holds an unproven/mismatched required row (all-targets-unproven). It is
+    an infeasibility, not a warning — every requirement is exactly one of satisfied/candidate/blocked."""
+    requirement_id: str
+    reason: str          # "no_eligible_tier" | "all_targets_unproven"
+
+
+@dataclass(frozen=True)
 class CandidateSet:
     satisfied: tuple[Satisfaction, ...]
     by_requirement: tuple[tuple[str, tuple[Candidate, ...]], ...]
     drift: tuple[DriftRow, ...]
+    blocked: tuple[BlockedRequirement, ...]
 
 
 @dataclass(frozen=True)
@@ -245,6 +255,7 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
     satisfied: list[Satisfaction] = []
     by_requirement: list[tuple[str, tuple[Candidate, ...]]] = []
     drift: list[DriftRow] = []
+    blocked: list[BlockedRequirement] = []
 
     for req in graph.desired:
         manifest = manifests[req.repo_id]
@@ -256,7 +267,7 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
             rows = archived.get((req.repo_id, label), {})
             reused: list[ReusableFile] = []
             missing: list[archive_manifest.ManifestFile] = []
-            blocked = False
+            target_blocked = False
             for mf in manifest:
                 verdict = _proof(mf, rows.get(mf.rfilename))
                 if verdict == "missing":
@@ -265,8 +276,8 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
                     reused.append(_reusable(mf, rows[mf.rfilename]))
                 else:
                     drift.append(DriftRow(req.requirement_id, label, mf.rfilename, "unproven_provenance"))
-                    blocked = True
-            if blocked:
+                    target_blocked = True
+            if target_blocked:
                 continue                                   # target omitted — never overwrite an unproven row
             reused_t = tuple(sorted(reused, key=lambda item: item.rfilename))
             if missing:
@@ -305,11 +316,17 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
         if cands:
             cands.sort(key=lambda c: (c.target_drive, _source_key(c.source), c.task_kind.value))
             by_requirement.append((req.requirement_id, tuple(cands)))
+        else:
+            # No satisfying copy and no valid candidate: an eligible drive that produced no candidate did
+            # so only because an unproven/mismatched required row omitted it. Account it as blocked.
+            reason = "no_eligible_tier" if not eligible else "all_targets_unproven"
+            blocked.append(BlockedRequirement(req.requirement_id, reason))
 
     satisfied.sort(key=lambda item: item.requirement_id)
     by_requirement.sort(key=lambda item: item[0])
     drift = sorted(set(drift), key=lambda item: (item.requirement_id, item.drive_label, item.rfilename, item.reason))
-    return CandidateSet(tuple(satisfied), tuple(by_requirement), tuple(drift))
+    blocked.sort(key=lambda item: item.requirement_id)
+    return CandidateSet(tuple(satisfied), tuple(by_requirement), tuple(drift), tuple(blocked))
 
 
 def _home_sources(req, reqs_by_id, manifest, archived) -> tuple[SourceIdentity, ...]:

--- a/modelark/capacity.py
+++ b/modelark/capacity.py
@@ -712,6 +712,12 @@ def plan_capacity(
     the only placement choice before #38 and is not canonical authority. Usable free comes from
     ``evidence_by_drive`` (the shared admission authority); a drive absent from it is fail-closed
     ``unknown`` and contributes zero executable capacity (#35-C)."""
+    if compression_cfg is not None:
+        # #36a: candidate budgets are captured during reconcile_plan() (from PlannerInput.compression_cfg),
+        # so a codec config here would be a safety-affecting no-op. Reject it loudly rather than mislead.
+        raise TypeError(
+            "plan_capacity(compression_cfg=...) is no longer honoured: candidate budgets are captured "
+            "during reconciliation. Pass compression_cfg to reconcile_plan()/capture_planner_input().")
     if provisioning is not None:
         warnings.warn(
             "plan_capacity(provisioning=...) is deprecated; use capacity_mode=...",
@@ -871,6 +877,38 @@ def plan_capacity(
         item for item in failures
         if not item.blocked_by_requirement or item.blocked_by_requirement not in root_failures
     ]
+
+    # Account for EVERY desired requirement (gap #1): exactly one of satisfied / assigned / unassigned /
+    # blocking. A requirement that had canonical candidates but whose targets all left the plan between
+    # reconcile_plan() and here is a typed stale-snapshot (TARGET_DRIVE_CHANGED); a requirement blocked at
+    # candidate time is already a blocking diagnostic. Anything else unaccounted is a graph defect.
+    accounted = (
+        {item.requirement_id for item in result.candidates.satisfied}
+        | {item.requirement_id for item in placement.tasks}
+        | {item.requirement_id for item in failures}
+        | {item.requirement_id for item in unassigned}          # failed to fit (failure may be dedup'd)
+        | {item.requirement_id for item in result.candidates.blocked}
+    )
+    had_candidates = {requirement_id for requirement_id, _ in result.candidates.by_requirement}
+    for requirement in result.requirements:
+        rid = requirement.requirement_id
+        if rid in accounted:
+            continue
+        stale = rid in had_candidates
+        is_replica = rid.startswith("protected_replica:")
+        failures.append(CapacityFailure(
+            code=FailureCode.TARGET_DRIVE_CHANGED if stale else FailureCode.GRAPH_INVARIANT,
+            capacity_mode=mode,
+            requirement_id=rid,
+            task_ids=(f"{'replicate' if is_replica else 'fetch'}:{rid}",),
+            target_tier=("replica" if is_replica else "primary"),
+            eligible_drives=requirement.eligible_drives,
+            required_bytes=0, available_bytes=0, safety_floor_bytes=0, workspace_bytes=0,
+            shortfall_bytes=0, evidence=None,
+            actions=(("reconcile_plan", "restore_target_drive_to_plan") if stale
+                     else ("inspect_integrity",)),
+        ))
+
     placement.tasks.sort(key=lambda item: (item.target_drive, item.kind.value, item.requirement_id))
     failures.sort(key=lambda item: (item.code.value, item.requirement_id or ""))
     return CapacityPlan(

--- a/modelark/capacity.py
+++ b/modelark/capacity.py
@@ -12,18 +12,18 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Mapping, Sequence
 
-from modelark import archive_manifest, capacity_evidence, compress, streamznn, wishlist
+from modelark import candidates, capacity_evidence, compress
+from modelark.budgets import CandidateBudget, EXPECTED_MARGIN, FileBudget  # shared budget truth (#36a)
 from modelark.reconcile import (
-    CopyFact,
     DiagnosticSeverity,
     ReconcileResult,
     TaskKind,
     WorkIntent,
 )
 
+__all__ = ["CandidateBudget", "EXPECTED_MARGIN", "FileBudget"]  # re-exported from the shared seam
 
 DEFAULT_FLOAT_RATIO = 0.67
-EXPECTED_MARGIN = 1.08
 RATIO_MIN_SAMPLE = 50_000_000_000
 RAID_MIN_HEADROOM_FRAC = 0.03
 _HEADROOM_TRANCHES = (
@@ -92,24 +92,6 @@ class CapacityDrive:
     def free_evidence(self) -> FreeEvidence | None:
         # One-release compatibility alias mapping the evidence kind to the legacy diagnostic enum.
         return {"live": FreeEvidence.LIVE, "anchor": FreeEvidence.SNAPSHOT}.get(self.evidence.kind)
-
-
-@dataclass(frozen=True)
-class FileBudget:
-    rfilename: str
-    guaranteed_durable: int
-    expected_durable: int
-    workspace_peak_guaranteed: int
-    workspace_peak_expected: int
-    evidence: str
-
-    def durable_for(self, mode: CapacityMode) -> int:
-        return (self.guaranteed_durable if mode == CapacityMode.GUARANTEED
-                else self.expected_durable)
-
-    def workspace_for(self, mode: CapacityMode) -> int:
-        return (self.workspace_peak_guaranteed if mode == CapacityMode.GUARANTEED
-                else self.workspace_peak_expected)
 
 
 @dataclass(frozen=True)
@@ -386,121 +368,28 @@ def inspect_drives(
     return tuple(facts)
 
 
-def _fact_by_repo_drive(result: ReconcileResult) -> dict[tuple[str, str], CopyFact]:
-    return {(item.repo_id, item.drive_label): item for item in result.facts}
-
-
-def _expected_file_bytes(item: archive_manifest.ManifestFile, ratio: float) -> int:
-    basis = item.size_bytes * ratio if item.storage_action == "compress" else item.size_bytes
-    return int(basis * EXPECTED_MARGIN)
-
-
-def _fetch_budget(
-    intent: WorkIntent,
-    target: str,
-    result: ReconcileResult,
-    ratio: float,
-    compression_cfg: Mapping[str, object],
-    facts: Mapping[tuple[str, str], CopyFact],
-) -> TaskBudget:
-    manifest = result.manifests[intent.repo_id]
-    present = facts.get((intent.repo_id, target))
-    present_names = present.present_files if present else frozenset()
-    missing = tuple(item for item in manifest if item.rfilename not in present_names)
-    file_budgets = []
-    chunk_bytes = streamznn.DEFAULT_CHUNK
-    for item in missing:
-        expected_file = _expected_file_bytes(item, ratio)
-        workspace_g = workspace_e = 0
-        if item.storage_action == "compress":
-            codec = compress.plan_codec(item.size_bytes, dict(compression_cfg))
-            if codec != compress.CODEC_RAW:
-                output_cap = codec_output_cap(
-                    item.size_bytes, codec, stream_chunk_bytes=chunk_bytes
-                )
-                workspace_g = output_cap
-                workspace_e = max(0, item.size_bytes + output_cap - expected_file)
-        file_budgets.append(FileBudget(
-            rfilename=item.rfilename,
-            guaranteed_durable=item.size_bytes,
-            expected_durable=expected_file,
-            workspace_peak_guaranteed=workspace_g,
-            workspace_peak_expected=workspace_e,
-            evidence="estimate",
-        ))
-    guaranteed = sum(item.guaranteed_durable for item in file_budgets)
-    expected = sum(item.expected_durable for item in file_budgets)
-    workspace_g = max((item.workspace_peak_guaranteed for item in file_budgets), default=0)
-    workspace_e = max((item.workspace_peak_expected for item in file_budgets), default=0)
+def _task_budget(candidate: candidates.Candidate) -> TaskBudget:
+    """Wrap a canonical Candidate's shared-seam budget as a capacity TaskBudget — no recomputation, so
+    the tiered_v1 adapter and the CandidateSet cannot drift. Candidates are the sole authority for the
+    reused/missing sets and their per-file budgets."""
+    budget = candidate.budget
+    source = candidate.source
+    source_drive = source.drive_label if isinstance(source, candidates.SourceIdentity) else None
+    evidence = budget.file_budgets[0].evidence if budget.file_budgets else "estimate"
     return TaskBudget(
-        task_id=intent.task_id,
-        requirement_id=intent.requirement_id,
-        repo_id=intent.repo_id,
-        kind=intent.kind,
-        target_drive=target,
-        source_drive=None,
-        missing_files=tuple(item.rfilename for item in missing),
-        file_budgets=tuple(file_budgets),
-        guaranteed_durable=guaranteed,
-        expected_durable=expected,
-        workspace_peak_guaranteed=workspace_g,
-        workspace_peak_expected=workspace_e,
-        evidence="estimate",
-    )
-
-
-def _replica_budget(
-    intent: WorkIntent,
-    target: str,
-    result: ReconcileResult,
-    ratio: float,
-    facts: Mapping[tuple[str, str], CopyFact],
-) -> TaskBudget:
-    manifest = result.manifests[intent.repo_id]
-    target_fact = facts.get((intent.repo_id, target))
-    present = target_fact.present_files if target_fact else frozenset()
-    missing = tuple(item for item in manifest if item.rfilename not in present)
-    source_fact = facts.get((intent.repo_id, intent.source_drive or ""))
-    source_sizes = dict(source_fact.stored_bytes_by_file) if source_fact is not None else {}
-    exact = bool(
-        source_fact is not None
-        and source_fact.complete
-        and all(source_sizes.get(item.rfilename, 0) > 0 or item.size_bytes == 0 for item in missing)
-    )
-    file_budgets = tuple(
-        FileBudget(
-            rfilename=item.rfilename,
-            guaranteed_durable=(
-                int(source_sizes[item.rfilename]) if exact else _expected_file_bytes(item, ratio)
-            ),
-            expected_durable=(
-                int(source_sizes[item.rfilename]) if exact else _expected_file_bytes(item, ratio)
-            ),
-            workspace_peak_guaranteed=(
-                int(source_sizes[item.rfilename]) if exact else _expected_file_bytes(item, ratio)
-            ),
-            workspace_peak_expected=(
-                int(source_sizes[item.rfilename]) if exact else _expected_file_bytes(item, ratio)
-            ),
-            evidence="exact" if exact else "estimate",
-        )
-        for item in missing
-    )
-    durable = sum(item.guaranteed_durable for item in file_budgets)
-    return TaskBudget(
-        task_id=intent.task_id,
-        requirement_id=intent.requirement_id,
-        repo_id=intent.repo_id,
-        kind=intent.kind,
-        target_drive=target,
-        source_drive=intent.source_drive,
-        missing_files=tuple(item.rfilename for item in missing),
-        file_budgets=file_budgets,
-        guaranteed_durable=durable,
-        expected_durable=durable,
-        workspace_peak_guaranteed=durable,
-        workspace_peak_expected=durable,
-        evidence="exact" if exact else "estimate",
+        task_id=f"{candidate.task_kind.value}:{candidate.requirement_id}",
+        requirement_id=candidate.requirement_id,
+        repo_id=candidate.requirement_id.split(":", 1)[1],
+        kind=candidate.task_kind,
+        target_drive=candidate.target_drive,
+        source_drive=source_drive,
+        missing_files=tuple(item.rfilename for item in candidate.missing_files),
+        file_budgets=budget.file_budgets,
+        guaranteed_durable=budget.guaranteed_durable,
+        expected_durable=budget.expected_durable,
+        workspace_peak_guaranteed=budget.workspace_peak_guaranteed,
+        workspace_peak_expected=budget.workspace_peak_expected,
+        evidence=evidence,
     )
 
 
@@ -529,8 +418,9 @@ def preflight_file(
 ) -> CapacityFailure | None:
     """Fresh-operation guard; the drive carries current admission evidence (``usable_now`` is the
     already-floor-adjusted admissible free), so this never re-subtracts the safety floor."""
-    durable = file_budget.durable_for(mode)
-    workspace = file_budget.workspace_for(mode)
+    guaranteed = mode == CapacityMode.GUARANTEED
+    durable = file_budget.durable_for(guaranteed)
+    workspace = file_budget.workspace_for(guaranteed)
     required = durable + workspace
     if required <= drive.usable_now:
         return None
@@ -725,6 +615,89 @@ def _batch_order(tasks: Sequence[AssignedTask], result: ReconcileResult) -> tupl
     )
 
 
+@dataclass
+class _Placeable:
+    """A requirement's placement inputs derived from the canonical CandidateSet by the legacy tiered_v1
+    adapter. Duck-types WorkIntent for _Placement/_failure_for_unassigned. Carries pre-computed candidate
+    budgets per target and the finish-in-place target that reproduces the pre-#36a proven-partial pin."""
+    requirement_id: str
+    repo_id: str
+    kind: TaskKind
+    task_id: str
+    eligible_drives: tuple[str, ...]
+    depends_on_requirement: str | None
+    budgets_by_target: dict[str, TaskBudget]
+    finish_in_place: str | None
+
+
+def _rank_home_drive(drive: CapacityDrive) -> tuple:
+    return (0 if drive.raid_backed else 1, -drive.capacity_bytes, drive.drive_label)
+
+
+def _best_finish_in_place(cands, drive_by_label) -> str | None:
+    """Reproduce the pre-#36a ``_choose_partial`` preference over canonical finish-in-place candidates:
+    least missing bytes, then most reused files, then tier/label. This is a legacy placement choice."""
+    partials = [item for item in cands if item.reused_files and item.target_drive in drive_by_label]
+    if not partials:
+        return None
+
+    def rank(candidate) -> tuple:
+        missing_bytes = sum(item.size_bytes for item in candidate.missing_files)
+        drive = drive_by_label[candidate.target_drive]
+        if candidate.task_kind == TaskKind.REPLICATE:
+            drank = (drive.capacity_bytes, drive.drive_label)
+        else:
+            drank = _rank_home_drive(drive)
+        return (missing_bytes, -len(candidate.reused_files), drank, candidate.target_drive)
+
+    return sorted(partials, key=rank)[0].target_drive
+
+
+def _legacy_placeables(cset, drive_by_label) -> list[_Placeable]:
+    """LEGACY tiered_v1 adapter (removed at #38): choose among CANONICAL candidates only — never legacy
+    filename facts. Collapses each replica to one canonical home source (or PendingHome) as the pre-#36a
+    path did, and pre-computes per-target budgets from the shared seam via the candidates."""
+    placeables = []
+    for requirement_id, cands in cset.by_requirement:
+        if not cands:
+            continue
+        kind = cands[0].task_kind
+        depends_on = None
+        if kind == TaskKind.REPLICATE:
+            source_labels = sorted({
+                item.source.drive_label for item in cands
+                if isinstance(item.source, candidates.SourceIdentity) and item.source.drive_label in drive_by_label
+            })
+            if source_labels:
+                chosen = sorted(source_labels, key=lambda label: _rank_home_drive(drive_by_label[label]))[0]
+                selected = [
+                    item for item in cands
+                    if isinstance(item.source, candidates.SourceIdentity) and item.source.drive_label == chosen
+                ]
+            else:
+                selected = [item for item in cands if isinstance(item.source, candidates.PendingHome)]
+                depends_on = next((item.depends_on_requirement for item in selected), None)
+        else:
+            selected = list(cands)
+        budgets_by_target = {
+            item.target_drive: _task_budget(item)
+            for item in selected if item.target_drive in drive_by_label
+        }
+        if not budgets_by_target:
+            continue
+        placeables.append(_Placeable(
+            requirement_id=requirement_id,
+            repo_id=requirement_id.split(":", 1)[1],
+            kind=kind,
+            task_id=f"{kind.value}:{requirement_id}",
+            eligible_drives=tuple(sorted(budgets_by_target)),
+            depends_on_requirement=depends_on,
+            budgets_by_target=budgets_by_target,
+            finish_in_place=_best_finish_in_place(selected, drive_by_label),
+        ))
+    return placeables
+
+
 def plan_capacity(
     con,
     result: ReconcileResult,
@@ -734,8 +707,10 @@ def plan_capacity(
     compression_cfg: Mapping[str, object] | None = None,
     provisioning: str | None = None,
 ) -> CapacityPlan:
-    """Materialize deterministic ``tiered_v1`` assignments and feasibility evidence. Usable free comes
-    from ``evidence_by_drive`` (the shared admission authority); a drive absent from it is fail-closed
+    """Materialize deterministic ``tiered_v1`` assignments and feasibility evidence over the CANONICAL
+    CandidateSet (``result.candidates``). This is the legacy placement adapter (removed at #38); it makes
+    the only placement choice before #38 and is not canonical authority. Usable free comes from
+    ``evidence_by_drive`` (the shared admission authority); a drive absent from it is fail-closed
     ``unknown`` and contributes zero executable capacity (#35-C)."""
     if provisioning is not None:
         warnings.warn(
@@ -750,142 +725,103 @@ def plan_capacity(
     mode = mode_from_value(capacity_mode or CapacityMode.GUARANTEED)
     drives = inspect_drives(con, result.plan_id, evidence_by_drive=evidence_by_drive)
     drive_by_label = {item.drive_label: item for item in drives}
-    facts = _fact_by_repo_drive(result)
-    ratio = plan_float_ratio(con)
-    compression_cfg = dict(compression_cfg or wishlist.compression())
     placement = _Placement(drives, mode)
     failures: list[CapacityFailure] = []
-    unassigned: list[WorkIntent] = []
+    unassigned: list[_Placeable] = []
 
-    fetch_intents = [item for item in result.intents if item.kind == TaskKind.FETCH]
-    homes = [item for item in fetch_intents
-             if item.requirement_id.startswith("protected_home:")]
-    bulk = [item for item in fetch_intents if item.requirement_id.startswith("primary:")]
+    placeables = _legacy_placeables(result.candidates, drive_by_label)
+    homes = [item for item in placeables
+             if item.kind == TaskKind.FETCH and item.requirement_id.startswith("protected_home:")]
+    bulk = [item for item in placeables
+            if item.kind == TaskKind.FETCH and item.requirement_id.startswith("primary:")]
 
-    # Protected partials remain pinned. All other protected homes share the distinguished
-    # largest-usable eligible home, preserving the legacy single-home policy.
-    for intent in sorted(homes, key=lambda item: item.requirement_id):
-        eligible = [drive_by_label[label] for label in intent.eligible_drives if label in drive_by_label]
-        if intent.pinned_target in drive_by_label:
-            target = intent.pinned_target
-        elif intent.pinned_target:
-            # Durable partials may never be silently re-homed. A stale pin is an
-            # unassigned typed failure, never a task omitted from every drive ledger.
-            target = None
-        elif eligible:
+    # Protected partials remain pinned to their finish-in-place target. Other protected homes share the
+    # distinguished largest-usable eligible home, preserving the legacy single-home policy.
+    for item in sorted(homes, key=lambda p: p.requirement_id):
+        if item.finish_in_place:
+            target = item.finish_in_place
+        else:
             target = sorted(
-                eligible,
-                key=lambda item: (-item.usable_now, -item.capacity_bytes, item.drive_label),
-            )[0].drive_label
-        else:
-            target = None
-        candidates = ([] if target is None else [
-            _fetch_budget(intent, target, result, ratio, compression_cfg, facts)
-        ])
-        if candidates:
-            placement.add(intent, candidates[0])
-        else:
-            unassigned.append(intent)
-            failures.append(_failure_for_unassigned(intent, candidates, placement))
+                item.budgets_by_target,
+                key=lambda label: (-drive_by_label[label].usable_now,
+                                   -drive_by_label[label].capacity_bytes, label),
+            )[0]
+        placement.add(item, item.budgets_by_target[target])
 
     # Durable partials are not repacked. Unpinned bulk uses RAID-first FFD, then largest primaries.
-    pinned_bulk = [item for item in bulk if item.pinned_target]
-    free_bulk = [item for item in bulk if not item.pinned_target]
-    for intent in sorted(pinned_bulk, key=lambda item: item.requirement_id):
-        candidates = [
-            _fetch_budget(intent, intent.pinned_target, result, ratio, compression_cfg, facts)
-        ] if intent.pinned_target in drive_by_label else []
-        if candidates and placement.fits(intent.pinned_target, candidates[0]):
-            placement.add(intent, candidates[0])
+    pinned_bulk = [item for item in bulk if item.finish_in_place]
+    free_bulk = [item for item in bulk if not item.finish_in_place]
+    for item in sorted(pinned_bulk, key=lambda p: p.requirement_id):
+        budget = item.budgets_by_target[item.finish_in_place]
+        if placement.fits(item.finish_in_place, budget):
+            placement.add(item, budget)
         else:
-            unassigned.append(intent)
-            failures.append(_failure_for_unassigned(intent, candidates, placement))
+            unassigned.append(item)
+            failures.append(_failure_for_unassigned(item, [budget], placement))
 
-    primary_order = sorted(
-        (item for item in drives if item.role == "primary"),
-        key=lambda item: (0 if item.raid_backed else 1, -item.capacity_bytes, item.drive_label),
-    )
+    primary_order = [item.drive_label for item in sorted(
+        (drive for drive in drives if drive.role == "primary"),
+        key=lambda drive: (0 if drive.raid_backed else 1, -drive.capacity_bytes, drive.drive_label),
+    )]
     sized_bulk = []
-    for intent in free_bulk:
-        candidates = [
-            _fetch_budget(intent, drive.drive_label, result, ratio, compression_cfg, facts)
-            for drive in primary_order if drive.drive_label in intent.eligible_drives
-        ]
-        largest = max((item.durable_for(mode) for item in candidates), default=0)
-        sized_bulk.append((intent, candidates, largest))
-    for intent, candidates, _ in sorted(
-        sized_bulk, key=lambda item: (-item[2], item[0].requirement_id)
-    ):
-        chosen = next((item for item in candidates if placement.fits(item.target_drive, item)), None)
+    for item in free_bulk:
+        ordered = [label for label in primary_order if label in item.budgets_by_target]
+        largest = max((item.budgets_by_target[label].durable_for(mode) for label in ordered), default=0)
+        sized_bulk.append((item, ordered, largest))
+    for item, ordered, _ in sorted(sized_bulk, key=lambda entry: (-entry[2], entry[0].requirement_id)):
+        chosen = next((label for label in ordered
+                       if placement.fits(label, item.budgets_by_target[label])), None)
         if chosen:
-            placement.add(intent, chosen)
+            placement.add(item, item.budgets_by_target[chosen])
         else:
-            unassigned.append(intent)
-            failures.append(_failure_for_unassigned(intent, candidates, placement))
+            unassigned.append(item)
+            failures.append(_failure_for_unassigned(
+                item, [item.budgets_by_target[label] for label in ordered], placement))
 
-    replica_intents = [item for item in result.intents if item.kind == TaskKind.REPLICATE]
-    pinned_replica = [item for item in replica_intents if item.pinned_target]
-    free_replica = [item for item in replica_intents if not item.pinned_target]
-    for intent in sorted(pinned_replica, key=lambda item: item.requirement_id):
-        candidates = [
-            _replica_budget(intent, intent.pinned_target, result, ratio, facts)
-        ] if intent.pinned_target in drive_by_label else []
-        if candidates and placement.fits(intent.pinned_target, candidates[0]):
-            placement.add(intent, candidates[0])
+    replicas = [item for item in placeables if item.kind == TaskKind.REPLICATE]
+    pinned_replica = [item for item in replicas if item.finish_in_place]
+    free_replica = [item for item in replicas if not item.finish_in_place]
+    for item in sorted(pinned_replica, key=lambda p: p.requirement_id):
+        budget = item.budgets_by_target[item.finish_in_place]
+        if placement.fits(item.finish_in_place, budget):
+            placement.add(item, budget)
         else:
-            unassigned.append(intent)
-            failures.append(_failure_for_unassigned(intent, candidates, placement))
+            unassigned.append(item)
+            failures.append(_failure_for_unassigned(item, [budget], placement))
 
     replica_drives = sorted(
-        (item for item in drives if item.role == "replica"),
-        key=lambda item: (item.capacity_bytes, item.drive_label),
+        (drive for drive in drives if drive.role == "replica"),
+        key=lambda drive: (drive.capacity_bytes, drive.drive_label),
     )
-    replica_candidates = {
-        intent.requirement_id: [
-            _replica_budget(intent, drive.drive_label, result, ratio, facts)
-            for drive in replica_drives if drive.drive_label in intent.eligible_drives
-        ]
-        for intent in free_replica
-    }
     # Prefer the smallest single target that can accept the complete remaining replica set.
     group_target = None
     for drive in replica_drives:
-        budgets = [
-            next((item for item in replica_candidates[intent.requirement_id]
-                  if item.target_drive == drive.drive_label), None)
-            for intent in free_replica
-        ]
-        if all(item is not None for item in budgets):
+        budgets = [item.budgets_by_target.get(drive.drive_label) for item in free_replica]
+        if all(budget is not None for budget in budgets):
             durable, workspace = placement.totals(drive.drive_label)
-            durable += sum(item.durable_for(mode) for item in budgets if item is not None)
-            workspace = max(
-                [workspace, *(item.workspace_for(mode) for item in budgets if item is not None)]
-            )
+            durable += sum(budget.durable_for(mode) for budget in budgets if budget is not None)
+            workspace = max([workspace, *(budget.workspace_for(mode) for budget in budgets if budget is not None)])
             if durable + workspace <= drive.usable_now:
                 group_target = drive.drive_label
                 break
     if group_target:
-        for intent in sorted(free_replica, key=lambda item: item.requirement_id):
-            budget = next(
-                item for item in replica_candidates[intent.requirement_id]
-                if item.target_drive == group_target
-            )
-            placement.add(intent, budget)
+        for item in sorted(free_replica, key=lambda p: p.requirement_id):
+            placement.add(item, item.budgets_by_target[group_target])
     else:
         sized_replica = []
-        for intent in free_replica:
-            candidates = replica_candidates[intent.requirement_id]
-            largest = max((item.durable_for(mode) for item in candidates), default=0)
-            sized_replica.append((intent, candidates, largest))
-        for intent, candidates, _ in sorted(
-            sized_replica, key=lambda item: (-item[2], item[0].requirement_id)
-        ):
-            chosen = next((item for item in candidates if placement.fits(item.target_drive, item)), None)
+        for item in free_replica:
+            ordered = [drive.drive_label for drive in replica_drives if drive.drive_label in item.budgets_by_target]
+            largest = max((item.budgets_by_target[label].durable_for(mode) for label in ordered), default=0)
+            sized_replica.append((item, ordered, largest))
+        for item, ordered, _ in sorted(sized_replica, key=lambda entry: (-entry[2], entry[0].requirement_id)):
+            chosen = next((label for label in ordered
+                           if placement.fits(label, item.budgets_by_target[label])), None)
             if chosen:
-                placement.add(intent, chosen)
+                placement.add(item, item.budgets_by_target[chosen])
             else:
-                unassigned.append(intent)
-                failures.append(_failure_for_unassigned(intent, candidates, placement))
+                unassigned.append(item)
+                failures.append(_failure_for_unassigned(
+                    item, [item.budgets_by_target[label] for label in ordered], placement))
 
     # A forced protected-home assignment can exceed its tier; report it after complete ledger math.
     ledgers = _ledgers(drives, placement.tasks)
@@ -923,7 +859,14 @@ def plan_capacity(
         ))
         failed_requirements.update(item.requirement_id for item in roots)
 
+    # A dependent replica's failure is deduplicated when its home is the root cause — whether the home is
+    # a capacity failure here or a blocking reconcile diagnostic (e.g. an empty-eligible TARGET_TIER_MISSING
+    # home, which #36a surfaces as a diagnostic rather than a candidate/failure).
     root_failures = {item.requirement_id for item in failures}
+    root_failures |= {
+        item.requirement_id for item in result.diagnostics
+        if item.requirement_id and item.severity in {DiagnosticSeverity.BLOCKING, DiagnosticSeverity.ERROR}
+    }
     failures = [
         item for item in failures
         if not item.blocked_by_requirement or item.blocked_by_requirement not in root_failures

--- a/modelark/librarian.py
+++ b/modelark/librarian.py
@@ -534,7 +534,8 @@ def queue_view(con, plan_id: str | None = None, capacity_mode: str = "guaranteed
         if repo in copy2:
             continue
         candidates = replica_candidates.get(repo, [])
-        hint = intent.pinned_target or (candidates[0] if candidates else None)
+        # #36a: reconcile emits no pin; the copy-2 hint is the eligible-tier candidate only.
+        hint = candidates[0] if candidates else None
         if hint:
             copy2[repo] = hint
             copy2_evidence[repo] = "eligible_hint"

--- a/modelark/reconcile.py
+++ b/modelark/reconcile.py
@@ -1,8 +1,12 @@
-"""Desired-state reconciliation for archive work (DEC-045).
+"""Desired-state reconciliation for archive work (DEC-045, RFC-002 / DEC-049, issue #36a).
 
-The durable catalog remains authoritative.  This module derives exact copy facts,
-requirements, and unassigned work intents without mutating the database. Capacity placement
-materializes concrete tasks; the executor discards and re-derives them at drive-batch boundaries.
+The durable catalog remains authoritative. ``reconcile_plan`` is now a compatibility façade over the
+pure functional core in :mod:`modelark.candidates`: one consistent read transaction captures catalog
+facts (and freezes config/ratio) into an immutable ``PlannerInput``; the pure ``requirements`` and
+``candidates`` functions are the sole semantic authority for satisfaction, reuse, sources, and candidate
+work. The canonical, no-pin :class:`~modelark.candidates.CandidateSet` is exposed on the result; the
+legacy ``ReconcileResult`` fields are projections of it for compatibility. Placement selection is the
+legacy ``tiered_v1`` adapter in :mod:`modelark.capacity` (removed at #38) — reconcile chooses nothing.
 """
 from __future__ import annotations
 
@@ -10,22 +14,24 @@ import hashlib
 import json
 import warnings
 from collections import Counter
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from typing import Mapping, Sequence
 
-from modelark import archive_manifest
+from modelark import archive_manifest, candidates
+from modelark.candidates import (  # re-exported: candidates.py is the owner of these shared types
+    CopyRequirement,
+    DriveFact,
+    RequirementKind,
+    TaskKind,
+)
 
-
-class RequirementKind(str, Enum):
-    PRIMARY = "primary"
-    PROTECTED_HOME = "protected_home"
-    PROTECTED_REPLICA = "protected_replica"
-
-
-class TaskKind(str, Enum):
-    FETCH = "fetch"
-    REPLICATE = "replicate"
+__all__ = [  # names other modules import from reconcile
+    "CopyFact", "CopyRequirement", "DriveFact", "DiagnosticSeverity", "PlanDiagnostic",
+    "RecoveryClass", "ReconcileResult", "RequirementKind", "TaskKind", "WorkIntent",
+    "capture_planner_input", "reconcile_plan", "shadow_report",
+]
 
 
 class DiagnosticSeverity(str, Enum):
@@ -39,26 +45,6 @@ class RecoveryClass(str, Enum):
     AUTOMATIC = "automatic"
     OPERATOR_ACTION = "operator_action"
     CODE_DEFECT = "code_defect"
-
-
-@dataclass(frozen=True)
-class DriveFact:
-    drive_label: str
-    role: str
-    raid_backed: bool
-    capacity_bytes: int
-    fs_uuid: str | None = None
-    annex_uuid: str | None = None
-    serial: str | None = None
-
-
-@dataclass(frozen=True)
-class CopyRequirement:
-    requirement_id: str
-    repo_id: str
-    kind: RequirementKind
-    eligible_drives: tuple[str, ...]
-    independent_of: str | None = None
 
 
 @dataclass(frozen=True)
@@ -80,12 +66,14 @@ class CopyFact:
 
 @dataclass(frozen=True)
 class WorkIntent:
+    # Compatibility projection only: an unsatisfied requirement's work list for legacy consumers.
+    # It carries NO pinned_target — placement selection is the capacity tiered_v1 adapter over the
+    # canonical CandidateSet, never a reconcile-side pin (#36a removes _choose_partial authority).
     task_id: str
     kind: TaskKind
     requirement_id: str
     repo_id: str
     eligible_drives: tuple[str, ...]
-    pinned_target: str | None
     source_drive: str | None
     depends_on_requirement: str | None
 
@@ -118,6 +106,7 @@ class ReconcileResult:
     satisfied: frozenset[str]
     matches: tuple[tuple[str, str], ...]
     diagnostics: tuple[PlanDiagnostic, ...]
+    candidates: candidates.CandidateSet  # canonical no-pin authority; legacy fields above project from it
 
     def to_dict(self) -> dict:
         payload = {
@@ -165,7 +154,6 @@ class ReconcileResult:
                     "requirement_id": item.requirement_id,
                     "repo": item.repo_id,
                     "eligible_drives": list(item.eligible_drives),
-                    "pinned_target": item.pinned_target,
                     "source_drive": item.source_drive,
                     "depends_on_requirement": item.depends_on_requirement,
                 }
@@ -216,164 +204,117 @@ def _selected_repos(con, repo_ids: Sequence[str] | None) -> tuple[str, ...]:
     )
 
 
-def _drives(con, plan_id: str) -> tuple[DriveFact, ...]:
+@contextmanager
+def _consistent_read(con):
+    """One consistent catalog read snapshot. Reuse the caller's transaction if one is already open."""
+    if con.in_transaction:
+        yield
+        return
+    con.execute("BEGIN")
+    try:
+        yield
+        con.execute("COMMIT")
+    except BaseException:
+        con.execute("ROLLBACK")
+        raise
+
+
+def _drive_facts(con, plan_id: str) -> tuple[DriveFact, ...]:
     rows = con.execute(
         "SELECT d.drive_label,coalesce(d.role,'primary'),coalesce(d.raid_backed,0),"
-        "coalesce(d.capacity_bytes,d.free_bytes,0),d.fs_uuid,d.annex_uuid,d.serial "
+        "coalesce(d.capacity_bytes,d.free_bytes,0),"
+        "coalesce(d.filesystem_capacity_bytes,d.capacity_bytes,0),coalesce(d.identity_epoch,1),"
+        "d.fs_uuid,d.annex_uuid,d.serial "
         "FROM plan_drives pd JOIN drives d USING(drive_label) WHERE pd.plan_id=? "
         "ORDER BY d.drive_label",
         [plan_id],
     ).fetchall()
     return tuple(
         DriveFact(
-            drive_label=row[0],
-            role=row[1],
-            raid_backed=bool(row[2]),
-            capacity_bytes=int(row[3] or 0),
-            fs_uuid=row[4],
-            annex_uuid=row[5],
-            serial=row[6],
+            drive_label=row[0], role=row[1], raid_backed=bool(row[2]),
+            capacity_bytes=int(row[3] or 0), filesystem_capacity_bytes=int(row[4] or 0),
+            identity_epoch=int(row[5] or 1), fs_uuid=row[6], annex_uuid=row[7], serial=row[8],
         )
         for row in rows
     )
 
 
-def _requirements(con, repo_ids: tuple[str, ...], drives: tuple[DriveFact, ...]) -> tuple[CopyRequirement, ...]:
+def _numcopies(con, repo_ids: tuple[str, ...]) -> dict[str, int]:
     if not repo_ids:
-        return ()
+        return {}
     placeholders = ",".join("?" for _ in repo_ids)
-    copies = dict(
+    return dict(
         con.execute(
             f"SELECT repo_id,coalesce(numcopies,1) FROM models WHERE repo_id IN ({placeholders})",
             list(repo_ids),
         ).fetchall()
     )
-    primary = tuple(d.drive_label for d in drives if d.role == "primary")
-    raids = tuple(d.drive_label for d in drives if d.role == "primary" and d.raid_backed)
-    replicas = tuple(d.drive_label for d in drives if d.role == "replica")
-    fallback = ()
-    if not raids and primary:
-        by_label = {d.drive_label: d for d in drives}
-        fallback = (
-            sorted(primary, key=lambda label: (-by_label[label].capacity_bytes, label))[0],
-        )
-
-    out = []
-    for repo_id in repo_ids:
-        if int(copies.get(repo_id, 1) or 1) < 2:
-            out.append(
-                CopyRequirement(
-                    requirement_id=f"primary:{repo_id}",
-                    repo_id=repo_id,
-                    kind=RequirementKind.PRIMARY,
-                    eligible_drives=primary,
-                )
-            )
-            continue
-        home_id = f"protected_home:{repo_id}"
-        out.append(
-            CopyRequirement(
-                requirement_id=home_id,
-                repo_id=repo_id,
-                kind=RequirementKind.PROTECTED_HOME,
-                eligible_drives=raids or fallback,
-            )
-        )
-        out.append(
-            CopyRequirement(
-                requirement_id=f"protected_replica:{repo_id}",
-                repo_id=repo_id,
-                kind=RequirementKind.PROTECTED_REPLICA,
-                eligible_drives=replicas,
-                independent_of=home_id,
-            )
-        )
-    return tuple(out)
 
 
-def _copy_facts(
-    con,
-    repo_ids: tuple[str, ...],
-    plan_drives: tuple[DriveFact, ...],
-    manifests: Mapping[str, tuple[archive_manifest.ManifestFile, ...]],
-) -> tuple[CopyFact, ...]:
-    if not repo_ids or not plan_drives:
+def _archived_facts(
+    con, repo_ids: tuple[str, ...], drive_labels: tuple[str, ...], rfilenames: tuple[str, ...]
+) -> tuple[candidates.ArchivedFileFact, ...]:
+    # Only archived rows for files some manifest actually references are relevant to satisfaction/reuse;
+    # skipping the rest keeps candidate construction bounded by required files, not total archived rows.
+    if not repo_ids or not drive_labels or not rfilenames:
         return ()
     repo_ph = ",".join("?" for _ in repo_ids)
-    drive_labels = tuple(d.drive_label for d in plan_drives)
     drive_ph = ",".join("?" for _ in drive_labels)
+    file_ph = ",".join("?" for _ in rfilenames)
     rows = con.execute(
-        "SELECT repo_id,drive_label,rfilename,coalesce(stored_bytes,0) FROM archived "
-        f"WHERE repo_id IN ({repo_ph}) AND drive_label IN ({drive_ph}) "
+        "SELECT repo_id,drive_label,rfilename,orig_sha256,orig_bytes,stored_bytes,annex_key FROM archived "
+        f"WHERE repo_id IN ({repo_ph}) AND drive_label IN ({drive_ph}) AND rfilename IN ({file_ph}) "
         "ORDER BY repo_id,drive_label,rfilename",
-        [*repo_ids, *drive_labels],
+        [*repo_ids, *drive_labels, *rfilenames],
     ).fetchall()
-    grouped: dict[tuple[str, str], list[tuple[str, int]]] = {}
-    for repo_id, drive_label, rfilename, stored_bytes in rows:
-        grouped.setdefault((repo_id, drive_label), []).append((rfilename, int(stored_bytes or 0)))
-
-    facts = []
-    for (repo_id, drive_label), present in sorted(grouped.items()):
-        manifest = manifests.get(repo_id)
-        if manifest is None:
-            continue
-        facts.append(
-            CopyFact(
-                repo_id=repo_id,
-                drive_label=drive_label,
-                required_files=frozenset(item.rfilename for item in manifest),
-                present_files=frozenset(name for name, _ in present),
-                stored_bytes_by_file=tuple(present),
-            )
+    return tuple(
+        candidates.ArchivedFileFact(
+            repo_id=row[0], drive_label=row[1], rfilename=row[2], orig_sha256=row[3],
+            orig_bytes=(int(row[4]) if row[4] is not None else None),
+            stored_bytes=(int(row[5]) if row[5] is not None else None), annex_key=row[6],
         )
-    return tuple(facts)
+        for row in rows
+    )
 
 
-def _drive_rank(kind: RequirementKind, drive: DriveFact) -> tuple:
-    if kind == RequirementKind.PROTECTED_REPLICA:
-        return (drive.capacity_bytes, drive.drive_label)
-    # PRIMARY and PROTECTED_HOME both prefer RAID-backed drives, then largest capacity.
-    return (0 if drive.raid_backed else 1, -drive.capacity_bytes, drive.drive_label)
+@dataclass(frozen=True)
+class _Facts:
+    planner_input: candidates.PlannerInput
+    manifest_batch: archive_manifest.ManifestBatch
+    selected_repos: tuple[str, ...]
 
 
-def _choose_complete(
-    requirement: CopyRequirement,
-    facts: Sequence[CopyFact],
-    drive_by_label: Mapping[str, DriveFact],
-) -> CopyFact | None:
-    candidates = [
-        fact for fact in facts
-        if fact.complete and fact.drive_label in requirement.eligible_drives
-    ]
-    if not candidates:
-        return None
-    return sorted(candidates, key=lambda fact: _drive_rank(requirement.kind, drive_by_label[fact.drive_label]))[0]
+def _read_facts(con, plan_id, repo_ids=None, policy=None) -> _Facts:
+    from modelark import capacity, wishlist  # local: capacity imports reconcile at module scope
+    with _consistent_read(con):
+        repos = _selected_repos(con, repo_ids)
+        batch = archive_manifest.inspect_manifests_for_repos(con, repos, policy)
+        usable = tuple(repo for repo in repos if repo in batch.manifests)
+        drives = _drive_facts(con, plan_id)
+        numcopies = _numcopies(con, usable)
+        manifest_files = tuple(sorted({
+            item.rfilename for manifest in batch.manifests.values() for item in manifest
+        }))
+        archived = _archived_facts(con, usable, tuple(d.drive_label for d in drives), manifest_files)
+        config = wishlist.compression()
+        ratio = capacity.plan_float_ratio(con)
+    planner_input = candidates.PlannerInput(
+        plan_id=plan_id,
+        selection=usable,
+        manifests=tuple((repo, batch.manifests[repo]) for repo in usable),
+        numcopies=tuple(sorted(numcopies.items())),
+        drives=drives,
+        archived=archived,
+        compression_cfg=tuple(sorted((str(key), value) for key, value in config.items())),
+        float_ratio=ratio,
+    )
+    return _Facts(planner_input, batch, repos)
 
 
-def _choose_partial(
-    requirement: CopyRequirement,
-    facts: Sequence[CopyFact],
-    manifest: Sequence[archive_manifest.ManifestFile],
-    drive_by_label: Mapping[str, DriveFact],
-) -> CopyFact | None:
-    sizes = {item.rfilename: item.size_bytes for item in manifest}
-    candidates = [
-        fact for fact in facts
-        if not fact.complete and fact.required_present and fact.drive_label in requirement.eligible_drives
-    ]
-    if not candidates:
-        return None
-
-    def rank(fact: CopyFact) -> tuple:
-        missing = sum(sizes[name] for name in fact.required_files - fact.present_files)
-        return (
-            missing,
-            -len(fact.required_present),
-            _drive_rank(requirement.kind, drive_by_label[fact.drive_label]),
-            fact.drive_label,
-        )
-
-    return sorted(candidates, key=rank)[0]
+def capture_planner_input(con, plan_id, repo_ids=None, policy=None) -> candidates.PlannerInput:
+    """Fact reader (impure shell): capture catalog facts in one consistent read transaction and freeze
+    graph-affecting config + the observed float ratio into an immutable, pure ``PlannerInput``."""
+    return _read_facts(con, plan_id, repo_ids, policy).planner_input
 
 
 def _same_failure_domain(left: DriveFact, right: DriveFact) -> bool:
@@ -387,142 +328,148 @@ def _same_failure_domain(left: DriveFact, right: DriveFact) -> bool:
     )
 
 
+def _rank_satisfying_drive(kind: RequirementKind, drive: DriveFact) -> tuple:
+    """Canonical pick among proven complete copies for the legacy ``matches`` projection (mirrors the
+    pre-#36a ``_choose_complete`` order: RAID-first/largest for homes, smallest for replicas)."""
+    if kind == RequirementKind.PROTECTED_REPLICA:
+        return (drive.capacity_bytes, drive.drive_label)
+    return (0 if drive.raid_backed else 1, -drive.capacity_bytes, drive.drive_label)
+
+
+def _facts_projection(inp: candidates.PlannerInput) -> tuple[CopyFact, ...]:
+    """Raw archived facts for display (ruling #4: raw facts may remain visible). Not authority."""
+    manifests = dict(inp.manifests)
+    grouped: dict[tuple[str, str], list[tuple[str, int]]] = {}
+    for row in inp.archived:
+        grouped.setdefault((row.repo_id, row.drive_label), []).append(
+            (row.rfilename, int(row.stored_bytes or 0))
+        )
+    facts = []
+    for (repo_id, drive_label), present in sorted(grouped.items()):
+        manifest = manifests.get(repo_id)
+        if manifest is None:
+            continue
+        facts.append(
+            CopyFact(
+                repo_id=repo_id, drive_label=drive_label,
+                required_files=frozenset(item.rfilename for item in manifest),
+                present_files=frozenset(name for name, _ in present),
+                stored_bytes_by_file=tuple(present),
+            )
+        )
+    return tuple(facts)
+
+
+def _intents_projection(cset: candidates.CandidateSet) -> tuple[WorkIntent, ...]:
+    """Compatibility work list projected from the canonical candidates — no pin, one row per unsatisfied
+    requirement, with the canonical source/dependency for legacy display only."""
+    intents = []
+    for requirement_id, cands in cset.by_requirement:
+        if not cands:
+            continue
+        kind = cands[0].task_kind
+        repo_id = requirement_id.split(":", 1)[1]
+        eligible = tuple(sorted({item.target_drive for item in cands}))
+        source_drive = None
+        depends_on = None
+        sources = sorted({
+            item.source.drive_label for item in cands
+            if isinstance(item.source, candidates.SourceIdentity)
+        })
+        if sources:
+            source_drive = sources[0]
+        else:
+            pending = [
+                item.source.requirement_id for item in cands
+                if isinstance(item.source, candidates.PendingHome)
+            ]
+            depends_on = pending[0] if pending else None
+        intents.append(
+            WorkIntent(
+                task_id=f"{kind.value}:{requirement_id}", kind=kind, requirement_id=requirement_id,
+                repo_id=repo_id, eligible_drives=eligible, source_drive=source_drive,
+                depends_on_requirement=depends_on,
+            )
+        )
+    return tuple(sorted(intents, key=lambda item: (item.repo_id, item.requirement_id)))
+
+
 def reconcile_plan(
     con,
     plan_id: str,
     repo_ids: Sequence[str] | None = None,
     policy: archive_manifest.ArchivePolicy | None = None,
 ) -> ReconcileResult:
-    """Derive exact requirements and work intents without writes or physical I/O."""
-    repos = _selected_repos(con, repo_ids)
-    manifest_batch = archive_manifest.inspect_manifests_for_repos(con, repos, policy)
-    usable_repos = tuple(repo for repo in repos if repo in manifest_batch.manifests)
-    drives = _drives(con, plan_id)
-    drive_by_label = {drive.drive_label: drive for drive in drives}
-    requirements = _requirements(con, usable_repos, drives)
-    facts = _copy_facts(con, usable_repos, drives, manifest_batch.manifests)
-    facts_by_repo: dict[str, list[CopyFact]] = {}
-    for fact in facts:
-        facts_by_repo.setdefault(fact.repo_id, []).append(fact)
+    """Compatibility façade over the pure core: capture one consistent snapshot, run pure
+    requirements/candidates (the sole authority for satisfaction, reuse, sources, and work), expose the
+    canonical no-pin ``CandidateSet``, and project the legacy fields from it. Chooses no placement."""
+    facts = _read_facts(con, plan_id, repo_ids, policy)
+    inp = facts.planner_input
+    graph = candidates.requirements(inp)
+    cset = candidates.candidates(inp, graph)
+
+    drive_by_label = {drive.drive_label: drive for drive in inp.drives}
+    req_by_id = {item.requirement_id: item for item in graph.desired}
+
+    satisfied = frozenset(item.requirement_id for item in cset.satisfied)
+    matches: dict[str, str] = {}
+    for sat in cset.satisfied:
+        kind = req_by_id[sat.requirement_id].kind
+        matches[sat.requirement_id] = sorted(
+            (copy.drive_label for copy in sat.copies),
+            key=lambda label: _rank_satisfying_drive(kind, drive_by_label[label]),
+        )[0]
 
     diagnostics = [
-        _diag(
-            "MANIFEST_POLICY",
-            DiagnosticSeverity.BLOCKING,
-            RecoveryClass.OPERATOR_ACTION,
-            None,
-            repo_id=repo_id,
-            message=str(error),
-        )
-        for repo_id, error in sorted(manifest_batch.errors.items())
+        _diag("MANIFEST_POLICY", DiagnosticSeverity.BLOCKING, RecoveryClass.OPERATOR_ACTION, None,
+              repo_id=repo_id, message=str(error))
+        for repo_id, error in sorted(facts.manifest_batch.errors.items())
     ]
-    matches: dict[str, str] = {}
-    requirement_by_id = {item.requirement_id: item for item in requirements}
-
-    for requirement in requirements:
+    for requirement in graph.desired:
         if not requirement.eligible_drives:
-            diagnostics.append(
-                _diag(
-                    "TARGET_TIER_MISSING",
-                    DiagnosticSeverity.BLOCKING,
-                    RecoveryClass.OPERATOR_ACTION,
-                    requirement.requirement_id,
-                    repo_id=requirement.repo_id,
-                    kind=requirement.kind.value,
-                )
-            )
-            continue
-        match = _choose_complete(
-            requirement, facts_by_repo.get(requirement.repo_id, ()), drive_by_label
-        )
-        if match is not None:
-            matches[requirement.requirement_id] = match.drive_label
-            continue
-        wrong = sorted(
-            fact.drive_label
-            for fact in facts_by_repo.get(requirement.repo_id, ())
-            if fact.complete and fact.drive_label not in requirement.eligible_drives
-        )
-        if wrong:
-            diagnostics.append(
-                _diag(
-                    "COPY_POLICY_DRIFT",
-                    DiagnosticSeverity.WARNING,
-                    RecoveryClass.AUTOMATIC,
-                    requirement.requirement_id,
-                    repo_id=requirement.repo_id,
-                    drives=tuple(wrong),
-                )
-            )
+            diagnostics.append(_diag(
+                "TARGET_TIER_MISSING", DiagnosticSeverity.BLOCKING, RecoveryClass.OPERATOR_ACTION,
+                requirement.requirement_id, repo_id=requirement.repo_id, kind=requirement.kind.value))
 
-    intents = []
-    for requirement in requirements:
-        if requirement.requirement_id in matches:
-            continue
-        manifest = manifest_batch.manifests[requirement.repo_id]
-        partial = _choose_partial(
-            requirement, facts_by_repo.get(requirement.repo_id, ()), manifest, drive_by_label
-        )
-        source_drive = None
-        depends_on = None
-        if requirement.kind == RequirementKind.PROTECTED_REPLICA:
-            home_id = requirement.independent_of
-            source_drive = matches.get(home_id or "")
-            if source_drive is None and home_id in requirement_by_id:
-                depends_on = home_id
-        kind = (TaskKind.REPLICATE if requirement.kind == RequirementKind.PROTECTED_REPLICA
-                else TaskKind.FETCH)
-        intents.append(
-            WorkIntent(
-                task_id=f"{kind.value}:{requirement.requirement_id}",
-                kind=kind,
-                requirement_id=requirement.requirement_id,
-                repo_id=requirement.repo_id,
-                eligible_drives=requirement.eligible_drives,
-                pinned_target=partial.drive_label if partial else None,
-                source_drive=source_drive,
-                depends_on_requirement=depends_on,
-            )
-        )
-        if kind == TaskKind.REPLICATE and source_drive is None and depends_on is None:
-            diagnostics.append(
-                _diag(
-                    "SOURCE_INCOMPLETE",
-                    DiagnosticSeverity.ERROR,
-                    RecoveryClass.CODE_DEFECT,
-                    requirement.requirement_id,
-                    repo_id=requirement.repo_id,
-                )
-            )
+    # Drift projected from the canonical CandidateSet (ruling #4). Wrong-tier proven copies are the
+    # legacy COPY_POLICY_DRIFT (only when the requirement is not otherwise satisfied); unproven/mismatched
+    # rows on eligible targets surface why a partial did not become finish-in-place work.
+    wrong_tier: dict[str, set[str]] = {}
+    unproven: dict[str, set[str]] = {}
+    for row in cset.drift:
+        if row.reason == "wrong_tier" and row.requirement_id not in satisfied:
+            wrong_tier.setdefault(row.requirement_id, set()).add(row.drive_label)
+        elif row.reason == "unproven_provenance":
+            unproven.setdefault(row.requirement_id, set()).add(row.drive_label)
+    for requirement_id, drives in sorted(wrong_tier.items()):
+        diagnostics.append(_diag(
+            "COPY_POLICY_DRIFT", DiagnosticSeverity.WARNING, RecoveryClass.AUTOMATIC, requirement_id,
+            repo_id=requirement_id.split(":", 1)[1], drives=tuple(sorted(drives))))
+    for requirement_id, drives in sorted(unproven.items()):
+        diagnostics.append(_diag(
+            "UNPROVEN_PROVENANCE", DiagnosticSeverity.WARNING, RecoveryClass.OPERATOR_ACTION,
+            requirement_id, repo_id=requirement_id.split(":", 1)[1], drives=tuple(sorted(drives))))
 
-    # Warn only from matched copies: unmet dependencies already have a more useful root diagnostic.
-    for repo_id in usable_repos:
+    for repo_id in inp.selection:
         home = matches.get(f"protected_home:{repo_id}")
         replica = matches.get(f"protected_replica:{repo_id}")
         if home and replica and _same_failure_domain(drive_by_label[home], drive_by_label[replica]):
-            diagnostics.append(
-                _diag(
-                    "FAILURE_DOMAIN_SUSPECT",
-                    DiagnosticSeverity.WARNING,
-                    RecoveryClass.OPERATOR_ACTION,
-                    f"protected_replica:{repo_id}",
-                    repo_id=repo_id,
-                    drives=(home, replica),
-                )
-            )
+            diagnostics.append(_diag(
+                "FAILURE_DOMAIN_SUSPECT", DiagnosticSeverity.WARNING, RecoveryClass.OPERATOR_ACTION,
+                f"protected_replica:{repo_id}", repo_id=repo_id, drives=(home, replica)))
 
     diagnostics.sort(key=lambda item: (item.code, item.requirement_id or "", item.detail))
-    intents.sort(key=lambda item: (item.repo_id, item.requirement_id))
     return ReconcileResult(
         plan_id=plan_id,
-        repo_ids=repos,
-        manifests=dict(manifest_batch.manifests),
-        requirements=requirements,
-        facts=facts,
-        intents=tuple(intents),
-        satisfied=frozenset(matches),
+        repo_ids=facts.selected_repos,
+        manifests=dict(inp.manifests),
+        requirements=graph.desired,
+        facts=_facts_projection(inp),
+        intents=_intents_projection(cset),
+        satisfied=satisfied,
         matches=tuple(sorted(matches.items())),
         diagnostics=tuple(diagnostics),
+        candidates=cset,
     )
 
 

--- a/modelark/reconcile.py
+++ b/modelark/reconcile.py
@@ -284,7 +284,7 @@ class _Facts:
     selected_repos: tuple[str, ...]
 
 
-def _read_facts(con, plan_id, repo_ids=None, policy=None) -> _Facts:
+def _read_facts(con, plan_id, repo_ids=None, policy=None, compression_cfg=None) -> _Facts:
     from modelark import capacity, wishlist  # local: capacity imports reconcile at module scope
     with _consistent_read(con):
         repos = _selected_repos(con, repo_ids)
@@ -296,7 +296,9 @@ def _read_facts(con, plan_id, repo_ids=None, policy=None) -> _Facts:
             item.rfilename for manifest in batch.manifests.values() for item in manifest
         }))
         archived = _archived_facts(con, usable, tuple(d.drive_label for d in drives), manifest_files)
-        config = wishlist.compression()
+        # Graph-affecting compression config is captured ONCE here (the impure shell); an explicit
+        # override is the supported injection point (e.g. tests), never a later plan_capacity argument.
+        config = wishlist.compression() if compression_cfg is None else dict(compression_cfg)
         ratio = capacity.plan_float_ratio(con)
     planner_input = candidates.PlannerInput(
         plan_id=plan_id,
@@ -311,10 +313,12 @@ def _read_facts(con, plan_id, repo_ids=None, policy=None) -> _Facts:
     return _Facts(planner_input, batch, repos)
 
 
-def capture_planner_input(con, plan_id, repo_ids=None, policy=None) -> candidates.PlannerInput:
+def capture_planner_input(con, plan_id, repo_ids=None, policy=None,
+                          compression_cfg=None) -> candidates.PlannerInput:
     """Fact reader (impure shell): capture catalog facts in one consistent read transaction and freeze
-    graph-affecting config + the observed float ratio into an immutable, pure ``PlannerInput``."""
-    return _read_facts(con, plan_id, repo_ids, policy).planner_input
+    graph-affecting config (``compression_cfg`` override or ``wishlist.compression()``) plus the observed
+    float ratio into an immutable, pure ``PlannerInput``."""
+    return _read_facts(con, plan_id, repo_ids, policy, compression_cfg).planner_input
 
 
 def _same_failure_domain(left: DriveFact, right: DriveFact) -> bool:
@@ -399,11 +403,13 @@ def reconcile_plan(
     plan_id: str,
     repo_ids: Sequence[str] | None = None,
     policy: archive_manifest.ArchivePolicy | None = None,
+    *,
+    compression_cfg: Mapping[str, object] | None = None,
 ) -> ReconcileResult:
     """Compatibility façade over the pure core: capture one consistent snapshot, run pure
     requirements/candidates (the sole authority for satisfaction, reuse, sources, and work), expose the
     canonical no-pin ``CandidateSet``, and project the legacy fields from it. Chooses no placement."""
-    facts = _read_facts(con, plan_id, repo_ids, policy)
+    facts = _read_facts(con, plan_id, repo_ids, policy, compression_cfg)
     inp = facts.planner_input
     graph = candidates.requirements(inp)
     cset = candidates.candidates(inp, graph)
@@ -425,30 +431,43 @@ def reconcile_plan(
               repo_id=repo_id, message=str(error))
         for repo_id, error in sorted(facts.manifest_batch.errors.items())
     ]
-    for requirement in graph.desired:
-        if not requirement.eligible_drives:
+    unproven_drives: dict[str, set[str]] = {}
+    for row in cset.drift:
+        if row.reason == "unproven_provenance":
+            unproven_drives.setdefault(row.requirement_id, set()).add(row.drive_label)
+
+    # Every blocked requirement (no eligible tier, or all eligible targets unproven) is a BLOCKING
+    # diagnostic — an unfinished copy can never be reported feasible (gap #1).
+    for item in cset.blocked:
+        req = req_by_id[item.requirement_id]
+        if item.reason == "no_eligible_tier":
             diagnostics.append(_diag(
                 "TARGET_TIER_MISSING", DiagnosticSeverity.BLOCKING, RecoveryClass.OPERATOR_ACTION,
-                requirement.requirement_id, repo_id=requirement.repo_id, kind=requirement.kind.value))
+                item.requirement_id, repo_id=req.repo_id, kind=req.kind.value))
+        else:
+            diagnostics.append(_diag(
+                "UNPROVEN_PROVENANCE", DiagnosticSeverity.BLOCKING, RecoveryClass.OPERATOR_ACTION,
+                item.requirement_id, repo_id=req.repo_id,
+                drives=tuple(sorted(unproven_drives.get(item.requirement_id, ())))))
 
-    # Drift projected from the canonical CandidateSet (ruling #4). Wrong-tier proven copies are the
-    # legacy COPY_POLICY_DRIFT (only when the requirement is not otherwise satisfied); unproven/mismatched
-    # rows on eligible targets surface why a partial did not become finish-in-place work.
+    # Drift on requirements that still have a valid candidate is advisory only (ruling #4): wrong-tier
+    # proven copies are COPY_POLICY_DRIFT; unproven rows on some targets while others remain valid warn.
+    blocked_ids = {item.requirement_id for item in cset.blocked}
+    with_candidates = {requirement_id for requirement_id, _ in cset.by_requirement}
     wrong_tier: dict[str, set[str]] = {}
-    unproven: dict[str, set[str]] = {}
     for row in cset.drift:
-        if row.reason == "wrong_tier" and row.requirement_id not in satisfied:
+        if (row.reason == "wrong_tier" and row.requirement_id not in satisfied
+                and row.requirement_id not in blocked_ids):
             wrong_tier.setdefault(row.requirement_id, set()).add(row.drive_label)
-        elif row.reason == "unproven_provenance":
-            unproven.setdefault(row.requirement_id, set()).add(row.drive_label)
     for requirement_id, drives in sorted(wrong_tier.items()):
         diagnostics.append(_diag(
             "COPY_POLICY_DRIFT", DiagnosticSeverity.WARNING, RecoveryClass.AUTOMATIC, requirement_id,
             repo_id=requirement_id.split(":", 1)[1], drives=tuple(sorted(drives))))
-    for requirement_id, drives in sorted(unproven.items()):
-        diagnostics.append(_diag(
-            "UNPROVEN_PROVENANCE", DiagnosticSeverity.WARNING, RecoveryClass.OPERATOR_ACTION,
-            requirement_id, repo_id=requirement_id.split(":", 1)[1], drives=tuple(sorted(drives))))
+    for requirement_id, drives in sorted(unproven_drives.items()):
+        if requirement_id in with_candidates:
+            diagnostics.append(_diag(
+                "UNPROVEN_PROVENANCE", DiagnosticSeverity.WARNING, RecoveryClass.OPERATOR_ACTION,
+                requirement_id, repo_id=requirement_id.split(":", 1)[1], drives=tuple(sorted(drives))))
 
     for repo_id in inp.selection:
         home = matches.get(f"protected_home:{repo_id}")

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -79,6 +79,16 @@ HC = "2" * 64        # a config/aux file with an upstream hash
 MARGIN = capacity.EXPECTED_MARGIN
 RATIO = capacity.DEFAULT_FLOAT_RATIO
 
+# Explicit graph-affecting compression config copied into the immutable input. The pure budget path
+# consumes exactly these values via compress.plan_codec (which does direct cfg[...] access) — it must
+# never invent defaults or fall back to wishlist.compression(). max_compress_ram_gb=64 keeps a small
+# shard in CODEC_WHOLE deterministically (no dependence on host zstd availability).
+_CFG = (("max_compress_ram_gb", 64), ("stream_compress", True), ("threads", 4))
+
+
+def _cfg_dict():
+    return dict(_CFG)
+
 
 def _require_pure():
     if not (_HAS_CANDIDATES and _HAS_BUDGETS):
@@ -116,7 +126,7 @@ def _arch(repo, drive, name, *, sha=None, obytes=None, sbytes=None, key=None):
         orig_sha256=sha, orig_bytes=obytes, stored_bytes=sbytes, annex_key=key)
 
 
-def _input(*, selection, manifests, numcopies, drives, archived, cfg=(), ratio=RATIO):
+def _input(*, selection, manifests, numcopies, drives, archived, cfg=_CFG, ratio=RATIO):
     return candidates.PlannerInput(
         plan_id="ark",
         selection=tuple(selection),
@@ -229,10 +239,18 @@ def _scenario_unproven_hash_blocks_target():
 
 
 def _scenario_mismatch_and_size_block_target():
-    for label, kw in (("hashbad", dict(sha="f" * 64, obytes=100)), ("sizebad", dict(sha=HW, obytes=999))):
+    # (label, archived kwargs, manifest sha). The last case is the hashless branch: no upstream SHA plus a
+    # non-null archived orig_sha256 but the WRONG orig_bytes → zero reuse credit (the size gate fails), so
+    # the required row is unproven and blocks its target rather than being silently reused.
+    cases = (
+        ("hashbad", dict(sha="f" * 64, obytes=100), HW),
+        ("sizebad", dict(sha=HW, obytes=999), HW),
+        ("hashless_sizebad", dict(sha="a" * 64, obytes=999), None),
+    )
+    for label, kw, manifest_sha in cases:
         inp = _input(
             selection=["org/m"],
-            manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+            manifests=[("org/m", [_mf("a.safetensors", 100, manifest_sha)])],
             numcopies=[("org/m", 1)],
             drives=[_drive("bad"), _drive("clean")],
             archived=[_arch("org/m", "bad", "a.safetensors", sbytes=100, **kw)],
@@ -332,6 +350,10 @@ def _scenario_protected_replica_pending_home():
     assert isinstance(rep[0].source, candidates.PendingHome)
     assert rep[0].source.requirement_id == "protected_home:org/m"
     assert rep[0].depends_on_requirement == "protected_home:org/m"
+    # With no exact source yet, the transfer cost is the deterministic ESTIMATE — a replica copies the
+    # stored bytes, so transfer equals the estimated durable budget (never zero, never a guessed exact
+    # size). Tied to the budget field rather than a hard-coded margin formula to stay robust.
+    assert rep[0].movement_cost.transfer_bytes == rep[0].budget.expected_durable > 0
 
 
 def _scenario_protected_replica_singular_exact_sources():
@@ -473,18 +495,20 @@ def test_contract_pure_no_io_boundary():
         params = set(inspect.signature(fn).parameters)
         assert "con" not in params and "connection" not in params, f"{fn.__name__} must take no DB connection"
     # Import/dependency boundary, checked at the source (catches BOTH `import X` and `from X import Y`):
-    # the pure module pulls in no SQLite/socket/DB/transport and never re-enters the impure
-    # reconcile/capacity layer (which would also be an import cycle).
+    # neither pure module pulls in SQLite/socket/DB/transport, reads global config (wishlist), or
+    # re-enters the impure reconcile/capacity layer (which would also be an import cycle). Banning
+    # wishlist proves the budget path takes config as data and never consults global configuration.
     banned = ("sqlite3", "socket", "modelark.fetch", "modelark.core.db",
-              "modelark.reconcile", "modelark.capacity")
-    imported = set()
-    for node in ast.walk(ast.parse(inspect.getsource(candidates))):
-        if isinstance(node, ast.Import):
-            imported.update(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            imported.add(node.module)
-    offenders = sorted(m for m in imported if any(m == b or m.startswith(b + ".") for b in banned))
-    assert not offenders, f"pure candidates.py must not import {offenders}"
+              "modelark.reconcile", "modelark.capacity", "modelark.wishlist")
+    for module in (candidates, budgets):
+        imported = set()
+        for node in ast.walk(ast.parse(inspect.getsource(module))):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        offenders = sorted(m for m in imported if any(m == b or m.startswith(b + ".") for b in banned))
+        assert not offenders, f"pure {module.__name__} must not import {offenders}"
     # Proportional runtime proof: a full run under a poisoned connection still succeeds.
     inp = _input(
         selection=["org/m"],
@@ -500,10 +524,40 @@ def test_contract_pure_no_io_boundary():
 def test_contract_shared_budget_seam_exposes_both_modes():
     _require_pure()
     assert hasattr(budgets, "FileBudget") and hasattr(budgets, "CandidateBudget")
-    assert candidates.CandidateBudget is budgets.CandidateBudget, "one budget truth shared with capacity"
-    fb = budgets.file_budget(_mf("a.safetensors", 100, HW), RATIO, {})
+    assert candidates.CandidateBudget is budgets.CandidateBudget, "one budget truth shared with candidates"
+    # gap #3: capacity must consume the SAME shared type, not a duplicate class/calculation.
+    assert capacity.FileBudget is budgets.FileBudget, "capacity must re-export budgets.FileBudget, not duplicate it"
+    # gap #1: the injected config is consumed (CODEC_WHOLE at 64 GB budget → output_cap == raw size).
+    fb = budgets.file_budget(_mf("a.safetensors", 100, HW), RATIO, _cfg_dict())
     assert fb.guaranteed_durable == 100 and fb.expected_durable == int(100 * RATIO * MARGIN)
-    assert hasattr(fb, "workspace_peak_guaranteed") and hasattr(fb, "workspace_peak_expected")
+    assert fb.workspace_peak_guaranteed == 100, "workspace must reflect the codec chosen from the injected cfg"
+    # gap #1: no invented defaults — a config missing the compress-gate keys must raise, not silently default.
+    raised = False
+    try:
+        budgets.file_budget(_mf("x.safetensors", 100, HW), RATIO, {})
+    except KeyError:
+        raised = True
+    assert raised, "the pure budget path must not invent compression defaults from an empty cfg"
+
+
+def test_contract_reconcile_plan_exposes_canonical_candidateset():
+    """gap #2 integration: the façade actually wires the pure core. reconcile_plan() exposes the
+    canonical CandidateSet (no pinned_target), so candidates.py cannot sit dormant while every current
+    test still passes. Uses the in-memory DB helpers below (resolved at call time)."""
+    _require_pure()
+    con = _mem()
+    _db_drive(con, "d1", cap=10**9)
+    _db_repo(con, "org/m", files=(
+        ("a.safetensors", 100, "safetensors", "bf16"),
+        ("b.safetensors", 100, "safetensors", "bf16")))
+    _db_archive(con, "org/m", "d1", ("a.safetensors", 100, 100, HW))   # proven partial → a candidate exists
+    result = reconcile.reconcile_plan(con, "ark")
+    assert isinstance(result.candidates, candidates.CandidateSet), \
+        "reconcile_plan() must expose the canonical CandidateSet — the pure core cannot stay dormant"
+    emitted = [c for _, cs in result.candidates.by_requirement for c in cs]
+    assert emitted, "expected a finish-in-place candidate for the unsatisfied requirement"
+    assert not any(hasattr(c, "pinned_target") for c in emitted), "façade candidates carry no pinned_target"
+    con.close()
 
 
 # --------------------------------------------------------------------------------------------------

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -1,0 +1,580 @@
+"""PR-05 / logical #36a canonical requirements & candidates (tests-first, RFC-002 / DEC-049).
+
+Gate 1 pins the PURE candidate contract BEFORE production. #36a replaces ``reconcile._choose_partial``/
+``WorkIntent.pinned_target`` authority with a functional core that, for every unsatisfied required copy,
+emits *all* verified finish-in-place partial candidates and *all* policy-permitted fresh targets with
+exact reuse/provenance/costs — and chooses nothing. #38 later consumes this canonical ``CandidateSet``,
+ranks reuse, and assigns targets; #36a supplies the no-pin input only.
+
+It encodes the operator's Gate-0/Gate-1 rulings:
+
+  1. ``reconcile_plan()`` becomes a compatibility façade over a one-transaction fact reader plus the pure
+     ``requirements``/``candidates`` core. Canonical requirements/candidates carry NO pin. The legacy
+     ``tiered_v1`` placement adapter may temporarily reproduce proven-partial behaviour by *consuming*
+     the candidates, but it is not canonical authority; the operator-visible pinning pathology is not
+     fully removed until #38 chooses the better fresh target.
+  2. Reuse is hash-bound. A required file on a target is REUSED only when a proven archived row exists
+     (``orig_bytes == manifest.size_bytes`` in both branches; if the manifest carries an upstream
+     SHA-256 the archived ``orig_sha256`` must equal it; otherwise a non-null archived ``orig_sha256``
+     binds the baseline, carrying the accepted same-path/same-size provider residual). A ReusableFile
+     records path, size, bound hash, and proof source.
+  3. A target that holds ANY required-but-unproven/mismatched archived row is neither a verified
+     finish-in-place candidate nor a fresh target: that target is OMITTED and its rows are preserved as
+     policy drift. #36a never emits "missing" work that would silently overwrite/delete such a row.
+  4. Missing work carries exact file identity (path, size, hash, storage action), not bare filenames.
+  5. Replica source is SINGULAR per candidate — one source-target candidate per exact ``SourceIdentity``
+     (differing stored sizes / annex keys / raw-fallback outcomes cannot share one exact budget); a
+     ``PendingHome`` reference is used only while the home requirement is unresolved (#38 resolves it).
+  6. ``FileBudget``/``CandidateBudget`` live in ``modelark.budgets`` and are shared by ``candidates`` and
+     the ``capacity`` compatibility path so the two cannot drift; budgets carry both guaranteed and
+     expected durable bytes plus both workspace peaks. ``MovementCost.transfer_bytes`` is a small
+     separate fact (fetch = raw acquisition bytes; replica = exact/estimated stored transfer from the
+     singular source); reused/missing membership is read from the file sets, never duplicated.
+  7. The no-RAID single-largest-primary protected-home fallback is preserved for this slice.
+  8. Records are deeply immutable canonical tuples/frozen records. The pure API accepts no DB
+     connection and imports no SQLite/transport.
+
+RED until ``modelark.candidates`` and ``modelark.budgets`` exist; the lazy import + ``_require_pure()``
+guard makes each contract test fail for the reviewed missing behaviour, not a fixture cascade. GREEN
+characterization tests freeze the executor-facing ``tiered_v1`` placement outcomes that the façade
+refactor must preserve — deliberately over BENIGN scenarios so the pin-can't-fit pathology is not frozen.
+
+Self-running: CI executes ``python tests/test_candidates.py`` directly.
+"""
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import sqlite3
+from unittest import mock
+
+import _admission_compat
+from modelark import archive_manifest, capacity, reconcile
+from modelark.core import db
+
+try:
+    import modelark.candidates as candidates
+    _HAS_CANDIDATES = True
+except ModuleNotFoundError as exc:               # ONLY the exact absent submodule — a real defect surfaces
+    if exc.name != "modelark.candidates":
+        raise
+    candidates = None
+    _HAS_CANDIDATES = False
+
+try:
+    import modelark.budgets as budgets
+    _HAS_BUDGETS = True
+except ModuleNotFoundError as exc:
+    if exc.name != "modelark.budgets":
+        raise
+    budgets = None
+    _HAS_BUDGETS = False
+
+
+# Distinct 64-hex upstream SHA-256 fixtures so provenance branches never collide by accident.
+HW = "1" * 64        # a weight shard's canonical upstream hash
+HW2 = "3" * 64       # a second weight shard
+HC = "2" * 64        # a config/aux file with an upstream hash
+MARGIN = capacity.EXPECTED_MARGIN
+RATIO = capacity.DEFAULT_FLOAT_RATIO
+
+
+def _require_pure():
+    if not (_HAS_CANDIDATES and _HAS_BUDGETS):
+        raise AssertionError(
+            "#36a must add the pure core modelark/candidates.py (requirements(inp)->RequirementGraph, "
+            "candidates(inp, graph)->CandidateSet with PlannerInput/DriveFact/ArchivedFileFact/Candidate/"
+            "ReusableFile/SourceIdentity/PendingHome/MovementCost/Satisfaction, no `con` params, no pin) "
+            "and the shared modelark/budgets.py (FileBudget/CandidateBudget + file_budget/aggregate), "
+            "and make reconcile_plan() a façade over the fact reader + pure core.")
+
+
+# --------------------------------------------------------------------------------------------------
+# Pure synthetic-input builders (no DB). Only constructed AFTER _require_pure() passes.
+# --------------------------------------------------------------------------------------------------
+def _mf(name, size, sha256, *, fmt="safetensors", quant="bf16"):
+    if fmt == "safetensors" and quant in archive_manifest.FLOAT_QUANTS:
+        action = "compress"
+    else:
+        action = "raw"
+    return archive_manifest.ManifestFile(
+        rfilename=name, size_bytes=size, sha256=sha256, format=fmt, quant=quant, storage_action=action)
+
+
+def _drive(label, *, role="primary", raid=False, cap=10**12, fscap=None, epoch=1,
+           fs_uuid=None, annex_uuid=None, serial=None):
+    return candidates.DriveFact(
+        drive_label=label, role=role, raid_backed=raid, capacity_bytes=cap,
+        filesystem_capacity_bytes=(cap if fscap is None else fscap), identity_epoch=epoch,
+        fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=serial)
+
+
+def _arch(repo, drive, name, *, sha=None, obytes=None, sbytes=None, key=None):
+    return candidates.ArchivedFileFact(
+        repo_id=repo, drive_label=drive, rfilename=name,
+        orig_sha256=sha, orig_bytes=obytes, stored_bytes=sbytes, annex_key=key)
+
+
+def _input(*, selection, manifests, numcopies, drives, archived, cfg=(), ratio=RATIO):
+    return candidates.PlannerInput(
+        plan_id="ark",
+        selection=tuple(selection),
+        manifests=tuple((repo, tuple(files)) for repo, files in manifests),
+        numcopies=tuple(numcopies),
+        drives=tuple(drives),
+        archived=tuple(archived),
+        compression_cfg=tuple(cfg),
+        float_ratio=ratio,
+    )
+
+
+def _run(inp):
+    graph = candidates.requirements(inp)
+    return graph, candidates.candidates(inp, graph)
+
+
+def _cands(cset, requirement_id):
+    for req_id, cand_tuple in cset.by_requirement:
+        if req_id == requirement_id:
+            return cand_tuple
+    return ()
+
+
+def _targets(cands):
+    return {c.target_drive for c in cands}
+
+
+def _missing_names(cand):
+    return {f.rfilename for f in cand.missing_files}
+
+
+def _reused_names(cand):
+    return {f.rfilename for f in cand.reused_files}
+
+
+# --------------------------------------------------------------------------------------------------
+# Change-contract matrix — RED until #36a lands. One compact table over the binding cases.
+# --------------------------------------------------------------------------------------------------
+def _scenario_metadata_only_stub():
+    """Aux proven, weights absent → one finish-in-place candidate; weights are exact missing identity."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("model.safetensors", 100, HW), _mf("config.json", 10, HC, fmt="aux", quant=None)])],
+        numcopies=[("org/m", 1)],
+        drives=[_drive("drive-01")],
+        archived=[_arch("org/m", "drive-01", "config.json", sha=HC, obytes=10, sbytes=10)],
+    )
+    graph, cset = _run(inp)
+    cands = _cands(cset, "primary:org/m")
+    assert _targets(cands) == {"drive-01"}, "expected one finish-in-place candidate on the partial drive"
+    c = cands[0]
+    assert _reused_names(c) == {"config.json"} and _missing_names(c) == {"model.safetensors"}
+    weight = next(f for f in c.missing_files if f.rfilename == "model.safetensors")
+    assert weight.size_bytes == 100 and weight.sha256 == HW and weight.storage_action == "compress"
+    assert c.movement_cost.transfer_bytes == 100      # raw acquisition bytes of the missing weight
+    assert c.budget.guaranteed_durable == 100
+
+
+def _scenario_partial_cant_hold_but_fresh_exists():
+    """#36a makes NO feasibility call: both the finish-in-place partial AND the fresh target are emitted."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW), _mf("b.safetensors", 100, HW2)])],
+        numcopies=[("org/m", 1)],
+        drives=[_drive("small", cap=1), _drive("fresh", cap=10**12)],
+        archived=[_arch("org/m", "small", "a.safetensors", sha=HW, obytes=100, sbytes=100)],
+    )
+    _, cset = _run(inp)
+    cands = _cands(cset, "primary:org/m")
+    assert _targets(cands) == {"small", "fresh"}, "tiny partial and roomy fresh target are BOTH alternatives"
+    small = next(c for c in cands if c.target_drive == "small")
+    fresh = next(c for c in cands if c.target_drive == "fresh")
+    assert _reused_names(small) == {"a.safetensors"} and _missing_names(small) == {"b.safetensors"}
+    assert _reused_names(fresh) == set() and _missing_names(fresh) == {"a.safetensors", "b.safetensors"}
+    assert not any(hasattr(c, "pinned_target") for c in cands)
+
+
+def _scenario_multiple_partial_drives():
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW), _mf("b.safetensors", 100, HW2)])],
+        numcopies=[("org/m", 1)],
+        drives=[_drive("d1"), _drive("d2")],
+        archived=[
+            _arch("org/m", "d1", "a.safetensors", sha=HW, obytes=100, sbytes=100),
+            _arch("org/m", "d2", "b.safetensors", sha=HW2, obytes=100, sbytes=100),
+        ],
+    )
+    _, cset = _run(inp)
+    cands = _cands(cset, "primary:org/m")
+    assert _targets(cands) == {"d1", "d2"}
+    assert _missing_names(next(c for c in cands if c.target_drive == "d1")) == {"b.safetensors"}
+    assert _missing_names(next(c for c in cands if c.target_drive == "d2")) == {"a.safetensors"}
+
+
+def _scenario_unproven_hash_blocks_target():
+    """Null archived hash on a required file → target OMITTED + drift; clean drive stays a fresh target."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+        numcopies=[("org/m", 1)],
+        drives=[_drive("legacy"), _drive("clean")],
+        archived=[_arch("org/m", "legacy", "a.safetensors", sha=None, obytes=100, sbytes=100)],
+    )
+    _, cset = _run(inp)
+    cands = _cands(cset, "primary:org/m")
+    assert _targets(cands) == {"clean"}, "unproven partial must not become a candidate (no silent overwrite)"
+    assert any(d.drive_label == "legacy" and d.rfilename == "a.safetensors" for d in cset.drift)
+
+
+def _scenario_mismatch_and_size_block_target():
+    for label, kw in (("hashbad", dict(sha="f" * 64, obytes=100)), ("sizebad", dict(sha=HW, obytes=999))):
+        inp = _input(
+            selection=["org/m"],
+            manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+            numcopies=[("org/m", 1)],
+            drives=[_drive("bad"), _drive("clean")],
+            archived=[_arch("org/m", "bad", "a.safetensors", sbytes=100, **kw)],
+        )
+        _, cset = _run(inp)
+        assert _targets(_cands(cset, "primary:org/m")) == {"clean"}, f"{label}: mismatched row must block its target"
+        assert any(d.drive_label == "bad" for d in cset.drift), f"{label}: drift not recorded"
+
+
+def _scenario_reuse_via_archived_hash_only():
+    """No upstream manifest SHA (git-tracked blob): a non-null archived orig_sha256 + size binds reuse."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("weights.safetensors", 100, HW),
+                              _mf("tokenizer.model", 20, None, fmt="aux", quant=None)])],
+        numcopies=[("org/m", 1)],
+        drives=[_drive("d1")],
+        archived=[
+            _arch("org/m", "d1", "weights.safetensors", sha=HW, obytes=100, sbytes=100),
+            _arch("org/m", "d1", "tokenizer.model", sha="a" * 64, obytes=20, sbytes=20),
+        ],
+    )
+    _, cset = _run(inp)
+    c = _cands(cset, "primary:org/m")[0]
+    tok = next(f for f in c.reused_files if f.rfilename == "tokenizer.model")
+    assert tok.proof_source == candidates.ProofSource.ARCHIVED_ORIG_SHA256 and tok.bound_hash == "a" * 64
+    w = next(f for f in c.reused_files if f.rfilename == "weights.safetensors")
+    assert w.proof_source == candidates.ProofSource.MANIFEST_SHA256 and w.bound_hash == HW
+
+
+def _scenario_format_and_byte_edges():
+    """GGUF, pickle, aux-only, zero-byte, and one huge shard all yield valid budgets."""
+    huge = 3 * 10**12
+    inp = _input(
+        selection=["g/gguf", "p/pt", "a/aux", "z/zero", "h/huge"],
+        manifests=[
+            ("g/gguf", [_mf("model.gguf", 50, HW, fmt="gguf", quant="Q4_K_M")]),
+            ("p/pt", [_mf("pytorch_model.bin", 50, HW, fmt="pytorch", quant="fp16")]),
+            ("a/aux", [_mf("readme.md", 5, None, fmt="aux", quant=None)]),
+            ("z/zero", [_mf("empty.safetensors", 0, HW)]),
+            ("h/huge", [_mf("shard.safetensors", huge, HW)]),
+        ],
+        numcopies=[(r, 1) for r in ("g/gguf", "p/pt", "a/aux", "z/zero", "h/huge")],
+        drives=[_drive("d1")],
+        archived=[],
+    )
+    _, cset = _run(inp)
+    gguf = _cands(cset, "primary:g/gguf")[0]
+    assert gguf.budget.guaranteed_durable == 50 and gguf.movement_cost.transfer_bytes == 50
+    huge_c = _cands(cset, "primary:h/huge")[0]
+    assert huge_c.budget.guaranteed_durable == huge
+    assert huge_c.budget.expected_durable == int(huge * RATIO * MARGIN)   # compressible float shard
+    zero_c = _cands(cset, "primary:z/zero")[0]
+    assert zero_c.budget.guaranteed_durable == 0
+
+
+def _scenario_complete_satisfaction_multi_copy():
+    """Numcopies=1 complete on two eligible drives → satisfaction lists both copies; no candidates."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+        numcopies=[("org/m", 1)],
+        drives=[_drive("d1"), _drive("d2")],
+        archived=[
+            _arch("org/m", "d1", "a.safetensors", sha=HW, obytes=100, sbytes=100),
+            _arch("org/m", "d2", "a.safetensors", sha=HW, obytes=100, sbytes=100),
+        ],
+    )
+    _, cset = _run(inp)
+    assert _cands(cset, "primary:org/m") == (), "a satisfied requirement emits no candidates"
+    sat = next(s for s in cset.satisfied if s.requirement_id == "primary:org/m")
+    assert {cp.drive_label for cp in sat.copies} == {"d1", "d2"}, "both complete copies are recorded, none chosen"
+
+
+def _scenario_protected_replica_pending_home():
+    """No home copy yet → replica candidates reference the home requirement, not a guessed source."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=[_drive("raid", raid=True), _drive("rep", role="replica")],
+        archived=[],
+    )
+    graph, cset = _run(inp)
+    home = _cands(cset, "protected_home:org/m")
+    rep = _cands(cset, "protected_replica:org/m")
+    assert _targets(home) == {"raid"}
+    assert _targets(rep) == {"rep"}
+    assert isinstance(rep[0].source, candidates.PendingHome)
+    assert rep[0].source.requirement_id == "protected_home:org/m"
+    assert rep[0].depends_on_requirement == "protected_home:org/m"
+
+
+def _scenario_protected_replica_singular_exact_sources():
+    """Two complete homes → ONE source-target candidate per exact SourceIdentity, each exact-costed."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=[_drive("raid1", raid=True), _drive("raid2", raid=True), _drive("rep", role="replica")],
+        archived=[
+            _arch("org/m", "raid1", "a.safetensors", sha=HW, obytes=100, sbytes=90, key="k1"),
+            _arch("org/m", "raid2", "a.safetensors", sha=HW, obytes=100, sbytes=88, key="k2"),
+        ],
+    )
+    _, cset = _run(inp)
+    rep = _cands(cset, "protected_replica:org/m")
+    sources = {c.source.drive_label for c in rep}
+    assert sources == {"raid1", "raid2"}, "one candidate per exact complete home source (no ExactSources bundle)"
+    assert all(isinstance(c.source, candidates.SourceIdentity) for c in rep)
+    by_src = {c.source.drive_label: c for c in rep}
+    assert by_src["raid1"].movement_cost.transfer_bytes == 90    # exact stored transfer from that source
+    assert by_src["raid2"].movement_cost.transfer_bytes == 88
+
+
+def _scenario_wrong_tier_complete_relocation_omitted():
+    """A complete copy on a non-eligible drive is drift, never an executable relocation candidate."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=[_drive("raid", raid=True), _drive("rep", role="replica"), _drive("plain")],
+        archived=[_arch("org/m", "plain", "a.safetensors", sha=HW, obytes=100, sbytes=100)],
+    )
+    _, cset = _run(inp)
+    home = _cands(cset, "protected_home:org/m")
+    assert "plain" not in _targets(home), "no annex-to-annex relocation candidate onto the eligible tier"
+    assert _targets(home) == {"raid"}
+    assert "protected_home:org/m" not in {s.requirement_id for s in cset.satisfied}
+    assert any(d.drive_label == "plain" for d in cset.drift)
+
+
+def _scenario_no_raid_single_largest_primary_fallback():
+    """Confirmed for this slice: with no RAID, protected_home eligibility is the single largest primary."""
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=[_drive("big", cap=9 * 10**12), _drive("small", cap=10**12), _drive("rep", role="replica")],
+        archived=[],
+    )
+    graph, cset = _run(inp)
+    home_req = next(r for r in graph.desired if r.requirement_id == "protected_home:org/m")
+    assert home_req.eligible_drives == ("big",), "no-RAID fallback is the single largest primary only"
+    assert _targets(_cands(cset, "protected_home:org/m")) == {"big"}
+
+
+_MATRIX = [
+    ("metadata_only_stub", _scenario_metadata_only_stub),
+    ("partial_cant_hold_but_fresh_exists", _scenario_partial_cant_hold_but_fresh_exists),
+    ("multiple_partial_drives", _scenario_multiple_partial_drives),
+    ("unproven_hash_blocks_target", _scenario_unproven_hash_blocks_target),
+    ("mismatch_and_size_block_target", _scenario_mismatch_and_size_block_target),
+    ("reuse_via_archived_hash_only", _scenario_reuse_via_archived_hash_only),
+    ("format_and_byte_edges", _scenario_format_and_byte_edges),
+    ("complete_satisfaction_multi_copy", _scenario_complete_satisfaction_multi_copy),
+    ("protected_replica_pending_home", _scenario_protected_replica_pending_home),
+    ("protected_replica_singular_exact_sources", _scenario_protected_replica_singular_exact_sources),
+    ("wrong_tier_complete_relocation_omitted", _scenario_wrong_tier_complete_relocation_omitted),
+    ("no_raid_single_largest_primary_fallback", _scenario_no_raid_single_largest_primary_fallback),
+]
+
+
+def test_contract_candidate_matrix():
+    _require_pure()
+    failures = []
+    for name, fn in _MATRIX:
+        try:
+            fn()
+        except AssertionError as exc:
+            failures.append(f"{name}: {exc}")
+    assert not failures, "matrix scenarios failed:\n  " + "\n  ".join(failures)
+
+
+def test_contract_no_pin_no_delete_deep_immutability():
+    _require_pure()
+    assert not any(f.name == "pinned_target" for f in dataclasses.fields(candidates.Candidate))
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+        numcopies=[("org/m", 1)],
+        drives=[_drive("d1")],
+        archived=[_arch("org/m", "d1", "a.safetensors", sha=HW, obytes=100, sbytes=100)],
+    )
+    archived_before = inp.archived
+    _, cset = _run(inp)
+    assert inp.archived is archived_before, "the pure path never mutates/rewrites archived facts"
+    # Deeply immutable: mutating any frozen record raises, and containers are tuples not lists/dicts.
+    sat = cset.satisfied[0]
+    caught = False
+    try:
+        sat.requirement_id = "x"                    # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        caught = True
+    assert caught, "records must be frozen"
+    assert isinstance(cset.satisfied, tuple) and isinstance(cset.by_requirement, tuple)
+
+
+def test_contract_determinism_and_stop_restart_reconstruction():
+    _require_pure()
+
+    def build(order):
+        drives = [_drive("d1"), _drive("d2"), _drive("rep", role="replica")]
+        archived = [
+            _arch("org/m", "d1", "a.safetensors", sha=HW, obytes=100, sbytes=100),
+            _arch("org/m", "d2", "b.safetensors", sha=HW2, obytes=100, sbytes=100),
+        ]
+        if order == "shuffled":
+            drives = list(reversed(drives))
+            archived = list(reversed(archived))
+        return _input(
+            selection=["org/m"],
+            manifests=[("org/m", [_mf("a.safetensors", 100, HW), _mf("b.safetensors", 100, HW2)])],
+            numcopies=[("org/m", 2)],
+            drives=drives,
+            archived=archived,
+        )
+
+    a1 = candidates.candidates(build("natural"), candidates.requirements(build("natural")))
+    a2 = candidates.candidates(build("shuffled"), candidates.requirements(build("shuffled")))
+    # Byte-equivalent reconstruction from unchanged durable facts (stop/restart), order-independent.
+    assert a1 == a2, "CandidateSet must be canonical and independent of input/query order"
+    g1 = candidates.requirements(build("natural"))
+    g2 = candidates.requirements(build("shuffled"))
+    assert g1.requirement_set_hash == g2.requirement_set_hash
+
+
+def test_contract_pure_no_io_boundary():
+    _require_pure()
+    for fn in (candidates.requirements, candidates.candidates):
+        params = set(inspect.signature(fn).parameters)
+        assert "con" not in params and "connection" not in params, f"{fn.__name__} must take no DB connection"
+    # Import boundary: the pure module pulls in no SQLite/transport.
+    assert getattr(candidates, "sqlite3", None) is None, "candidates.py must not import sqlite3"
+    assert getattr(candidates, "fetch", None) is None, "candidates.py must not import the transport"
+    # Proportional runtime proof: a full run under a poisoned connection still succeeds.
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("a.safetensors", 100, HW)])],
+        numcopies=[("org/m", 1)],
+        drives=[_drive("d1")],
+        archived=[],
+    )
+    with mock.patch("sqlite3.connect", side_effect=AssertionError("pure core must not touch SQLite")):
+        _run(inp)
+
+
+def test_contract_shared_budget_seam_exposes_both_modes():
+    _require_pure()
+    assert hasattr(budgets, "FileBudget") and hasattr(budgets, "CandidateBudget")
+    assert candidates.CandidateBudget is budgets.CandidateBudget, "one budget truth shared with capacity"
+    fb = budgets.file_budget(_mf("a.safetensors", 100, HW), RATIO, {})
+    assert fb.guaranteed_durable == 100 and fb.expected_durable == int(100 * RATIO * MARGIN)
+    assert hasattr(fb, "workspace_peak_guaranteed") and hasattr(fb, "workspace_peak_expected")
+
+
+# --------------------------------------------------------------------------------------------------
+# Characterization — GREEN now. Freezes executor-facing tiered_v1 placement the façade must preserve.
+# Deliberately BENIGN (finish-in-place fits; fresh spread) so the pin-can't-fit pathology is NOT frozen.
+# --------------------------------------------------------------------------------------------------
+def _mem():
+    con = sqlite3.connect(":memory:", isolation_level=None)
+    for statement in db._statements(db.SCHEMA_PATH.read_text()):
+        con.execute(statement)
+    con.execute("INSERT INTO plans(plan_id,name,is_active) VALUES('ark','Ark',1)")
+    return con
+
+
+def _db_drive(con, label, *, role="primary", raid=False, cap=10**9):
+    con.execute(
+        "INSERT INTO drives(drive_label,role,raid_backed,capacity_bytes,free_bytes) VALUES(?,?,?,?,?)",
+        [label, role, int(raid), cap, cap])
+    con.execute("INSERT INTO plan_drives(plan_id,drive_label) VALUES('ark',?)", [label])
+
+
+def _db_repo(con, repo, *, copies=1, files=(("model.safetensors", 100, "safetensors", "bf16"),), sha=HW):
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES(?,?)", [repo, copies])
+    con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES(?,'2026-01-01')", [repo])
+    con.executemany(
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant,sha256) VALUES(?,?,?,?,?,?)",
+        [(repo, name, size, fmt, quant, sha) for name, size, fmt, quant in files])
+
+
+def _db_archive(con, repo, drive, *rows):
+    con.executemany(
+        "INSERT INTO archived(repo_id,rfilename,drive_label,stored_bytes,orig_bytes,orig_sha256,compressed) "
+        "VALUES(?,?,?,?,?,?,0)",
+        [(repo, name, drive, sbytes, obytes, sha) for name, sbytes, obytes, sha in rows])
+
+
+def test_char_finish_in_place_when_partial_fits_is_preserved():
+    """A proven partial on an eligible primary that has room stays a finish-in-place target."""
+    with _admission_compat.seam_patch():
+        con = _mem()
+        _db_drive(con, "d1", cap=10**9)
+        _db_repo(con, "org/m", files=(
+            ("a.safetensors", 100, "safetensors", "bf16"),
+            ("b.safetensors", 100, "safetensors", "bf16")))
+        _db_archive(con, "org/m", "d1", ("a.safetensors", 100, 100, HW))
+        result = reconcile.reconcile_plan(con, "ark")
+        plan = capacity.plan_capacity(con, result, evidence_by_drive=_admission_compat.evidence_for_plan(con))
+        targets = {t.requirement_id: t.target_drive for t in plan.tasks}
+        assert targets.get("primary:org/m") == "d1", "finish-in-place placement must survive the façade refactor"
+        con.close()
+
+
+def test_char_fresh_bulk_spread_is_deterministic():
+    """Fresh placement across ample primaries is stable and repeatable — behavior the façade preserves."""
+    with _admission_compat.seam_patch():
+        con = _mem()
+        _db_drive(con, "d1", cap=10**9)
+        _db_drive(con, "d2", cap=10**9)
+        _db_repo(con, "org/a")
+        _db_repo(con, "org/b")
+        first = capacity.plan_capacity(
+            con, reconcile.reconcile_plan(con, "ark"),
+            evidence_by_drive=_admission_compat.evidence_for_plan(con))
+        again = capacity.plan_capacity(
+            con, reconcile.reconcile_plan(con, "ark"),
+            evidence_by_drive=_admission_compat.evidence_for_plan(con))
+        assert first.to_dict()["tasks"] == again.to_dict()["tasks"]
+        assert {t.requirement_id for t in first.tasks} == {"primary:org/a", "primary:org/b"}
+        con.close()
+
+
+def main():
+    tests = sorted((n, f) for n, f in globals().items()
+                   if n.startswith("test_") and callable(f))
+    passed, failed = [], []
+    for name, fn in tests:
+        try:
+            fn()
+            passed.append(name)
+            print(f"PASS  {name}")
+        except Exception as exc:                 # noqa: BLE001 — Gate-1 wants the full red/green map
+            failed.append(name)
+            print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
+    print(f"\n{len(passed)} passed, {len(failed)} failed")
+    print("(Gate-1 tests-only: the test_contract_* map is EXPECTED RED until #36a production lands;")
+    print(" the test_char_* characterization is GREEN and must stay green through the façade refactor.)")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -246,8 +246,11 @@ def _scenario_reuse_via_archived_hash_only():
     """No upstream manifest SHA (git-tracked blob): a non-null archived orig_sha256 + size binds reuse."""
     inp = _input(
         selection=["org/m"],
+        # A third un-archived file keeps the requirement INCOMPLETE, so both proven reused files are
+        # inspected on a finish-in-place candidate (not swallowed into a fully-satisfied requirement).
         manifests=[("org/m", [_mf("weights.safetensors", 100, HW),
-                              _mf("tokenizer.model", 20, None, fmt="aux", quant=None)])],
+                              _mf("tokenizer.model", 20, None, fmt="aux", quant=None),
+                              _mf("extra.safetensors", 50, HW2)])],
         numcopies=[("org/m", 1)],
         drives=[_drive("d1")],
         archived=[
@@ -257,6 +260,7 @@ def _scenario_reuse_via_archived_hash_only():
     )
     _, cset = _run(inp)
     c = _cands(cset, "primary:org/m")[0]
+    assert _missing_names(c) == {"extra.safetensors"}, "the un-archived file keeps a finish-in-place candidate"
     tok = next(f for f in c.reused_files if f.rfilename == "tokenizer.model")
     assert tok.proof_source == candidates.ProofSource.ARCHIVED_ORIG_SHA256 and tok.bound_hash == "a" * 64
     w = next(f for f in c.reused_files if f.rfilename == "weights.safetensors")

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -304,8 +304,12 @@ def _scenario_format_and_byte_edges():
     _, cset = _run(inp)
     gguf = _cands(cset, "primary:g/gguf")[0]
     assert gguf.budget.guaranteed_durable == 50 and gguf.movement_cost.transfer_bytes == 50
-    pt = _cands(cset, "primary:p/pt")           # pickle is stored raw (no compression)
-    assert len(pt) == 1 and pt[0].budget.guaranteed_durable == 50 and pt[0].budget.expected_durable == 50
+    pt = _cands(cset, "primary:p/pt")           # pickle is stored raw (no compression shrink)
+    # guaranteed == size proves no compression shrink for a raw file; expected still carries the shared
+    # seam's estimate margin (capacity applies EXPECTED_MARGIN to raw and compress alike — test_capacity
+    # pins the same margin-on-raw for a gguf replica estimate).
+    assert len(pt) == 1 and pt[0].budget.guaranteed_durable == 50
+    assert pt[0].budget.expected_durable == int(50 * MARGIN)
     aux = _cands(cset, "primary:a/aux")         # aux-only repo is stored raw
     assert len(aux) == 1 and aux[0].budget.guaranteed_durable == 5
     huge_c = _cands(cset, "primary:h/huge")[0]

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -494,20 +494,24 @@ def test_contract_pure_no_io_boundary():
     for fn in (candidates.requirements, candidates.candidates):
         params = set(inspect.signature(fn).parameters)
         assert "con" not in params and "connection" not in params, f"{fn.__name__} must take no DB connection"
-    # Import/dependency boundary, checked at the source (catches BOTH `import X` and `from X import Y`):
-    # neither pure module pulls in SQLite/socket/DB/transport, reads global config (wishlist), or
-    # re-enters the impure reconcile/capacity layer (which would also be an import cycle). Banning
-    # wishlist proves the budget path takes config as data and never consults global configuration.
-    banned = ("sqlite3", "socket", "modelark.fetch", "modelark.core.db",
-              "modelark.reconcile", "modelark.capacity", "modelark.wishlist")
+    # Import/dependency boundary, checked at the source: neither pure module may pull in SQLite/socket/
+    # DB/transport, read global config (wishlist), or re-enter the impure reconcile/capacity layer (also
+    # an import cycle). Banning wishlist proves the budget path takes config as data, never global config.
+    # Match on dotted COMPONENTS so every import form is covered, including the relative/aliased ones a
+    # fully-qualified prefix check misses: `import modelark.wishlist`, `from modelark import wishlist`
+    # (records the name, not just `modelark`), `from modelark.wishlist import x`, `from . import wishlist`
+    # (ImportFrom.module is None), and `from .wishlist import x` (module is the bare leaf `wishlist`).
+    banned = {"sqlite3", "socket", "wishlist", "fetch", "reconcile", "capacity", "db"}
     for module in (candidates, budgets):
-        imported = set()
+        names = set()
         for node in ast.walk(ast.parse(inspect.getsource(module))):
             if isinstance(node, ast.Import):
-                imported.update(alias.name for alias in node.names)
-            elif isinstance(node, ast.ImportFrom) and node.module:
-                imported.add(node.module)
-        offenders = sorted(m for m in imported if any(m == b or m.startswith(b + ".") for b in banned))
+                names.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    names.add(node.module)
+                names.update(alias.name for alias in node.names)   # `from pkg import submodule`
+        offenders = sorted(n for n in names if banned & set(n.split(".")))
         assert not offenders, f"pure {module.__name__} must not import {offenders}"
     # Proportional runtime proof: a full run under a poisoned connection still succeeds.
     inp = _input(

--- a/tests/test_candidates.py
+++ b/tests/test_candidates.py
@@ -43,6 +43,7 @@ Self-running: CI executes ``python tests/test_candidates.py`` directly.
 """
 from __future__ import annotations
 
+import ast
 import dataclasses
 import inspect
 import sqlite3
@@ -281,6 +282,10 @@ def _scenario_format_and_byte_edges():
     _, cset = _run(inp)
     gguf = _cands(cset, "primary:g/gguf")[0]
     assert gguf.budget.guaranteed_durable == 50 and gguf.movement_cost.transfer_bytes == 50
+    pt = _cands(cset, "primary:p/pt")           # pickle is stored raw (no compression)
+    assert len(pt) == 1 and pt[0].budget.guaranteed_durable == 50 and pt[0].budget.expected_durable == 50
+    aux = _cands(cset, "primary:a/aux")         # aux-only repo is stored raw
+    assert len(aux) == 1 and aux[0].budget.guaranteed_durable == 5
     huge_c = _cands(cset, "primary:h/huge")[0]
     assert huge_c.budget.guaranteed_durable == huge
     assert huge_c.budget.expected_durable == int(huge * RATIO * MARGIN)   # compressible float shard
@@ -401,8 +406,8 @@ def test_contract_candidate_matrix():
     for name, fn in _MATRIX:
         try:
             fn()
-        except AssertionError as exc:
-            failures.append(f"{name}: {exc}")
+        except Exception as exc:                 # noqa: BLE001 — keep the whole matrix map, not the first abort
+            failures.append(f"{name}: {type(exc).__name__}: {exc}")
     assert not failures, "matrix scenarios failed:\n  " + "\n  ".join(failures)
 
 
@@ -416,10 +421,9 @@ def test_contract_no_pin_no_delete_deep_immutability():
         drives=[_drive("d1")],
         archived=[_arch("org/m", "d1", "a.safetensors", sha=HW, obytes=100, sbytes=100)],
     )
-    archived_before = inp.archived
     _, cset = _run(inp)
-    assert inp.archived is archived_before, "the pure path never mutates/rewrites archived facts"
     # Deeply immutable: mutating any frozen record raises, and containers are tuples not lists/dicts.
+    # (No-mutate/no-delete of archived facts is proven by the drift scenarios preserving unproven rows.)
     sat = cset.satisfied[0]
     caught = False
     try:
@@ -464,9 +468,19 @@ def test_contract_pure_no_io_boundary():
     for fn in (candidates.requirements, candidates.candidates):
         params = set(inspect.signature(fn).parameters)
         assert "con" not in params and "connection" not in params, f"{fn.__name__} must take no DB connection"
-    # Import boundary: the pure module pulls in no SQLite/transport.
-    assert getattr(candidates, "sqlite3", None) is None, "candidates.py must not import sqlite3"
-    assert getattr(candidates, "fetch", None) is None, "candidates.py must not import the transport"
+    # Import/dependency boundary, checked at the source (catches BOTH `import X` and `from X import Y`):
+    # the pure module pulls in no SQLite/socket/DB/transport and never re-enters the impure
+    # reconcile/capacity layer (which would also be an import cycle).
+    banned = ("sqlite3", "socket", "modelark.fetch", "modelark.core.db",
+              "modelark.reconcile", "modelark.capacity")
+    imported = set()
+    for node in ast.walk(ast.parse(inspect.getsource(candidates))):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    offenders = sorted(m for m in imported if any(m == b or m.startswith(b + ".") for b in banned))
+    assert not offenders, f"pure candidates.py must not import {offenders}"
     # Proportional runtime proof: a full run under a poisoned connection still succeeds.
     inp = _input(
         selection=["org/m"],

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -90,8 +90,8 @@ def test_incident_shape_reserves_only_nine_missing_homes_and_fits():
         elif index < 124:
             _archive(con, repo, "raid", (("model.safetensors", 67, 100),))
 
-    graph = reconcile.reconcile_plan(con, "ark")
-    result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    result = capacity.plan_capacity(con, graph)
     home_tasks = [item for item in result.tasks
                   if item.requirement_id.startswith("protected_home:")]
     replica_tasks = [item for item in result.tasks
@@ -111,8 +111,8 @@ def test_replica_workspace_is_max_while_durable_is_sum():
         repo = f"org/model-{index}"
         _repo(con, repo, copies=2, files=(("model.gguf", 100, "gguf", None),))
         _archive(con, repo, "raid", (("model.gguf", 100, 100),))
-    graph = reconcile.reconcile_plan(con, "ark")
-    result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    result = capacity.plan_capacity(con, graph)
     ledger = next(item for item in result.ledgers if item.drive_label == "replica")
     assert result.feasible
     assert ledger.guaranteed_durable == 300
@@ -126,8 +126,8 @@ def test_unknown_zero_source_size_falls_back_to_replica_estimate():
     _drive(con, "replica", role="replica")
     _repo(con, "org/model", copies=2, files=(("model.gguf", 100, "gguf", None),))
     _archive(con, "org/model", "raid", (("model.gguf", 0, 100),))
-    graph = reconcile.reconcile_plan(con, "ark")
-    result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    result = capacity.plan_capacity(con, graph)
     task = next(item for item in result.tasks if item.kind == reconcile.TaskKind.REPLICATE)
     assert task.budget.evidence == "estimate"
     assert task.budget.guaranteed_durable == 108
@@ -137,8 +137,8 @@ def test_manifest_policy_diagnostic_makes_shadow_capacity_infeasible():
     con = _mem()
     _drive(con, "primary")
     _repo(con, "pickle/model", files=(("pytorch_model.bin", 100, "pytorch", "fp16"),))
-    graph = reconcile.reconcile_plan(con, "ark")
-    result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    result = capacity.plan_capacity(con, graph)
     assert result.blocking_diagnostics == ("MANIFEST_POLICY",)
     assert not result.feasible
 
@@ -147,8 +147,8 @@ def test_workspace_short_is_distinct_from_durable_short():
     con = _mem()
     _drive(con, "primary", capacity_bytes=1_000, free=200)
     _repo(con, "org/model")
-    graph = reconcile.reconcile_plan(con, "ark")
-    result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    result = capacity.plan_capacity(con, graph)
     failure = result.failures[0]
     assert failure.code == capacity.FailureCode.CAPACITY_WORKSPACE_SHORT
     assert failure.required_bytes > failure.available_bytes
@@ -159,8 +159,8 @@ def test_dependent_replica_failure_is_deduplicated_to_missing_home_tier():
     con = _mem()
     _drive(con, "replica", role="replica", capacity_bytes=100)
     _repo(con, "org/model", copies=2)
-    graph = reconcile.reconcile_plan(con, "ark")
-    result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    result = capacity.plan_capacity(con, graph)
     # #36a: a home with no eligible tier has no candidate, so it is a reconcile blocking diagnostic
     # (TARGET_TIER_MISSING) rather than a capacity failure. The dependent replica is still not reported
     # as a spurious capacity failure — the missing home tier remains the single root cause.
@@ -174,6 +174,40 @@ def test_dependent_replica_failure_is_deduplicated_to_missing_home_tier():
 # chooses only among canonical candidates whose targets are in-plan drives.)
 
 
+def test_all_targets_unproven_is_infeasible_not_silently_dropped():
+    # gap #1: the only eligible drive holds the required file with NO provable provenance (a legacy row).
+    # The target is omitted (never overwritten), the requirement is blocked, and the plan is INFEASIBLE
+    # with a typed provenance diagnostic — never a silent feasible=True with zero tasks.
+    con = _mem()
+    _drive(con, "primary")
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
+    con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES('org/m','2026-01-01')")
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
+                "VALUES('org/m','model.safetensors',100,'safetensors','bf16')")     # no manifest sha256
+    con.execute("INSERT INTO archived(repo_id,rfilename,drive_label,orig_bytes,stored_bytes,compressed) "
+                "VALUES('org/m','model.safetensors','primary',100,100,0)")           # no orig_sha256 → unproven
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    result = capacity.plan_capacity(con, graph)
+    assert graph.candidates.by_requirement == ()                                     # no candidate emitted
+    assert [b.reason for b in graph.candidates.blocked] == ["all_targets_unproven"]
+    assert "UNPROVEN_PROVENANCE" in result.blocking_diagnostics
+    assert not result.feasible
+
+
+def test_candidate_target_removed_after_reconcile_is_typed_stale_not_dropped():
+    # gap #1: a canonical candidate's drive leaves the plan between reconcile_plan() and plan_capacity().
+    # The requirement must surface as a typed stale-snapshot (TARGET_DRIVE_CHANGED), not vanish.
+    con = _mem()
+    _drive(con, "d1")
+    _repo(con, "org/m")
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    con.execute("DELETE FROM plan_drives WHERE drive_label='d1'")                    # stale snapshot
+    result = capacity.plan_capacity(con, graph)
+    assert not result.feasible
+    assert any(item.requirement_id == "primary:org/m"
+               and item.code == capacity.FailureCode.TARGET_DRIVE_CHANGED for item in result.failures)
+
+
 def test_compression_aware_mode_can_fit_where_guaranteed_durable_cannot():
     con = _mem()
     _drive(con, "primary", capacity_bytes=1_000, free=340)
@@ -182,12 +216,12 @@ def test_compression_aware_mode_can_fit_where_guaranteed_durable_cannot():
         files=(("a.safetensors", 100, "safetensors", "bf16"),
                ("b.safetensors", 100, "safetensors", "bf16")),
     )
-    graph = reconcile.reconcile_plan(con, "ark")
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
     guaranteed = capacity.plan_capacity(
-        con, graph, capacity_mode="guaranteed", compression_cfg=_cfg()
+        con, graph, capacity_mode="guaranteed"
     )
     aware = capacity.plan_capacity(
-        con, graph, capacity_mode="compression_aware", compression_cfg=_cfg()
+        con, graph, capacity_mode="compression_aware"
     )
     assert not guaranteed.feasible
     assert guaranteed.failures[0].code == capacity.FailureCode.CAPACITY_WORKSPACE_SHORT
@@ -235,9 +269,9 @@ def test_tiered_v1_is_deterministic_raid_first_and_smallest_replica():
     _repo(con, "org/protected", copies=2, files=(("p.gguf", 200, "gguf", None),))
     _repo(con, "org/bulk-a", files=(("a.gguf", 300, "gguf", None),))
     _repo(con, "org/bulk-b", files=(("b.gguf", 250, "gguf", None),))
-    graph = reconcile.reconcile_plan(con, "ark")
-    first = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
-    second = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+    graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+    first = capacity.plan_capacity(con, graph)
+    second = capacity.plan_capacity(con, graph)
     assert first.to_dict() == second.to_dict()
     targets = {item.requirement_id: item.target_drive for item in first.tasks}
     assert targets["protected_home:org/protected"] == "raid"
@@ -346,8 +380,8 @@ def test_phase2_candidate_cross_product_stays_bounded():
         # built in reconcile_plan -> candidates(); placement wraps them without recomputation. Count the
         # per-file budget calls there: 1000 repos × 10 eligible primaries × 1 missing file = 10k, bounded.
         with mock.patch.object(budgets, "file_budget", side_effect=counted):
-            graph = reconcile.reconcile_plan(con, "ark")
-            result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+            graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
+            result = capacity.plan_capacity(con, graph)
         elapsed = time.perf_counter() - started
         assert elapsed < 2.0, f"10k-candidate placement took {elapsed:.3f}s"
         assert calls == 10_000

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import sqlite3
 import time
-from dataclasses import replace
 from unittest import mock
 
 import pytest
@@ -43,17 +42,19 @@ def _drive(con, label, *, role="primary", raid=False, capacity_bytes=10_000, fre
 def _repo(con, repo, *, copies=1, files=(("model.safetensors", 100, "safetensors", "bf16"),)):
     con.execute("INSERT INTO models(repo_id,numcopies) VALUES(?,?)", [repo, copies])
     con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES(?,'2026-01-01')", [repo])
+    # #36a: manifest sha256 lets the matching archived orig_sha256 prove reuse.
     con.executemany(
-        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) VALUES(?,?,?,?,?)",
-        [(repo, name, size, fmt, quant) for name, size, fmt, quant in files],
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant,sha256) VALUES(?,?,?,?,?,?)",
+        [(repo, name, size, fmt, quant, f"sha-{repo}-{name}") for name, size, fmt, quant in files],
     )
 
 
 def _archive(con, repo, drive, rows):
+    # Reusable archived content proves provenance: orig_sha256 matches the manifest sha256 for that file.
     con.executemany(
-        "INSERT INTO archived(repo_id,rfilename,drive_label,stored_bytes,orig_bytes,compressed) "
-        "VALUES(?,?,?,?,?,?)",
-        [(repo, name, drive, stored, original, int(stored < original))
+        "INSERT INTO archived(repo_id,rfilename,drive_label,orig_sha256,stored_bytes,orig_bytes,compressed) "
+        "VALUES(?,?,?,?,?,?,?)",
+        [(repo, name, drive, f"sha-{repo}-{name}", stored, original, int(stored < original))
          for name, stored, original in rows],
     )
 
@@ -160,31 +161,17 @@ def test_dependent_replica_failure_is_deduplicated_to_missing_home_tier():
     _repo(con, "org/model", copies=2)
     graph = reconcile.reconcile_plan(con, "ark")
     result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
-    assert [item.code for item in result.failures] == [capacity.FailureCode.TARGET_TIER_MISSING]
-    assert result.failures[0].requirement_id == "protected_home:org/model"
-    assert any(item.requirement_id == "protected_replica:org/model"
-               for item in result.unassigned_intents)
-
-
-def test_stale_home_pin_cannot_create_an_unledgered_feasible_task():
-    con = _mem()
-    _drive(con, "raid", raid=True)
-    _drive(con, "replica", role="replica")
-    _repo(con, "org/model", copies=2)
-    graph = reconcile.reconcile_plan(con, "ark")
-    home = next(item for item in graph.intents
-                if item.requirement_id == "protected_home:org/model")
-    stale_home = replace(home, pinned_target="removed-drive")
-    graph = replace(
-        graph,
-        intents=tuple(stale_home if item is home else item for item in graph.intents),
-    )
-    result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
+    # #36a: a home with no eligible tier has no candidate, so it is a reconcile blocking diagnostic
+    # (TARGET_TIER_MISSING) rather than a capacity failure. The dependent replica is still not reported
+    # as a spurious capacity failure — the missing home tier remains the single root cause.
     assert not result.feasible
-    assert all(item.target_drive != "removed-drive" for item in result.tasks)
-    failure = next(item for item in result.failures
-                   if item.requirement_id == "protected_home:org/model")
-    assert failure.code == capacity.FailureCode.GRAPH_INVARIANT
+    assert "TARGET_TIER_MISSING" in result.blocking_diagnostics
+    assert not any(item.requirement_id == "protected_replica:org/model" for item in result.failures)
+
+
+# (Removed test_stale_home_pin_cannot_create_an_unledgered_feasible_task: #36a removes _choose_partial /
+# WorkIntent.pinned_target entirely, so a stale reconcile-side pin can no longer exist. Placement now
+# chooses only among canonical candidates whose targets are in-plan drives.)
 
 
 def test_compression_aware_mode_can_fit_where_guaranteed_durable_cannot():
@@ -344,9 +331,9 @@ def test_phase2_candidate_cross_product_stays_bounded():
     con.execute("COMMIT")
     del files, archived
 
-    graph = reconcile.reconcile_plan(con, "ark")
+    from modelark import budgets
     calls = 0
-    original = capacity._fetch_budget
+    original = budgets.file_budget
 
     def counted(*args, **kwargs):
         nonlocal calls
@@ -355,7 +342,11 @@ def test_phase2_candidate_cross_product_stays_bounded():
 
     try:
         started = time.perf_counter()
-        with mock.patch.object(capacity, "_fetch_budget", side_effect=counted):
+        # #36a: the candidate cross-product (one shared-seam budget per requirement×eligible-target) is
+        # built in reconcile_plan -> candidates(); placement wraps them without recomputation. Count the
+        # per-file budget calls there: 1000 repos × 10 eligible primaries × 1 missing file = 10k, bounded.
+        with mock.patch.object(budgets, "file_budget", side_effect=counted):
+            graph = reconcile.reconcile_plan(con, "ark")
             result = capacity.plan_capacity(con, graph, compression_cfg=_cfg())
         elapsed = time.perf_counter() - started
         assert elapsed < 2.0, f"10k-candidate placement took {elapsed:.3f}s"

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -41,17 +41,26 @@ def _drive(con, label, *, role="primary", raid=False, capacity=10**12, identity=
 def _repo(con, repo, *, copies=1, files=(("model.safetensors", 100, "safetensors", "bf16"),)):
     con.execute("INSERT INTO models(repo_id,numcopies) VALUES(?,?)", [repo, copies])
     con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES(?,'2026-01-01')", [repo])
+    # #36a: valid archived content needs provable provenance — give every file a manifest sha256 so its
+    # matching archived orig_sha256 (below) binds reuse. Intentional legacy/hashless cases pass sha=None.
     con.executemany(
-        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) VALUES(?,?,?,?,?)",
-        [(repo, name, size, fmt, quant) for name, size, fmt, quant in files],
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant,sha256) VALUES(?,?,?,?,?,?)",
+        [(repo, name, size, fmt, quant, f"sha-{repo}-{name}") for name, size, fmt, quant in files],
     )
 
 
 def _archive(con, repo, drive, *names):
-    con.executemany(
-        "INSERT INTO archived(repo_id,rfilename,drive_label,stored_bytes,compressed) VALUES(?,?,?,?,0)",
-        [(repo, name, drive, 1) for name in names],
-    )
+    # Reusable archived content: orig_sha256 == the manifest sha256 and orig_bytes == the manifest size.
+    for name in names:
+        row = con.execute(
+            "SELECT size_bytes, sha256 FROM files WHERE repo_id=? AND rfilename=?", [repo, name]
+        ).fetchone()
+        size, sha = (row[0], row[1]) if row else (1, None)
+        con.execute(
+            "INSERT INTO archived(repo_id,rfilename,drive_label,orig_sha256,orig_bytes,stored_bytes,compressed) "
+            "VALUES(?,?,?,?,?,?,0)",
+            [repo, name, drive, sha, size, 1],
+        )
 
 
 def test_incident_shape_creates_only_nine_home_fetches_and_shadow_removes_116_phantoms():
@@ -78,8 +87,14 @@ def test_incident_shape_creates_only_nine_home_fetches_and_shadow_removes_116_ph
     assert len(replicas) == 125
     assert sum(i.source_drive == "drive-00" for i in replicas) == 116
     assert sum(i.depends_on_requirement is not None for i in replicas) == 9
-    assert all(i.pinned_target == "drive-00" for i in homes[:8])
-    assert homes[-1].pinned_target is None
+    # #36a: reconcile emits no pin. The 8 shard-partial homes carry a finish-in-place candidate on
+    # drive-00 (reused files); the 9th (nothing archived) has a fresh-only candidate. #38 chooses.
+    by_req = dict(result.candidates.by_requirement)
+    home_reqs = [r for r in by_req if r.startswith("protected_home:")]
+    assert len(home_reqs) == 9
+    assert sum(any(c.reused_files for c in by_req[r]) for r in home_reqs) == 8
+    assert sum(all(not c.reused_files for c in by_req[r]) for r in home_reqs) == 1
+    assert all(c.target_drive == "drive-00" for r in home_reqs for c in by_req[r])
 
     report = reconcile.shadow_report(con, "ark")
     assert report["shadow"]["satisfied_legacy_reservations_removed"] == 116
@@ -105,11 +120,15 @@ def test_exact_sets_prevent_extra_file_from_masking_missing_required_file():
     fact = next(f for f in result.facts if f.drive_label == "raid")
     assert not fact.complete
     assert fact.required_files == {"model.safetensors", "config.json"}
-    home = next(i for i in result.intents if i.requirement_id.startswith("protected_home:"))
-    assert home.pinned_target == "raid"
+    # #36a: the finish-in-place candidate on raid reuses the proven weight and lists the missing config
+    # as exact work — the extra ignored.onnx never masks the missing required file.
+    home_cands = dict(result.candidates.by_requirement)["protected_home:org/model"]
+    on_raid = next(c for c in home_cands if c.target_drive == "raid")
+    assert {f.rfilename for f in on_raid.reused_files} == {"model.safetensors"}
+    assert {f.rfilename for f in on_raid.missing_files} == {"config.json"}
 
 
-def test_multiple_partials_choose_least_missing_without_unioning_drives():
+def test_multiple_partials_are_emitted_without_unioning_drives():
     con = _mem()
     _drive(con, "raid-a", raid=True)
     _drive(con, "raid-b", raid=True)
@@ -125,8 +144,12 @@ def test_multiple_partials_choose_least_missing_without_unioning_drives():
     _archive(con, "org/model", "raid-a", "model.safetensors", "config.json")
     _archive(con, "org/model", "raid-b", "config.json", "tokenizer.json")
     result = reconcile.reconcile_plan(con, "ark")
-    home = next(i for i in result.intents if i.requirement_id.startswith("protected_home:"))
-    assert home.pinned_target == "raid-a"  # 20 missing vs 100 missing
+    # #36a emits BOTH finish-in-place partials as separate candidates (no union, no choice — #38 ranks
+    # by the least-missing cost). raid-a misses only tokenizer.json; raid-b misses model.safetensors.
+    by_target = {c.target_drive: c for c in dict(result.candidates.by_requirement)["protected_home:org/model"]}
+    assert set(by_target) == {"raid-a", "raid-b"}
+    assert {f.rfilename for f in by_target["raid-a"].missing_files} == {"tokenizer.json"}
+    assert {f.rfilename for f in by_target["raid-b"].missing_files} == {"model.safetensors"}
     assert not any(f.complete for f in result.facts)
 
 

--- a/tests/test_replan.py
+++ b/tests/test_replan.py
@@ -125,10 +125,10 @@ def _executor_harness(*, failed=()):
             for item in task_manifests[repo]:
                 con.execute(
                     "INSERT OR IGNORE INTO archived"
-                    "(repo_id,rfilename,drive_label,orig_bytes,stored_bytes,compressed,annex_key) "
-                    "VALUES(?,?,?,?,?,0,?)",
-                    [repo, item.rfilename, drive_label, item.size_bytes, item.size_bytes,
-                     f"key-{repo}-{item.rfilename}"],
+                    "(repo_id,rfilename,drive_label,orig_sha256,orig_bytes,stored_bytes,compressed,annex_key) "
+                    "VALUES(?,?,?,?,?,?,0,?)",
+                    [repo, item.rfilename, drive_label, f"sha-{repo}-{item.rfilename}",
+                     item.size_bytes, item.size_bytes, f"key-{repo}-{item.rfilename}"],
                 )
             stored.append(repo)
         return {"stored_repos": stored, "failed_repos": bad, "capacity_failure": None,
@@ -141,14 +141,14 @@ def _executor_harness(*, failed=()):
         for task in tasks:
             for name in task.budget.missing_files:
                 row = con.execute(
-                    "SELECT orig_bytes,stored_bytes,compressed,annex_key FROM archived "
+                    "SELECT orig_sha256,orig_bytes,stored_bytes,compressed,annex_key FROM archived "
                     "WHERE repo_id=? AND rfilename=? AND drive_label=?",
                     [task.repo_id, name, task.source_drive],
                 ).fetchone()
                 con.execute(
                     "INSERT OR IGNORE INTO archived"
-                    "(repo_id,rfilename,drive_label,orig_bytes,stored_bytes,compressed,annex_key) "
-                    "VALUES(?,?,?,?,?,?,?)", [task.repo_id, name, task.target_drive, *row],
+                    "(repo_id,rfilename,drive_label,orig_sha256,orig_bytes,stored_bytes,compressed,annex_key) "
+                    "VALUES(?,?,?,?,?,?,?,?)", [task.repo_id, name, task.target_drive, *row],
                 )
                 copied += 1
         return {"deferred": False, "source_offline": False, "deferred_targets": [],
@@ -173,8 +173,8 @@ def test_satisfied_home_copy_is_not_reserved_or_fetched_again():
     con, calls, fake_run, fake_replica = _executor_harness()
     con.execute(
         "INSERT INTO archived"
-        "(repo_id,rfilename,drive_label,orig_bytes,stored_bytes,compressed,annex_key) "
-        "VALUES('must','model.gguf','drive-00',200,200,0,'key-must-model.gguf')"
+        "(repo_id,rfilename,drive_label,orig_sha256,orig_bytes,stored_bytes,compressed,annex_key) "
+        "VALUES('must','model.gguf','drive-00','sha-must-model.gguf',200,200,0,'key-must-model.gguf')"
     )
     with mock.patch.object(fill.fetch, "run", side_effect=fake_run), \
          mock.patch.object(fill.fetch, "run_replica_tasks", side_effect=fake_replica), \
@@ -192,8 +192,8 @@ def test_bulk_fetch_always_ranks_before_partial_replica():
     con, _, _, _ = _executor_harness()
     con.execute(
         "INSERT INTO archived"
-        "(repo_id,rfilename,drive_label,orig_bytes,stored_bytes,compressed,annex_key) "
-        "VALUES('must','model.gguf','drive-00',200,200,0,'key-must-model.gguf')"
+        "(repo_id,rfilename,drive_label,orig_sha256,orig_bytes,stored_bytes,compressed,annex_key) "
+        "VALUES('must','model.gguf','drive-00','sha-must-model.gguf',200,200,0,'key-must-model.gguf')"
     )
     snapshot = fill._reconcile(fetch.RunCtx(con=con), "ark", "guaranteed", None)
     fetch_tasks = [task for task in snapshot.ledger.tasks if task.kind == reconcile.TaskKind.FETCH]


### PR DESCRIPTION
## Logical #36a — pure requirements/candidates (RFC-002 / DEC-049)

Replaces `reconcile._choose_partial` / `WorkIntent.pinned_target` authority with a pure functional core. For every unsatisfied required copy, the core emits **all** verified finish-in-place partials and **all** policy-permitted fresh targets with exact reuse/provenance, exact missing-file identity, deterministic costs, and singular replica sources — and **chooses nothing**. #38 consumes the canonical `CandidateSet`, ranks reuse, and selects targets; the operator-visible pinning defect persists until then.

- Base: `fix/placement-capacity-hardening` (frozen-lineage integration branch; no `main` merge/rebase).
- Issue: https://github.com/Auspex-Aerie/modelark/issues/36 (logical #36a).

### What landed
- **`modelark/candidates.py`** (pure; no DB/FS/config/clock/network): `PlannerInput`/`DriveFact`/`ArchivedFileFact` + `RequirementGraph`/`CandidateSet` are the sole semantic authority for satisfaction, reuse, sources, and candidate work. Hash-bound reuse; a target holding any unproven/mismatched required row is omitted and preserved as drift (never overwritten); every requirement is accounted as exactly one of satisfied / candidate / blocked.
- **`modelark/budgets.py`** (pure shared seam): `FileBudget`/`CandidateBudget` + `file_budget`/`aggregate` — one budget truth for both the capacity path and candidates.
- **`modelark/reconcile.py`**: `reconcile_plan()` is a compatibility façade over `capture_planner_input` (one consistent read transaction; config/ratio frozen in) plus the pure core. It exposes `result.candidates` and projects the legacy fields from it; blocked requirements become BLOCKING diagnostics.
- **`modelark/capacity.py`**: `plan_capacity` is the temporary legacy `tiered_v1` adapter (removed at #38) — chooses only among canonical candidates, accounts every requirement, and rejects the obsolete `compression_cfg` argument. `capacity.FileBudget is budgets.FileBudget`.
- **`modelark/librarian.py`**: copy-2 hint derives from the eligible candidate (no pin).
- Test-fixture provenance migration (separate commit) and two regressions (all-targets-unproven, candidate-target-removal).

### Behavior change (required, #36 contract)
A migrated hashless archived row is now **drift** — it cannot satisfy a requirement, earn reuse credit, or serve as a replica source until provenance is proven (`fetch.py` records `orig_sha256` at ingest; `hash_repair.py` backfills legacy rows).

### Validation
CI green (test 3.10/3.12, e2e); Greptile pass, zero findings. Locally: 8/8 pure-core contract tests; 250+ pytest across all suites touching the changed modules; full non-e2e CI-style + e2e green; ruff clean; wheel ships both new modules with import/wiring smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)