### PR TITLE
PR-07 (#37) Gate 2: lifecycle/eligibility schema, planner, bootstrap (production)

### DIFF
--- a/modelark/candidates.py
+++ b/modelark/candidates.py
@@ -49,6 +49,9 @@ class DriveFact:
     fs_uuid: str | None = None
     annex_uuid: str | None = None
     serial: str | None = None
+    # Catalog v4 (#37): orthogonal durable axes. Defaults match schema migration safe defaults.
+    lifecycle: str = "active"       # active | lost | retired
+    eligibility: str = "enabled"    # enabled | excluded
 
 
 @dataclass(frozen=True)
@@ -172,17 +175,66 @@ class PlannerInput:
 
 
 # ------------------------------------------------------------------------------------------------
+# Lifecycle × eligibility helpers (#37)
+# ------------------------------------------------------------------------------------------------
+def _is_placeable(drive: DriveFact) -> bool:
+    """New placement / finish-in-place writes require active + enabled."""
+    return drive.lifecycle == "active" and drive.eligibility == "enabled"
+
+
+def _is_satisfying(drive: DriveFact) -> bool:
+    """Verified complete copies count on any active drive (enabled or excluded)."""
+    return drive.lifecycle == "active"
+
+
+def _satisfaction_pool(req: CopyRequirement, by_label: dict[str, DriveFact]) -> tuple[str, ...]:
+    """Role-tier drives that may satisfy ``req`` — lifecycle-active only; eligibility unrestricted.
+
+    Placement targets remain ``req.eligible_drives`` (placeable-only from :func:`requirements`).
+    """
+    order = sorted(by_label)
+    active_primary = tuple(
+        label for label in order
+        if by_label[label].role == "primary" and _is_satisfying(by_label[label])
+    )
+    active_raids = tuple(label for label in active_primary if by_label[label].raid_backed)
+    active_replicas = tuple(
+        label for label in order
+        if by_label[label].role == "replica" and _is_satisfying(by_label[label])
+    )
+    if req.kind == RequirementKind.PRIMARY:
+        return active_primary
+    if req.kind == RequirementKind.PROTECTED_HOME:
+        # RAID homes when any active RAID primary exists; else any active primary (no-RAID fleet).
+        return active_raids if active_raids else active_primary
+    if req.kind == RequirementKind.PROTECTED_REPLICA:
+        return active_replicas
+    return ()
+
+
+# ------------------------------------------------------------------------------------------------
 # Requirements
 # ------------------------------------------------------------------------------------------------
 def requirements(inp: PlannerInput) -> RequirementGraph:
     """Desired copy set: numcopies<2 → one primary copy; numcopies≥2 → a protected home plus an
     independent replica. Home eligibility is RAID-backed primaries, or (no-RAID fallback for this slice)
-    the single largest primary. Only repositories with a supported manifest yield requirements."""
+    the single largest primary. Only repositories with a supported manifest yield requirements.
+
+    ``eligible_drives`` lists **placeable** targets only (active+enabled). Satisfaction may still
+    use active+excluded complete copies via :func:`candidates` satisfaction pool.
+    """
     by_label = {d.drive_label: d for d in inp.drives}
     order = sorted(by_label)
-    primary = tuple(label for label in order if by_label[label].role == "primary")
+    # Fresh placement / fallback selection never targets non-placeable drives (#37).
+    primary = tuple(
+        label for label in order
+        if by_label[label].role == "primary" and _is_placeable(by_label[label])
+    )
     raids = tuple(label for label in primary if by_label[label].raid_backed)
-    replicas = tuple(label for label in order if by_label[label].role == "replica")
+    replicas = tuple(
+        label for label in order
+        if by_label[label].role == "replica" and _is_placeable(by_label[label])
+    )
     fallback: tuple[str, ...] = ()
     if not raids and primary:
         fallback = (sorted(primary, key=lambda label: (-by_label[label].capacity_bytes, label))[0],)
@@ -246,7 +298,8 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
     manifests = dict(inp.manifests)
     cfg = dict(inp.compression_cfg)
     ratio = inp.float_ratio
-    eligible_all = {d.drive_label for d in inp.drives}
+    by_label = {d.drive_label: d for d in inp.drives}
+    known_labels = set(by_label)
     archived: dict[tuple[str, str], dict[str, ArchivedFileFact]] = {}
     for row in inp.archived:
         archived.setdefault((row.repo_id, row.drive_label), {})[row.rfilename] = row
@@ -259,11 +312,14 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
 
     for req in graph.desired:
         manifest = manifests[req.repo_id]
-        eligible = req.eligible_drives
+        # Placeable write targets (active+enabled, role-filtered by requirements).
+        place_pool = set(req.eligible_drives)
+        # Satisfaction may also use active+excluded complete copies on the same role tier.
+        sat_pool = _satisfaction_pool(req, by_label)
 
         complete: list[tuple[str, tuple[ReusableFile, ...]]] = []
         valid: list[tuple[str, tuple[ReusableFile, ...], tuple[archive_manifest.ManifestFile, ...]]] = []
-        for label in eligible:
+        for label in sat_pool:
             rows = archived.get((req.repo_id, label), {})
             reused: list[ReusableFile] = []
             missing: list[archive_manifest.ManifestFile] = []
@@ -275,18 +331,24 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
                 elif verdict == "proven":
                     reused.append(_reusable(mf, rows[mf.rfilename]))
                 else:
-                    drift.append(DriftRow(req.requirement_id, label, mf.rfilename, "unproven_provenance"))
+                    # Unproven on a placeable target is drift + omit; on excluded/non-placeable,
+                    # still omit from satisfaction but only drift placeable overwrites.
+                    if label in place_pool:
+                        drift.append(DriftRow(
+                            req.requirement_id, label, mf.rfilename, "unproven_provenance"))
                     target_blocked = True
             if target_blocked:
-                continue                                   # target omitted — never overwrite an unproven row
+                continue                                   # never overwrite an unproven row
             reused_t = tuple(sorted(reused, key=lambda item: item.rfilename))
             if missing:
-                valid.append((label, reused_t, tuple(sorted(missing, key=lambda item: item.rfilename))))
+                # Finish-in-place / fresh write targets must be placeable (active+enabled).
+                if label in place_pool:
+                    valid.append((label, reused_t, tuple(sorted(missing, key=lambda item: item.rfilename))))
             else:
                 complete.append((label, reused_t))
 
-        # Wrong-tier: a proven-complete copy on a non-eligible drive is drift, not a relocation candidate.
-        for label in sorted(eligible_all - set(eligible)):
+        # Wrong-tier: a proven-complete copy outside the satisfaction pool is drift, not relocation.
+        for label in sorted(known_labels - set(sat_pool)):
             rows = archived.get((req.repo_id, label), {})
             if rows and all(_proof(mf, rows.get(mf.rfilename)) == "proven" for mf in manifest):
                 for mf in manifest:
@@ -301,7 +363,7 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
             continue
 
         cands: list[Candidate] = []
-        sources = _home_sources(req, reqs_by_id, manifest, archived) \
+        sources = _home_sources(req, reqs_by_id, manifest, archived, by_label) \
             if req.kind == RequirementKind.PROTECTED_REPLICA else ()
         for label, reused, missing in valid:
             if req.kind == RequirementKind.PROTECTED_REPLICA:
@@ -319,7 +381,7 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
         else:
             # No satisfying copy and no valid candidate: an eligible drive that produced no candidate did
             # so only because an unproven/mismatched required row omitted it. Account it as blocked.
-            reason = "no_eligible_tier" if not eligible else "all_targets_unproven"
+            reason = "no_eligible_tier" if not place_pool else "all_targets_unproven"
             blocked.append(BlockedRequirement(req.requirement_id, reason))
 
     satisfied.sort(key=lambda item: item.requirement_id)
@@ -329,12 +391,13 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
     return CandidateSet(tuple(satisfied), tuple(by_requirement), tuple(drift), tuple(blocked))
 
 
-def _home_sources(req, reqs_by_id, manifest, archived) -> tuple[SourceIdentity, ...]:
+def _home_sources(req, reqs_by_id, manifest, archived, by_label) -> tuple[SourceIdentity, ...]:
+    """Replica SourceIdentity from active complete homes — includes active+excluded; never lost/retired."""
     home = reqs_by_id.get(req.independent_of)
     if home is None:
         return ()
     sources: list[SourceIdentity] = []
-    for label in home.eligible_drives:
+    for label in _satisfaction_pool(home, by_label):
         rows = archived.get((req.repo_id, label), {})
         if rows and all(_proof(mf, rows.get(mf.rfilename)) == "proven" for mf in manifest):
             key = orig = None

--- a/modelark/candidates.py
+++ b/modelark/candidates.py
@@ -188,11 +188,14 @@ def _is_satisfying(drive: DriveFact) -> bool:
 
 
 def _satisfaction_pool(req: CopyRequirement, by_label: dict[str, DriveFact]) -> tuple[str, ...]:
-    """Canonical satisfaction tier for ``req`` — lifecycle-active only; eligibility unrestricted.
+    """Canonical active satisfaction tier for ``req`` — lifecycle-active only; eligibility unrestricted.
 
     Placement targets remain ``req.eligible_drives`` (placeable-only from :func:`requirements`).
     Protected-home mirrors placement policy shape: active RAID primaries when any exist, else the
     single largest active primary (not every active primary).
+
+    Accepted *complete* satisfaction is the union of this tier and the authorized placement tier
+    (:func:`_accepted_complete_pool`); fresh/partial writes stay placeable-only.
     """
     order = sorted(by_label)
     active_primary = tuple(
@@ -216,6 +219,16 @@ def _satisfaction_pool(req: CopyRequirement, by_label: dict[str, DriveFact]) -> 
     if req.kind == RequirementKind.PROTECTED_REPLICA:
         return active_replicas
     return ()
+
+
+def _accepted_complete_pool(req: CopyRequirement, by_label: dict[str, DriveFact]) -> set[str]:
+    """Drives whose complete proven copy may satisfy ``req`` / source a replica (#37 finding 15).
+
+    Union of the canonical active satisfaction tier and the current authorized placement tier
+    (``req.eligible_drives``). A drive the planner may write home onto must still count once the
+    write is complete — otherwise the next reconcile refuses its own placement.
+    """
+    return set(_satisfaction_pool(req, by_label)) | set(req.eligible_drives)
 
 
 # ------------------------------------------------------------------------------------------------
@@ -320,11 +333,10 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
         manifest = manifests[req.repo_id]
         # Placeable write targets (active+enabled, role-filtered by requirements).
         place_pool = set(req.eligible_drives)
-        # Canonical satisfaction tier (may include active+excluded; shape matches home policy).
-        sat_pool = set(_satisfaction_pool(req, by_label))
-        # Scan the union so placement targets are not omitted when they diverge from sat_pool
-        # (e.g. excluded RAID in sat_pool + plain placeable fallback in place_pool).
-        scan_labels = sorted(sat_pool | place_pool)
+        # Accepted complete satisfaction = canonical active tier ∪ authorized placement tier.
+        accepted_complete = _accepted_complete_pool(req, by_label)
+        # Scan the same union so placement targets and sat-tier drives are both assessed.
+        scan_labels = sorted(accepted_complete)
 
         complete: list[tuple[str, tuple[ReusableFile, ...]]] = []
         valid: list[tuple[str, tuple[ReusableFile, ...], tuple[archive_manifest.ManifestFile, ...]]] = []
@@ -353,12 +365,11 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
                 # Finish-in-place / fresh write targets must be placeable (active+enabled).
                 if label in place_pool:
                     valid.append((label, reused_t, tuple(sorted(missing, key=lambda item: item.rfilename))))
-            elif label in sat_pool:
-                # Only the canonical satisfaction tier may satisfy (not mere placement targets).
+            elif label in accepted_complete:
                 complete.append((label, reused_t))
 
-        # Wrong-tier: a proven-complete copy outside the satisfaction pool is drift, not relocation.
-        for label in sorted(known_labels - sat_pool):
+        # Wrong-tier: proven-complete outside the accepted-complete pool is drift, not relocation.
+        for label in sorted(known_labels - accepted_complete):
             rows = archived.get((req.repo_id, label), {})
             if rows and all(_proof(mf, rows.get(mf.rfilename)) == "proven" for mf in manifest):
                 for mf in manifest:
@@ -402,12 +413,12 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
 
 
 def _home_sources(req, reqs_by_id, manifest, archived, by_label) -> tuple[SourceIdentity, ...]:
-    """Replica SourceIdentity from active complete homes — includes active+excluded; never lost/retired."""
+    """Replica SourceIdentity from accepted complete homes (canonical sat ∪ placeable tier)."""
     home = reqs_by_id.get(req.independent_of)
     if home is None:
         return ()
     sources: list[SourceIdentity] = []
-    for label in _satisfaction_pool(home, by_label):
+    for label in sorted(_accepted_complete_pool(home, by_label)):
         rows = archived.get((req.repo_id, label), {})
         if rows and all(_proof(mf, rows.get(mf.rfilename)) == "proven" for mf in manifest):
             key = orig = None

--- a/modelark/candidates.py
+++ b/modelark/candidates.py
@@ -188,9 +188,11 @@ def _is_satisfying(drive: DriveFact) -> bool:
 
 
 def _satisfaction_pool(req: CopyRequirement, by_label: dict[str, DriveFact]) -> tuple[str, ...]:
-    """Role-tier drives that may satisfy ``req`` — lifecycle-active only; eligibility unrestricted.
+    """Canonical satisfaction tier for ``req`` — lifecycle-active only; eligibility unrestricted.
 
     Placement targets remain ``req.eligible_drives`` (placeable-only from :func:`requirements`).
+    Protected-home mirrors placement policy shape: active RAID primaries when any exist, else the
+    single largest active primary (not every active primary).
     """
     order = sorted(by_label)
     active_primary = tuple(
@@ -205,8 +207,12 @@ def _satisfaction_pool(req: CopyRequirement, by_label: dict[str, DriveFact]) -> 
     if req.kind == RequirementKind.PRIMARY:
         return active_primary
     if req.kind == RequirementKind.PROTECTED_HOME:
-        # RAID homes when any active RAID primary exists; else any active primary (no-RAID fleet).
-        return active_raids if active_raids else active_primary
+        if active_raids:
+            return active_raids
+        if not active_primary:
+            return ()
+        # No-RAID fleet: only the largest active primary may satisfy protected-home.
+        return (sorted(active_primary, key=lambda lab: (-by_label[lab].capacity_bytes, lab))[0],)
     if req.kind == RequirementKind.PROTECTED_REPLICA:
         return active_replicas
     return ()
@@ -314,12 +320,15 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
         manifest = manifests[req.repo_id]
         # Placeable write targets (active+enabled, role-filtered by requirements).
         place_pool = set(req.eligible_drives)
-        # Satisfaction may also use active+excluded complete copies on the same role tier.
-        sat_pool = _satisfaction_pool(req, by_label)
+        # Canonical satisfaction tier (may include active+excluded; shape matches home policy).
+        sat_pool = set(_satisfaction_pool(req, by_label))
+        # Scan the union so placement targets are not omitted when they diverge from sat_pool
+        # (e.g. excluded RAID in sat_pool + plain placeable fallback in place_pool).
+        scan_labels = sorted(sat_pool | place_pool)
 
         complete: list[tuple[str, tuple[ReusableFile, ...]]] = []
         valid: list[tuple[str, tuple[ReusableFile, ...], tuple[archive_manifest.ManifestFile, ...]]] = []
-        for label in sat_pool:
+        for label in scan_labels:
             rows = archived.get((req.repo_id, label), {})
             reused: list[ReusableFile] = []
             missing: list[archive_manifest.ManifestFile] = []
@@ -344,11 +353,12 @@ def candidates(inp: PlannerInput, graph: RequirementGraph) -> CandidateSet:
                 # Finish-in-place / fresh write targets must be placeable (active+enabled).
                 if label in place_pool:
                     valid.append((label, reused_t, tuple(sorted(missing, key=lambda item: item.rfilename))))
-            else:
+            elif label in sat_pool:
+                # Only the canonical satisfaction tier may satisfy (not mere placement targets).
                 complete.append((label, reused_t))
 
         # Wrong-tier: a proven-complete copy outside the satisfaction pool is drift, not relocation.
-        for label in sorted(known_labels - set(sat_pool)):
+        for label in sorted(known_labels - sat_pool):
             rows = archived.get((req.repo_id, label), {})
             if rows and all(_proof(mf, rows.get(mf.rfilename)) == "proven" for mf in manifest):
                 for mf in manifest:

--- a/modelark/capacity.py
+++ b/modelark/capacity.py
@@ -846,22 +846,6 @@ def _project_assigned_tasks(
     return tuple(out)
 
 
-def _placeable_drive_labels(con, plan_id: str) -> frozenset[str]:
-    """State-only Gate-B revalidation: active+enabled plan members (no manifest/archive recapture).
-
-    Missing/malformed lifecycle or eligibility never coerce to placeable (#37 finding 14).
-    """
-    rows = con.execute(
-        "SELECT d.drive_label, d.lifecycle, d.eligibility "
-        "FROM plan_drives pd JOIN drives d USING(drive_label) WHERE pd.plan_id=?",
-        [plan_id],
-    ).fetchall()
-    return frozenset(
-        label for label, lifecycle, eligibility in rows
-        if lifecycle == "active" and eligibility == "enabled"
-    )
-
-
 def _build_solver_input(
     con,
     result: ReconcileResult,
@@ -872,14 +856,16 @@ def _build_solver_input(
 ) -> tuple[placement.SolverInput, tuple[CapacityDrive, ...], frozenset[str]]:
     """Shell: admission evidence → pure SolverInput (no floor recomputation).
 
-    Placeability is re-read with a state-only drive query at Gate-B time so a lifecycle/
-    eligibility flip after reconcile capture fail-closes as TARGET_DRIVE_CHANGED (#37).
-    Drive facts for the pure solver come from the same light plan-membership reread (not a
-    full planner recapture of manifests/archives/config/ratios).
+    Placeability is derived from a single state-only ``_drive_facts`` reread at Gate-B time so a
+    lifecycle/eligibility flip after reconcile capture fail-closes as TARGET_DRIVE_CHANGED (#37).
+    Missing/malformed lifecycle or eligibility never coerce to placeable.
     """
     capacity_drives = inspect_drives(con, result.plan_id, evidence_by_drive=evidence_by_drive)
     drive_facts = reconcile._drive_facts(con, result.plan_id)
-    placeable = _placeable_drive_labels(con, result.plan_id)
+    placeable = frozenset(
+        d.drive_label for d in drive_facts
+        if d.lifecycle == "active" and d.eligibility == "enabled"
+    )
     # Prefer the CandidateSet already on the reconcile result (same snapshot as the caller saw).
     graph = candidates.RequirementGraph(
         desired=tuple(result.requirements),

--- a/modelark/capacity.py
+++ b/modelark/capacity.py
@@ -853,10 +853,18 @@ def _build_solver_input(
     mode: CapacityMode,
     evidence_by_drive: Mapping[str, capacity_evidence.Evidence] | None,
     bounds: placement.SolverBounds,
-) -> tuple[placement.SolverInput, tuple[CapacityDrive, ...]]:
-    """Shell: admission evidence → pure SolverInput (no floor recomputation)."""
+) -> tuple[placement.SolverInput, tuple[CapacityDrive, ...], frozenset[str]]:
+    """Shell: admission evidence → pure SolverInput (no floor recomputation).
+
+    Returns placeable drive labels re-read from the catalog at Gate-B time so a lifecycle/
+    eligibility flip after reconcile capture fail-closes as TARGET_DRIVE_CHANGED (#37).
+    """
     capacity_drives = inspect_drives(con, result.plan_id, evidence_by_drive=evidence_by_drive)
     planner = reconcile.capture_planner_input(con, result.plan_id)
+    placeable = frozenset(
+        d.drive_label for d in planner.drives
+        if d.lifecycle == "active" and d.eligibility == "enabled"
+    )
     # Prefer the CandidateSet already on the reconcile result (same snapshot as the caller saw).
     graph = candidates.RequirementGraph(
         desired=tuple(result.requirements),
@@ -899,23 +907,32 @@ def _build_solver_input(
         policy_version=placement.POLICY_VERSION,
         bounds=bounds,
     )
-    return inp, capacity_drives
+    return inp, capacity_drives, placeable
 
 
 def _stale_target_failures(
     result: ReconcileResult,
     capacity_drives: Sequence[CapacityDrive],
     mode: CapacityMode,
+    *,
+    placeable_labels: frozenset[str] | None = None,
 ) -> list[CapacityFailure]:
-    """Detect candidates whose targets left the plan between reconcile and placement."""
+    """Detect candidates whose targets left the plan or lost placeability between reconcile and placement.
+
+    A target that remains a plan member but is no longer active+enabled (lifecycle/eligibility race)
+    is treated as gone for new placement — fail-closed TARGET_DRIVE_CHANGED (#37).
+    """
     in_plan = {d.drive_label for d in capacity_drives}
+    usable = placeable_labels if placeable_labels is not None else frozenset(in_plan)
+    # Placement may only land on labels that are still plan members AND still placeable.
+    usable = frozenset(lab for lab in usable if lab in in_plan)
     failures: list[CapacityFailure] = []
     for rid, cs in result.candidates.by_requirement:
         if not cs:
             continue
-        if any(c.target_drive in in_plan for c in cs):
+        if any(c.target_drive in usable for c in cs):
             continue
-        # Every remaining candidate target is gone → typed stale snapshot.
+        # Every remaining candidate target is gone or non-placeable → typed stale snapshot.
         is_replica = rid.startswith("protected_replica:")
         failures.append(CapacityFailure(
             code=FailureCode.TARGET_DRIVE_CHANGED,
@@ -1138,7 +1155,7 @@ def plan_capacity(
     mode = mode_from_value(capacity_mode or CapacityMode.GUARANTEED)
 
     bounds = _adapter_solver_bounds()
-    solver_inp, capacity_drives = _build_solver_input(
+    solver_inp, capacity_drives, placeable_labels = _build_solver_input(
         con, result, mode=mode, evidence_by_drive=evidence_by_drive, bounds=bounds,
     )
 
@@ -1147,8 +1164,9 @@ def plan_capacity(
         if item.severity in {DiagnosticSeverity.BLOCKING, DiagnosticSeverity.ERROR}
     }))
 
-    # Stale snapshot: candidate targets left the plan after reconcile — typed failure, no solve.
-    stale = _stale_target_failures(result, capacity_drives, mode)
+    # Stale snapshot: candidate targets left the plan or lost placeability after reconcile.
+    stale = _stale_target_failures(
+        result, capacity_drives, mode, placeable_labels=placeable_labels)
     if stale:
         return CapacityPlan(
             mode=mode,

--- a/modelark/capacity.py
+++ b/modelark/capacity.py
@@ -846,6 +846,22 @@ def _project_assigned_tasks(
     return tuple(out)
 
 
+def _placeable_drive_labels(con, plan_id: str) -> frozenset[str]:
+    """State-only Gate-B revalidation: active+enabled plan members (no manifest/archive recapture).
+
+    Missing/malformed lifecycle or eligibility never coerce to placeable (#37 finding 14).
+    """
+    rows = con.execute(
+        "SELECT d.drive_label, d.lifecycle, d.eligibility "
+        "FROM plan_drives pd JOIN drives d USING(drive_label) WHERE pd.plan_id=?",
+        [plan_id],
+    ).fetchall()
+    return frozenset(
+        label for label, lifecycle, eligibility in rows
+        if lifecycle == "active" and eligibility == "enabled"
+    )
+
+
 def _build_solver_input(
     con,
     result: ReconcileResult,
@@ -856,15 +872,14 @@ def _build_solver_input(
 ) -> tuple[placement.SolverInput, tuple[CapacityDrive, ...], frozenset[str]]:
     """Shell: admission evidence → pure SolverInput (no floor recomputation).
 
-    Returns placeable drive labels re-read from the catalog at Gate-B time so a lifecycle/
+    Placeability is re-read with a state-only drive query at Gate-B time so a lifecycle/
     eligibility flip after reconcile capture fail-closes as TARGET_DRIVE_CHANGED (#37).
+    Drive facts for the pure solver come from the same light plan-membership reread (not a
+    full planner recapture of manifests/archives/config/ratios).
     """
     capacity_drives = inspect_drives(con, result.plan_id, evidence_by_drive=evidence_by_drive)
-    planner = reconcile.capture_planner_input(con, result.plan_id)
-    placeable = frozenset(
-        d.drive_label for d in planner.drives
-        if d.lifecycle == "active" and d.eligibility == "enabled"
-    )
+    drive_facts = reconcile._drive_facts(con, result.plan_id)
+    placeable = _placeable_drive_labels(con, result.plan_id)
     # Prefer the CandidateSet already on the reconcile result (same snapshot as the caller saw).
     graph = candidates.RequirementGraph(
         desired=tuple(result.requirements),
@@ -899,7 +914,7 @@ def _build_solver_input(
     inp = placement.SolverInput(
         graph=graph,
         candidates=result.candidates,
-        drives=planner.drives,
+        drives=drive_facts,
         executable_budget=tuple(executable),
         max_usable_for_epoch=tuple(maxima),
         drive_evidence=tuple(evidence_pairs),
@@ -919,8 +934,9 @@ def _stale_target_failures(
 ) -> list[CapacityFailure]:
     """Detect candidates whose targets left the plan or lost placeability between reconcile and placement.
 
-    A target that remains a plan member but is no longer active+enabled (lifecycle/eligibility race)
-    is treated as gone for new placement — fail-closed TARGET_DRIVE_CHANGED (#37).
+    **Any** captured candidate target that is no longer plan-member + active+enabled fail-closes the
+    requirement as TARGET_DRIVE_CHANGED — including multi-target races where another target remains
+    placeable (#37 finding 13). Do not strip the stale target and re-solve.
     """
     in_plan = {d.drive_label for d in capacity_drives}
     usable = placeable_labels if placeable_labels is not None else frozenset(in_plan)
@@ -930,9 +946,9 @@ def _stale_target_failures(
     for rid, cs in result.candidates.by_requirement:
         if not cs:
             continue
-        if any(c.target_drive in usable for c in cs):
+        # Fail closed if any captured target is no longer usable (not: if any remains usable).
+        if all(c.target_drive in usable for c in cs):
             continue
-        # Every remaining candidate target is gone or non-placeable → typed stale snapshot.
         is_replica = rid.startswith("protected_replica:")
         failures.append(CapacityFailure(
             code=FailureCode.TARGET_DRIVE_CHANGED,

--- a/modelark/core/db.py
+++ b/modelark/core/db.py
@@ -93,6 +93,8 @@ _V3_EVIDENCE_TABLES = ("drive_dirty_generations", "drive_clean_anchors")
 # pre-v3 drive shape until the actual v3 transaction takes its own backup.
 _V3_DRIVE_COLUMN_NAMES = ("identity_epoch", "write_generation", "filesystem_capacity_bytes",
                           "identity_fingerprint", "write_authority")
+# v4 lifecycle/eligibility must not be pulled backward into the v0 integrity rebuild either.
+_V4_DRIVE_COLUMN_NAMES = ("lifecycle", "eligibility")
 
 
 def _apply_schema(con: sqlite3.Connection, tables_only: bool = False) -> None:
@@ -188,7 +190,8 @@ _INTEGRITY_TABLES = (
 _VIEW_NAMES = ("v_ui", "v_model_summary", "v_storage_by_drive")
 _INTEGRITY_SCHEMA_VERSION = 1
 _CAPACITY_MODE_SCHEMA_VERSION = 2
-_SCHEMA_VERSION = 3
+_CAPACITY_EVIDENCE_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 4  # v4: drives.lifecycle + drives.eligibility (#37)
 
 
 def _validate_catalog_version(version: int, *, read_only: bool = False) -> None:
@@ -281,7 +284,9 @@ def _rebuild_integrity_tables(con: sqlite3.Connection) -> None:
             con.execute(f'DROP TABLE IF EXISTS "{new}"')
             # Preserve the pre-v3 drive shape: a v0/v1 rebuild must not introduce the catalog-v3
             # columns, so the later v2->v3 transaction takes a genuine pre-v3 backup.
-            exclude = _V3_DRIVE_COLUMN_NAMES if table == "drives" else ()
+            exclude = (
+                (_V3_DRIVE_COLUMN_NAMES + _V4_DRIVE_COLUMN_NAMES) if table == "drives" else ()
+            )
             con.execute(_canonical_table_sql(table, new, exclude=exclude))
             old_cols = {r[1] for r in con.execute(f'PRAGMA table_info("{table}")').fetchall()}
             new_cols = [r[1] for r in con.execute(f'PRAGMA table_info("{new}")').fetchall()]
@@ -418,7 +423,8 @@ def _migrate_capacity_evidence_v3(con, *, backup_existing: bool) -> None:
     failure leaves a pristine v2 catalog."""
     columns = {row[1] for row in con.execute('PRAGMA table_info("drives")').fetchall()}
     if "identity_epoch" in columns:
-        con.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")   # fresh/canonical drives already v3-shaped
+        # Already v3-shaped drives; stamp evidence version only (not latest schema).
+        con.execute(f"PRAGMA user_version={_CAPACITY_EVIDENCE_SCHEMA_VERSION}")
         return
     if con.execute("PRAGMA foreign_keys").fetchone()[0]:
         raise RuntimeError("Capacity-evidence migration requires foreign_keys=OFF")
@@ -435,13 +441,56 @@ def _migrate_capacity_evidence_v3(con, *, backup_existing: bool) -> None:
         if violations:
             raise RuntimeError(
                 f"Capacity-evidence migration produced foreign-key violations: {violations[:12]}")
-        con.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
+        con.execute(f"PRAGMA user_version={_CAPACITY_EVIDENCE_SCHEMA_VERSION}")
         con.execute("COMMIT")
     except Exception as exc:
         con.execute("ROLLBACK")
         if isinstance(exc, RuntimeError):
             raise
         raise RuntimeError(f"Cannot migrate catalog to v3 capacity evidence ({exc})") from exc
+
+
+# Catalog-v4 (#37) orthogonal lifecycle × eligibility on drives.
+_V4_DRIVE_COLUMNS = (
+    ("lifecycle",
+     "ALTER TABLE drives ADD COLUMN lifecycle VARCHAR NOT NULL DEFAULT 'active' "
+     "CHECK (lifecycle IN ('active','lost','retired'))"),
+    ("eligibility",
+     "ALTER TABLE drives ADD COLUMN eligibility VARCHAR NOT NULL DEFAULT 'enabled' "
+     "CHECK (eligibility IN ('enabled','excluded'))"),
+)
+
+
+def _migrate_lifecycle_eligibility_v4(con, *, backup_existing: bool) -> None:
+    """Backup-first, transactional, additive v3→v4: add lifecycle + eligibility with safe defaults.
+
+    Existing rows become exactly active+enabled via NOT NULL DEFAULT. No tombstone tables or
+    fabricated evidence. All DDL + user_version commit in one transaction.
+    """
+    columns = {row[1] for row in con.execute('PRAGMA table_info("drives")').fetchall()}
+    if "lifecycle" in columns and "eligibility" in columns:
+        con.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
+        return
+    if con.execute("PRAGMA foreign_keys").fetchone()[0]:
+        raise RuntimeError("Lifecycle/eligibility migration requires foreign_keys=OFF")
+    if backup_existing:
+        _backup_before_migration(con, "pre-lifecycle-v4")
+    con.execute("BEGIN IMMEDIATE")
+    try:
+        for name, ddl in _V4_DRIVE_COLUMNS:
+            if name not in columns:
+                con.execute(ddl)
+        violations = con.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise RuntimeError(
+                f"Lifecycle/eligibility migration produced foreign-key violations: {violations[:12]}")
+        con.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
+        con.execute("COMMIT")
+    except Exception as exc:
+        con.execute("ROLLBACK")
+        if isinstance(exc, RuntimeError):
+            raise
+        raise RuntimeError(f"Cannot migrate catalog to v4 lifecycle/eligibility ({exc})") from exc
 
 
 def _migrate(con, version: int, *, backup_existing: bool) -> None:
@@ -454,8 +503,11 @@ def _migrate(con, version: int, *, backup_existing: bool) -> None:
     if version < _CAPACITY_MODE_SCHEMA_VERSION:
         _migrate_capacity_mode_v2(con, backup_existing=backup_existing)
         version = _CAPACITY_MODE_SCHEMA_VERSION
-    if version < _SCHEMA_VERSION:
+    if version < _CAPACITY_EVIDENCE_SCHEMA_VERSION:
         _migrate_capacity_evidence_v3(con, backup_existing=backup_existing)
+        version = _CAPACITY_EVIDENCE_SCHEMA_VERSION
+    if version < _SCHEMA_VERSION:
+        _migrate_lifecycle_eligibility_v4(con, backup_existing=backup_existing)
         version = _SCHEMA_VERSION
     if version != _SCHEMA_VERSION:
         raise RuntimeError(f"Catalog migration stopped at v{version}, expected v{_SCHEMA_VERSION}")

--- a/modelark/core/schema.sql
+++ b/modelark/core/schema.sql
@@ -82,7 +82,13 @@ CREATE TABLE IF NOT EXISTS drives (
                               CHECK (identity_fingerprint IS NULL
                                      OR length(identity_fingerprint) = 64),
     write_authority           VARCHAR NOT NULL DEFAULT 'unknown'
-                              CHECK (write_authority IN ('unknown','dedicated_local'))
+                              CHECK (write_authority IN ('unknown','dedicated_local')),
+    -- Catalog v4 (#37) orthogonal lifecycle × eligibility. Defaults active+enabled for new rows
+    -- and for migrated existing drives. Offline/mounted presence is not stored here.
+    lifecycle                 VARCHAR NOT NULL DEFAULT 'active'
+                              CHECK (lifecycle IN ('active','lost','retired')),
+    eligibility               VARCHAR NOT NULL DEFAULT 'enabled'
+                              CHECK (eligibility IN ('enabled','excluded'))
 );
 
 -- Which file lives on which drive (mirror of `git annex whereis`).

--- a/modelark/librarian.py
+++ b/modelark/librarian.py
@@ -187,7 +187,7 @@ def placed_copies(con) -> dict[str, int]:
         "            GROUP BY f.repo_id), "
         "perdrive AS (SELECT a.repo_id, a.drive_label, count(*) n FROM archived a "
         "             JOIN drives d ON d.drive_label = a.drive_label "
-        "             WHERE coalesce(d.lifecycle,'active')='active' "
+        "             WHERE d.lifecycle='active' "
         "             GROUP BY a.repo_id, a.drive_label) "
         "SELECT pd.repo_id, count(*) FROM perdrive pd JOIN planned pl "
         "  ON pd.repo_id = pl.repo_id AND pd.n >= pl.n GROUP BY pd.repo_id").fetchall()

--- a/modelark/librarian.py
+++ b/modelark/librarian.py
@@ -174,14 +174,21 @@ def placed_copies(con) -> dict[str, int]:
     """Per repo: how many drives hold a COMPLETE copy — ALL of the repo's planned files
     (safetensors + aux + gguf-when-no-safetensors, mirroring fetch.plan). Counting DISTINCT
     drives is too coarse (DEC-019): a drive with a half-fetched repo must NOT count toward
-    numcopies, or an interrupted copy would look 'done'."""
+    numcopies, or an interrupted copy would look 'done'.
+
+    #37: only **active** drives count (enabled or excluded). Lost/retired complete rows remain
+    in durable archived provenance but do not satisfy compatibility totals / queue completion.
+    """
     rows = con.execute(
         "WITH hasst AS (SELECT repo_id, max(CASE WHEN format='safetensors' THEN 1 ELSE 0 END) s "
         "               FROM files GROUP BY repo_id), "
         "planned AS (SELECT f.repo_id, count(*) n FROM files f JOIN hasst h USING(repo_id) "
         "            WHERE f.format IN ('safetensors','aux') OR (f.format='gguf' AND h.s=0) "
         "            GROUP BY f.repo_id), "
-        "perdrive AS (SELECT repo_id, drive_label, count(*) n FROM archived GROUP BY repo_id, drive_label) "
+        "perdrive AS (SELECT a.repo_id, a.drive_label, count(*) n FROM archived a "
+        "             JOIN drives d ON d.drive_label = a.drive_label "
+        "             WHERE coalesce(d.lifecycle,'active')='active' "
+        "             GROUP BY a.repo_id, a.drive_label) "
         "SELECT pd.repo_id, count(*) FROM perdrive pd JOIN planned pl "
         "  ON pd.repo_id = pl.repo_id AND pd.n >= pl.n GROUP BY pd.repo_id").fetchall()
     return dict(rows)

--- a/modelark/plan.py
+++ b/modelark/plan.py
@@ -158,12 +158,20 @@ def plan_drive_labels(con, plan_id) -> list[str]:
 
 
 def bootstrap(con, plan_id=DEFAULT_PLAN) -> dict:
-    """Idempotent: ensure plan `ark` exists, owns every currently-registered drive, and is active if no
+    """Idempotent: ensure plan `ark` exists, owns every placeable registered drive, and is active if no
     plan is. Safe to call on every startup — creates nothing that exists, removes nothing. Called from
-    the portal serve() startup, the CLI `plan`/`library plan` commands, and registration (#34)."""
+    the portal serve() startup, the CLI `plan`/`library plan` commands, and registration (#34).
+
+    #37: only **missing active+enabled** drives are inserted into plan_drives. Existing membership
+    (including excluded/lost/retired historical rows) is preserved; axes are never mutated.
+    """
     if get(con, plan_id) is None:
         create(con, plan_id, name="Ark")
-    for row in con.execute("SELECT drive_label FROM drives").fetchall():
+    for row in con.execute(
+        "SELECT drive_label FROM drives "
+        "WHERE coalesce(lifecycle,'active')='active' AND coalesce(eligibility,'enabled')='enabled' "
+        "ORDER BY drive_label"
+    ).fetchall():
         add_drive(con, plan_id, row[0])
     if active(con) is None:
         set_active(con, plan_id)
@@ -179,8 +187,12 @@ def _headroom(cap: int, raid_backed: bool) -> int:
 
 
 def capacity(con, plan_id) -> int:
-    """Σ (capacity − headroom) over the plan's drives — the nominal fleet size the plan can fill. Uses
-    the registration capacity snapshot (stable), NOT live free (that is the per-model failsafe's job)."""
+    """Σ (capacity − headroom) over the plan's placeable drives — the nominal fleet size the plan can
+    fill. Uses the registration capacity snapshot (stable), NOT live free (per-model failsafe).
+
+    #37: only active+enabled plan members contribute. Excluded/lost/retired historical membership
+    does not inflate usable fleet capacity.
+    """
     labels = plan_drive_labels(con, plan_id)
     if not labels:
         return 0
@@ -188,7 +200,9 @@ def capacity(con, plan_id) -> int:
     total = 0
     for _, cap, raid in con.execute(
             f"SELECT drive_label, coalesce(capacity_bytes, free_bytes, 0), coalesce(raid_backed, false) "
-            f"FROM drives WHERE drive_label IN ({ph})", labels).fetchall():
+            f"FROM drives WHERE drive_label IN ({ph}) "
+            f"AND coalesce(lifecycle,'active')='active' "
+            f"AND coalesce(eligibility,'enabled')='enabled'", labels).fetchall():
         total += max(0, cap - _headroom(cap, bool(raid)))
     return total
 

--- a/modelark/plan.py
+++ b/modelark/plan.py
@@ -169,7 +169,7 @@ def bootstrap(con, plan_id=DEFAULT_PLAN) -> dict:
         create(con, plan_id, name="Ark")
     for row in con.execute(
         "SELECT drive_label FROM drives "
-        "WHERE coalesce(lifecycle,'active')='active' AND coalesce(eligibility,'enabled')='enabled' "
+        "WHERE lifecycle='active' AND eligibility='enabled' "
         "ORDER BY drive_label"
     ).fetchall():
         add_drive(con, plan_id, row[0])
@@ -201,8 +201,7 @@ def capacity(con, plan_id) -> int:
     for _, cap, raid in con.execute(
             f"SELECT drive_label, coalesce(capacity_bytes, free_bytes, 0), coalesce(raid_backed, false) "
             f"FROM drives WHERE drive_label IN ({ph}) "
-            f"AND coalesce(lifecycle,'active')='active' "
-            f"AND coalesce(eligibility,'enabled')='enabled'", labels).fetchall():
+            f"AND lifecycle='active' AND eligibility='enabled'", labels).fetchall():
         total += max(0, cap - _headroom(cap, bool(raid)))
     return total
 

--- a/modelark/reconcile.py
+++ b/modelark/reconcile.py
@@ -225,7 +225,7 @@ def _drive_facts(con, plan_id: str) -> tuple[DriveFact, ...]:
         "coalesce(d.capacity_bytes,d.free_bytes,0),"
         "coalesce(d.filesystem_capacity_bytes,d.capacity_bytes,0),coalesce(d.identity_epoch,1),"
         "d.fs_uuid,d.annex_uuid,d.serial,"
-        "coalesce(d.lifecycle,'active'),coalesce(d.eligibility,'enabled') "
+        "d.lifecycle,d.eligibility "
         "FROM plan_drives pd JOIN drives d USING(drive_label) WHERE pd.plan_id=? "
         "ORDER BY d.drive_label",
         [plan_id],

--- a/modelark/reconcile.py
+++ b/modelark/reconcile.py
@@ -224,7 +224,8 @@ def _drive_facts(con, plan_id: str) -> tuple[DriveFact, ...]:
         "SELECT d.drive_label,coalesce(d.role,'primary'),coalesce(d.raid_backed,0),"
         "coalesce(d.capacity_bytes,d.free_bytes,0),"
         "coalesce(d.filesystem_capacity_bytes,d.capacity_bytes,0),coalesce(d.identity_epoch,1),"
-        "d.fs_uuid,d.annex_uuid,d.serial "
+        "d.fs_uuid,d.annex_uuid,d.serial,"
+        "coalesce(d.lifecycle,'active'),coalesce(d.eligibility,'enabled') "
         "FROM plan_drives pd JOIN drives d USING(drive_label) WHERE pd.plan_id=? "
         "ORDER BY d.drive_label",
         [plan_id],
@@ -234,6 +235,7 @@ def _drive_facts(con, plan_id: str) -> tuple[DriveFact, ...]:
             drive_label=row[0], role=row[1], raid_backed=bool(row[2]),
             capacity_bytes=int(row[3] or 0), filesystem_capacity_bytes=int(row[4] or 0),
             identity_epoch=int(row[5] or 1), fs_uuid=row[6], annex_uuid=row[7], serial=row[8],
+            lifecycle=row[9], eligibility=row[10],
         )
         for row in rows
     )

--- a/tests/test_capacity_evidence.py
+++ b/tests/test_capacity_evidence.py
@@ -149,7 +149,7 @@ def test_shadow_selects_current_epoch_anchor_not_a_higher_old_epoch_generation(t
     db.CATALOG_DIR = tmp_path
     db.DB_PATH = tmp_path / "catalog.sqlite"
     con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fresh catalog must be v3 (Gate-1 red)"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, "fresh catalog must be at current schema version"
     fp = "a" * 64
     con.execute(
         "INSERT INTO drives(drive_label,capacity_bytes,free_bytes,identity_epoch,write_generation,"
@@ -182,8 +182,8 @@ def test_shadow_read_is_side_effect_free_and_all_unknown(tmp_path):
     db.CATALOG_DIR = tmp_path
     db.DB_PATH = tmp_path / "catalog.sqlite"
     con = db.connect()                                   # fresh catalog is v3 directly (no migration here)
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
-        "fresh catalog must be v3 (expected Gate-1 red)"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, \
+        "fresh catalog must be at current schema version"
     con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) VALUES('drive-00',1000,500)")
     con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) VALUES('drive-01',1000,900)")
     before_free = con.execute("SELECT drive_label, free_bytes FROM drives ORDER BY 1").fetchall()
@@ -198,7 +198,7 @@ def test_shadow_read_is_side_effect_free_and_all_unknown(tmp_path):
     # legacy free_bytes is exposed ONLY as a diagnostic, never as executable/admissible free
     assert shadow["drive-00"].legacy_free_bytes == 500 and shadow["drive-01"].legacy_free_bytes == 900
     # diagnostic read: no admission input mutated, no evidence fabricated
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION
     assert con.execute("SELECT drive_label, free_bytes FROM drives ORDER BY 1").fetchall() == before_free
     assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
     assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0

--- a/tests/test_catalog_v3_migration.py
+++ b/tests/test_catalog_v3_migration.py
@@ -101,8 +101,8 @@ def _reopen_raw():
 def test_migrate_v2_to_v3_adds_schema_and_preserves_rows(tmp_path):
     _seed_v2(tmp_path)
     con = db.connect()                                  # triggers the v2->v3 migration
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
-        "v2->v3 migration not implemented (expected Gate-1 red)"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, \
+        "full migration chain must land at current schema version"
 
     dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
     assert {"identity_epoch", "write_generation", "filesystem_capacity_bytes",
@@ -135,8 +135,8 @@ def test_migration_is_idempotent(tmp_path):
     _seed_v2(tmp_path)
     db.connect().close()
     con = db.connect()                                  # second open must be a stable no-op
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
-        "v2->v3 migration not implemented (expected Gate-1 red)"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, \
+        "full migration chain must land at current schema version"
     assert con.execute("SELECT count(*) FROM drive_dirty_generations").fetchone()[0] == 0
     assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
     dcols = [r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()]
@@ -196,8 +196,8 @@ def test_migration_aborts_on_foreign_key_violation(tmp_path):
 def test_v3_schema_constraint_matrix(tmp_path):
     _seed_v2(tmp_path)
     con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, \
-        "v3 schema not created (expected Gate-1 red)"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, \
+        "full migration chain must land at current schema version"
 
     def rejected(sql, exc_types, contains=None):
         """A negative case: the statement must raise the SPECIFIC constraint error, so an unrelated

--- a/tests/test_catalog_v4_lifecycle_migration.py
+++ b/tests/test_catalog_v4_lifecycle_migration.py
@@ -303,17 +303,22 @@ def test_newer_catalog_rejection_uses_schema_version_plus_one(tmp_path):
 
 
 def test_fresh_drive_insert_defaults_to_active_enabled(tmp_path):
-    """Schema defaults (and thus registration upserts that omit the columns) → exactly active+enabled.
+    """Fresh-install schema.sql defaults → exactly active+enabled (not merely v3→v4 ALTER defaults).
 
-    Does NOT pass lifecycle/eligibility in the INSERT — only the durable defaults may supply them.
+    Starts from a nonexistent catalog path so ``db.connect()`` bootstraps packaged schema, then
+    inserts a drive WITHOUT lifecycle/eligibility. Migration defaults are covered separately by
+    ``test_migrate_v3_to_v4_…``.
     """
-    _seed_v3(tmp_path)
-    con = db.connect()
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    assert not db.DB_PATH.exists(), "must start with no catalog file"
+    con = db.connect()  # fresh bootstrap of packaged schema
     assert con.execute("PRAGMA user_version").fetchone()[0] == 4, (
-        "v4 schema required for default pins (expected Gate-1 red)")
+        "fresh catalog must be v4 (expected Gate-1 red until packaged schema is v4)")
     dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
-    assert {"lifecycle", "eligibility"} <= dcols
-    # Omit the new columns entirely — registration-style minimal insert.
+    assert {"lifecycle", "eligibility"} <= dcols, (
+        "fresh schema.sql must define lifecycle and eligibility columns")
+    # Omit the new columns entirely — registration-style minimal insert relies on DEFAULT clauses.
     con.execute(
         "INSERT INTO drives(drive_label,capacity_bytes,free_bytes,role,raid_backed) "
         "VALUES('fresh-drive',2000,1500,'primary',0)")
@@ -321,10 +326,6 @@ def test_fresh_drive_insert_defaults_to_active_enabled(tmp_path):
         "SELECT lifecycle, eligibility FROM drives WHERE drive_label='fresh-drive'").fetchone()
     assert row == ("active", "enabled"), (
         f"fresh drive without explicit lifecycle/eligibility must default to active+enabled; got {row}")
-    # Migrated pre-existing row also still active+enabled.
-    assert con.execute(
-        "SELECT lifecycle, eligibility FROM drives WHERE drive_label='drive-00'"
-    ).fetchone() == ("active", "enabled")
     con.close()
 
 

--- a/tests/test_catalog_v4_lifecycle_migration.py
+++ b/tests/test_catalog_v4_lifecycle_migration.py
@@ -4,13 +4,8 @@ Gate 1: v3→v4 migration contract BEFORE production. Change-contract tests are 
 ``lifecycle`` / ``eligibility`` columns, domain CHECKs, and a backup-first transactional
 migration exist. Fail for the reviewed missing v4 behavior — not a broken fixture.
 
-Scope: schema additions + migration only. No exclude/include/lost/retire *operations*, no new
-CLI/API, no presence-as-lifecycle, no #39.
-
-Rulings (Gate-0 accepted):
-  - Existing drives migrate to exactly active + enabled.
-  - Retired drives row is the tombstone (no separate tombstone table yet).
-  - No fabricated evidence/tombstone rows; prior FK/catalog facts preserved.
+The v3 fixture is FROZEN and production-independent: it never calls ``db.connect()`` to build the
+pre-migration catalog (that would bake in whatever the packaged schema is after Gate 2).
 """
 from __future__ import annotations
 
@@ -35,19 +30,93 @@ class _FailOn:
         return getattr(self._con, name)
 
 
+# Frozen catalog-v3 drives shape — independent of packaged schema after Gate 2 adds lifecycle cols.
+_V3_DRIVES_DDL = """
+CREATE TABLE drives (
+    drive_label        VARCHAR PRIMARY KEY NOT NULL CHECK (length(trim(drive_label)) > 0),
+    fs_uuid            VARCHAR,
+    annex_uuid         VARCHAR,
+    capacity_bytes     BIGINT CHECK (capacity_bytes IS NULL OR capacity_bytes >= 0),
+    free_bytes         BIGINT CHECK (free_bytes IS NULL OR free_bytes >= 0),
+    hw_model           VARCHAR,
+    serial             VARCHAR,
+    physical_location  VARCHAR,
+    role               VARCHAR NOT NULL DEFAULT 'primary' CHECK (role IN ('primary','replica')),
+    raid_backed        BOOLEAN NOT NULL DEFAULT false CHECK (raid_backed IN (0, 1)),
+    health             VARCHAR,
+    last_seen          TIMESTAMP,
+    notes              VARCHAR,
+    identity_epoch            INTEGER NOT NULL DEFAULT 1 CHECK (identity_epoch >= 1),
+    write_generation          INTEGER NOT NULL DEFAULT 0 CHECK (write_generation >= 0),
+    filesystem_capacity_bytes BIGINT
+                              CHECK (filesystem_capacity_bytes IS NULL
+                                     OR filesystem_capacity_bytes >= 0),
+    identity_fingerprint      VARCHAR
+                              CHECK (identity_fingerprint IS NULL
+                                     OR length(identity_fingerprint) = 64),
+    write_authority           VARCHAR NOT NULL DEFAULT 'unknown'
+                              CHECK (write_authority IN ('unknown','dedicated_local'))
+)
+"""
+
+
 def _reopen_raw():
     return sqlite3.connect(str(db.DB_PATH), isolation_level=None)
 
 
 def _seed_v3(tmp_path):
-    """Genuine v3 catalog (current packaged shape) at user_version=3, with one drive + FK facts."""
+    """Genuine frozen v3 catalog at user_version=3 — never depends on packaged schema version."""
     db.CATALOG_DIR = tmp_path
     db.DB_PATH = tmp_path / "catalog.sqlite"
-    con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture assumes packaged schema is v3"
-    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
-    assert "lifecycle" not in dcols and "eligibility" not in dcols, (
-        "v3 fixture must not already carry v4 lifecycle/eligibility columns")
+    con = sqlite3.connect(str(db.DB_PATH), isolation_level=None)
+    con.execute("PRAGMA foreign_keys=ON")
+    con.execute(_V3_DRIVES_DDL)
+    con.execute("""
+        CREATE TABLE models (
+            repo_id VARCHAR PRIMARY KEY NOT NULL,
+            numcopies INTEGER NOT NULL DEFAULT 1
+        )
+    """)
+    con.execute("""
+        CREATE TABLE files (
+            repo_id VARCHAR NOT NULL,
+            rfilename VARCHAR NOT NULL,
+            size_bytes BIGINT,
+            format VARCHAR,
+            quant VARCHAR,
+            PRIMARY KEY (repo_id, rfilename),
+            FOREIGN KEY (repo_id) REFERENCES models(repo_id)
+        )
+    """)
+    con.execute("""
+        CREATE TABLE archived (
+            repo_id VARCHAR NOT NULL,
+            rfilename VARCHAR NOT NULL,
+            drive_label VARCHAR NOT NULL,
+            compressed INTEGER NOT NULL DEFAULT 0,
+            orig_bytes BIGINT,
+            stored_bytes BIGINT,
+            PRIMARY KEY (repo_id, rfilename, drive_label),
+            FOREIGN KEY (drive_label) REFERENCES drives(drive_label)
+        )
+    """)
+    con.execute("""
+        CREATE TABLE plans (
+            plan_id VARCHAR PRIMARY KEY NOT NULL,
+            name VARCHAR,
+            is_active INTEGER NOT NULL DEFAULT 0,
+            capacity_mode VARCHAR NOT NULL DEFAULT 'guaranteed'
+        )
+    """)
+    con.execute("""
+        CREATE TABLE plan_drives (
+            plan_id VARCHAR NOT NULL,
+            drive_label VARCHAR NOT NULL,
+            PRIMARY KEY (plan_id, drive_label),
+            FOREIGN KEY (plan_id) REFERENCES plans(plan_id),
+            FOREIGN KEY (drive_label) REFERENCES drives(drive_label)
+        )
+    """)
     con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
     con.execute(
         "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
@@ -60,14 +129,18 @@ def _seed_v3(tmp_path):
     con.execute(
         "INSERT INTO archived(repo_id,rfilename,drive_label,compressed,orig_bytes,stored_bytes) "
         "VALUES('org/m','model.safetensors','drive-00',0,100,100)")
-    con.execute("INSERT INTO plans(plan_id,name,is_active,capacity_mode) VALUES('ark','Ark',1,'guaranteed')")
+    con.execute(
+        "INSERT INTO plans(plan_id,name,is_active,capacity_mode) "
+        "VALUES('ark','Ark',1,'guaranteed')")
     con.execute("INSERT INTO plan_drives(plan_id,drive_label) VALUES('ark','drive-00')")
-    # Force stamp v3 in case connect() ever auto-migrates early in a half-landed build.
     con.execute("PRAGMA user_version=3")
     con.close()
+
     check = _reopen_raw()
     assert check.execute("PRAGMA user_version").fetchone()[0] == 3
-    assert "lifecycle" not in {r[1] for r in check.execute("PRAGMA table_info(drives)").fetchall()}
+    dcols = {r[1] for r in check.execute("PRAGMA table_info(drives)").fetchall()}
+    assert "lifecycle" not in dcols and "eligibility" not in dcols
+    assert {"identity_epoch", "write_authority"} <= dcols
     check.close()
 
 
@@ -84,19 +157,17 @@ def test_migrate_v3_to_v4_adds_lifecycle_eligibility_and_preserves_rows(tmp_path
         "SELECT lifecycle, eligibility, capacity_bytes, free_bytes, fs_uuid, annex_uuid, serial, "
         "identity_epoch, write_generation, write_authority "
         "FROM drives WHERE drive_label='drive-00'").fetchone()
-    # Migrated defaults: exactly active + enabled; no fabricated evidence; legacy scalars preserved.
     assert row[0] == "active" and row[1] == "enabled", row
     assert row[2:] == (1000, 500, "fs-00", "annex-00", "serial-00", 1, 0, "unknown"), row
 
     assert con.execute("SELECT count(*) FROM models").fetchone()[0] == 1
     assert con.execute("SELECT count(*) FROM archived").fetchone()[0] == 1
     assert con.execute("SELECT count(*) FROM plan_drives").fetchone()[0] == 1
-    # No fabricated tombstone / evidence tables for this slice.
     tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
     assert "drive_tombstones" not in tables
 
     bak = db.DB_PATH.with_name(db.DB_PATH.name + ".pre-lifecycle-v4.bak")
-    assert bak.is_file(), "non-overwriting v3 backup must exist before destructive/column migration"
+    assert bak.is_file(), "non-overwriting v3 backup must exist before column migration"
     b = sqlite3.connect(str(bak))
     assert b.execute("PRAGMA user_version").fetchone()[0] == 3, "backup must remain a v3 catalog"
     assert "lifecycle" not in {r[1] for r in b.execute("PRAGMA table_info(drives)").fetchall()}
@@ -124,7 +195,7 @@ def test_v4_injected_failure_rolls_back_columns_and_user_version(tmp_path):
     _seed_v3(tmp_path)
     con = _reopen_raw()
     con.execute("PRAGMA foreign_keys=OFF")
-    proxy = _FailOn(con, "eligibility")  # fail after backup while adding columns
+    proxy = _FailOn(con, "eligibility")
     try:
         db._migrate_lifecycle_eligibility_v4(proxy, backup_existing=True)
         raise AssertionError("migration should have raised")
@@ -154,13 +225,10 @@ def test_v4_domain_and_not_null_constraints(tmp_path):
         except sqlite3.IntegrityError:
             return True
 
-    # Invalid domain values refused.
     assert rejected("UPDATE drives SET lifecycle='ghost' WHERE drive_label='drive-00'")
     assert rejected("UPDATE drives SET eligibility='maybe' WHERE drive_label='drive-00'")
-    # NOT NULL — cannot clear either axis.
     assert rejected("UPDATE drives SET lifecycle=NULL WHERE drive_label='drive-00'")
     assert rejected("UPDATE drives SET eligibility=NULL WHERE drive_label='drive-00'")
-    # Valid pair still accepted.
     con.execute("UPDATE drives SET lifecycle='retired', eligibility='excluded' "
                 "WHERE drive_label='drive-00'")
     assert con.execute(
@@ -170,12 +238,7 @@ def test_v4_domain_and_not_null_constraints(tmp_path):
 
 
 def test_v0_to_v4_does_not_introduce_lifecycle_columns_during_integrity_rebuild(tmp_path):
-    """Integrity rebuild (v0 path) must not invent v4 columns early; v4 lands in its own step.
-
-    Reuses the pre-v3 strip pattern from test_db_sqlite: evidence backup after connect must lack
-    lifecycle/eligibility. Final catalog after Gate-2 must be v4 with active+enabled defaults.
-    """
-    # Build a genuine pre-constraint pre-v3 catalog (same approach as test_db_sqlite).
+    """Integrity rebuild must not invent v4 columns early; evidence backup remains pre-lifecycle."""
     db.CATALOG_DIR = tmp_path
     db.DB_PATH = tmp_path / "catalog.sqlite"
     con = db.connect()
@@ -192,7 +255,10 @@ def test_v0_to_v4_does_not_introduce_lifecycle_columns_during_integrity_rebuild(
     con.execute("DROP TABLE IF EXISTS drive_dirty_generations")
     pre_v3 = ("drive_label,fs_uuid,annex_uuid,capacity_bytes,free_bytes,hw_model,serial,"
               "physical_location,role,raid_backed,health,last_seen,notes")
-    con.execute(f"CREATE TABLE drives__pre3 AS SELECT {pre_v3} FROM drives")
+    # Drop lifecycle cols if a future packaged schema already has them before strip.
+    present = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    pre_cols = ",".join(c for c in pre_v3.split(",") if c in present)
+    con.execute(f"CREATE TABLE drives__pre3 AS SELECT {pre_cols} FROM drives")
     con.execute("DROP TABLE drives")
     con.execute("ALTER TABLE drives__pre3 RENAME TO drives")
     con.execute("INSERT INTO drives(drive_label,free_bytes,role,raid_backed) "
@@ -219,7 +285,7 @@ def test_v0_to_v4_does_not_introduce_lifecycle_columns_during_integrity_rebuild(
 
 
 def test_newer_catalog_rejection_uses_schema_version_plus_one(tmp_path):
-    """Hard-coded future version must track the build, not a frozen '4' literal forever."""
+    """Hard-coded future version must track the build, not a frozen literal forever."""
     db.CATALOG_DIR = tmp_path
     db.DB_PATH = tmp_path / "catalog.sqlite"
     con = db.connect()
@@ -252,7 +318,7 @@ def main():
                 fn()
             passed.append(name)
             print(f"PASS  {name}")
-        except Exception as exc:  # noqa: BLE001 — Gate-1 wants the full red/green map
+        except Exception as exc:  # noqa: BLE001
             failed.append((name, type(exc).__name__, str(exc)[:200]))
             print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
     print(f"\n{len(passed)} passed, {len(failed)} failed")

--- a/tests/test_catalog_v4_lifecycle_migration.py
+++ b/tests/test_catalog_v4_lifecycle_migration.py
@@ -1,0 +1,265 @@
+"""PR-07 / #37 catalog-v4 lifecycle + eligibility migration (tests-first, DEC-049 / RFC-002).
+
+Gate 1: v3→v4 migration contract BEFORE production. Change-contract tests are RED until
+``lifecycle`` / ``eligibility`` columns, domain CHECKs, and a backup-first transactional
+migration exist. Fail for the reviewed missing v4 behavior — not a broken fixture.
+
+Scope: schema additions + migration only. No exclude/include/lost/retire *operations*, no new
+CLI/API, no presence-as-lifecycle, no #39.
+
+Rulings (Gate-0 accepted):
+  - Existing drives migrate to exactly active + enabled.
+  - Retired drives row is the tombstone (no separate tombstone table yet).
+  - No fabricated evidence/tombstone rows; prior FK/catalog facts preserved.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from modelark.core import db
+
+
+class _FailOn:
+    """Connection proxy that raises when a marker appears in a statement (mid-migration inject)."""
+
+    def __init__(self, con, marker):
+        self._con = con
+        self._marker = marker
+
+    def execute(self, sql, *args):
+        if self._marker in sql:
+            raise sqlite3.OperationalError(f"injected failure at: {self._marker}")
+        return self._con.execute(sql, *args)
+
+    def __getattr__(self, name):
+        return getattr(self._con, name)
+
+
+def _reopen_raw():
+    return sqlite3.connect(str(db.DB_PATH), isolation_level=None)
+
+
+def _seed_v3(tmp_path):
+    """Genuine v3 catalog (current packaged shape) at user_version=3, with one drive + FK facts."""
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture assumes packaged schema is v3"
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    assert "lifecycle" not in dcols and "eligibility" not in dcols, (
+        "v3 fixture must not already carry v4 lifecycle/eligibility columns")
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
+    con.execute(
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
+        "VALUES('org/m','model.safetensors',100,'safetensors','bf16')")
+    con.execute(
+        "INSERT INTO drives(drive_label,capacity_bytes,free_bytes,fs_uuid,annex_uuid,serial,"
+        "role,raid_backed,identity_epoch,write_generation,write_authority) "
+        "VALUES('drive-00',1000,500,'fs-00','annex-00','serial-00',"
+        "'primary',0,1,0,'unknown')")
+    con.execute(
+        "INSERT INTO archived(repo_id,rfilename,drive_label,compressed,orig_bytes,stored_bytes) "
+        "VALUES('org/m','model.safetensors','drive-00',0,100,100)")
+    con.execute("INSERT INTO plans(plan_id,name,is_active,capacity_mode) VALUES('ark','Ark',1,'guaranteed')")
+    con.execute("INSERT INTO plan_drives(plan_id,drive_label) VALUES('ark','drive-00')")
+    # Force stamp v3 in case connect() ever auto-migrates early in a half-landed build.
+    con.execute("PRAGMA user_version=3")
+    con.close()
+    check = _reopen_raw()
+    assert check.execute("PRAGMA user_version").fetchone()[0] == 3
+    assert "lifecycle" not in {r[1] for r in check.execute("PRAGMA table_info(drives)").fetchall()}
+    check.close()
+
+
+def test_migrate_v3_to_v4_adds_lifecycle_eligibility_and_preserves_rows(tmp_path):
+    _seed_v3(tmp_path)
+    con = db.connect()  # must run v3→v4 migration once implemented
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 4, (
+        "v3→v4 lifecycle/eligibility migration not implemented (expected Gate-1 red)")
+
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    assert {"lifecycle", "eligibility"} <= dcols
+
+    row = con.execute(
+        "SELECT lifecycle, eligibility, capacity_bytes, free_bytes, fs_uuid, annex_uuid, serial, "
+        "identity_epoch, write_generation, write_authority "
+        "FROM drives WHERE drive_label='drive-00'").fetchone()
+    # Migrated defaults: exactly active + enabled; no fabricated evidence; legacy scalars preserved.
+    assert row[0] == "active" and row[1] == "enabled", row
+    assert row[2:] == (1000, 500, "fs-00", "annex-00", "serial-00", 1, 0, "unknown"), row
+
+    assert con.execute("SELECT count(*) FROM models").fetchone()[0] == 1
+    assert con.execute("SELECT count(*) FROM archived").fetchone()[0] == 1
+    assert con.execute("SELECT count(*) FROM plan_drives").fetchone()[0] == 1
+    # No fabricated tombstone / evidence tables for this slice.
+    tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+    assert "drive_tombstones" not in tables
+
+    bak = db.DB_PATH.with_name(db.DB_PATH.name + ".pre-lifecycle-v4.bak")
+    assert bak.is_file(), "non-overwriting v3 backup must exist before destructive/column migration"
+    b = sqlite3.connect(str(bak))
+    assert b.execute("PRAGMA user_version").fetchone()[0] == 3, "backup must remain a v3 catalog"
+    assert "lifecycle" not in {r[1] for r in b.execute("PRAGMA table_info(drives)").fetchall()}
+    b.close()
+    con.close()
+
+
+def test_v4_migration_is_idempotent(tmp_path):
+    _seed_v3(tmp_path)
+    db.connect().close()
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 4, (
+        "v3→v4 migration not implemented (expected Gate-1 red)")
+    dcols = [r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()]
+    assert len(dcols) == len(set(dcols)), "no duplicate columns from a second migration"
+    row = con.execute(
+        "SELECT lifecycle, eligibility FROM drives WHERE drive_label='drive-00'").fetchone()
+    assert row == ("active", "enabled")
+    con.close()
+
+
+def test_v4_injected_failure_rolls_back_columns_and_user_version(tmp_path):
+    assert hasattr(db, "_migrate_lifecycle_eligibility_v4"), (
+        "v4 migration helper not implemented yet (expected Gate-1 red)")
+    _seed_v3(tmp_path)
+    con = _reopen_raw()
+    con.execute("PRAGMA foreign_keys=OFF")
+    proxy = _FailOn(con, "eligibility")  # fail after backup while adding columns
+    try:
+        db._migrate_lifecycle_eligibility_v4(proxy, backup_existing=True)
+        raise AssertionError("migration should have raised")
+    except RuntimeError:
+        pass
+    con.close()
+
+    raw = _reopen_raw()
+    assert raw.execute("PRAGMA user_version").fetchone()[0] == 3, "failed migration must leave v3"
+    dcols = {r[1] for r in raw.execute("PRAGMA table_info(drives)").fetchall()}
+    assert "lifecycle" not in dcols and "eligibility" not in dcols
+    assert raw.execute("SELECT count(*) FROM drives").fetchone()[0] == 1
+    raw.close()
+    assert db.DB_PATH.with_name(db.DB_PATH.name + ".pre-lifecycle-v4.bak").is_file()
+
+
+def test_v4_domain_and_not_null_constraints(tmp_path):
+    _seed_v3(tmp_path)
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 4, (
+        "v4 schema not created (expected Gate-1 red)")
+
+    def rejected(sql):
+        try:
+            con.execute(sql)
+            return False
+        except sqlite3.IntegrityError:
+            return True
+
+    # Invalid domain values refused.
+    assert rejected("UPDATE drives SET lifecycle='ghost' WHERE drive_label='drive-00'")
+    assert rejected("UPDATE drives SET eligibility='maybe' WHERE drive_label='drive-00'")
+    # NOT NULL — cannot clear either axis.
+    assert rejected("UPDATE drives SET lifecycle=NULL WHERE drive_label='drive-00'")
+    assert rejected("UPDATE drives SET eligibility=NULL WHERE drive_label='drive-00'")
+    # Valid pair still accepted.
+    con.execute("UPDATE drives SET lifecycle='retired', eligibility='excluded' "
+                "WHERE drive_label='drive-00'")
+    assert con.execute(
+        "SELECT lifecycle, eligibility FROM drives WHERE drive_label='drive-00'"
+    ).fetchone() == ("retired", "excluded")
+    con.close()
+
+
+def test_v0_to_v4_does_not_introduce_lifecycle_columns_during_integrity_rebuild(tmp_path):
+    """Integrity rebuild (v0 path) must not invent v4 columns early; v4 lands in its own step.
+
+    Reuses the pre-v3 strip pattern from test_db_sqlite: evidence backup after connect must lack
+    lifecycle/eligibility. Final catalog after Gate-2 must be v4 with active+enabled defaults.
+    """
+    # Build a genuine pre-constraint pre-v3 catalog (same approach as test_db_sqlite).
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    con = db.connect()
+    con.execute("PRAGMA foreign_keys=OFF")
+    for view in db._VIEW_NAMES:
+        con.execute(f'DROP VIEW IF EXISTS "{view}"')
+    for table in db._INTEGRITY_TABLES:
+        con.execute(f'CREATE TABLE "{table}__legacy" AS SELECT * FROM "{table}"')
+    for table in reversed(db._INTEGRITY_TABLES):
+        con.execute(f'DROP TABLE "{table}"')
+    for table in db._INTEGRITY_TABLES:
+        con.execute(f'ALTER TABLE "{table}__legacy" RENAME TO "{table}"')
+    con.execute("DROP TABLE IF EXISTS drive_clean_anchors")
+    con.execute("DROP TABLE IF EXISTS drive_dirty_generations")
+    pre_v3 = ("drive_label,fs_uuid,annex_uuid,capacity_bytes,free_bytes,hw_model,serial,"
+              "physical_location,role,raid_backed,health,last_seen,notes")
+    con.execute(f"CREATE TABLE drives__pre3 AS SELECT {pre_v3} FROM drives")
+    con.execute("DROP TABLE drives")
+    con.execute("ALTER TABLE drives__pre3 RENAME TO drives")
+    con.execute("INSERT INTO drives(drive_label,free_bytes,role,raid_backed) "
+                "VALUES('drive-00',500,'primary',0)")
+    con.execute("PRAGMA user_version=0")
+    con.close()
+
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 4, (
+        "full migration must land at v4 (expected Gate-1 red until v4 exists)")
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    assert {"lifecycle", "eligibility"} <= dcols
+    row = con.execute(
+        "SELECT lifecycle, eligibility FROM drives WHERE drive_label='drive-00'").fetchone()
+    assert row == ("active", "enabled"), row
+    v3_bak = db.DB_PATH.with_name(db.DB_PATH.name + ".pre-evidence-v3.bak")
+    assert v3_bak.is_file(), "v0 path must still take the evidence v3 backup"
+    b = sqlite3.connect(str(v3_bak))
+    bcols = {r[1] for r in b.execute("PRAGMA table_info(drives)").fetchall()}
+    assert "lifecycle" not in bcols and "eligibility" not in bcols, (
+        "integrity/evidence steps must not introduce v4 columns early")
+    b.close()
+    con.close()
+
+
+def test_newer_catalog_rejection_uses_schema_version_plus_one(tmp_path):
+    """Hard-coded future version must track the build, not a frozen '4' literal forever."""
+    db.CATALOG_DIR = tmp_path
+    db.DB_PATH = tmp_path / "catalog.sqlite"
+    con = db.connect()
+    future = db._SCHEMA_VERSION + 1
+    con.execute(f"PRAGMA user_version={future}")
+    con.close()
+    try:
+        db.connect()
+        raise AssertionError("an older program must reject a newer catalog")
+    except RuntimeError as exc:
+        assert "newer than this ModelArk build" in str(exc), exc
+    raw = sqlite3.connect(str(db.DB_PATH))
+    assert raw.execute("PRAGMA user_version").fetchone()[0] == future
+    raw.close()
+
+
+def main():
+    import inspect
+    import tempfile
+    from pathlib import Path
+
+    tests = sorted((n, f) for n, f in globals().items()
+                   if n.startswith("test_") and callable(f))
+    passed, failed = [], []
+    for name, fn in tests:
+        try:
+            if "tmp_path" in inspect.signature(fn).parameters:
+                fn(Path(tempfile.mkdtemp(prefix="mark-v4-")))
+            else:
+                fn()
+            passed.append(name)
+            print(f"PASS  {name}")
+        except Exception as exc:  # noqa: BLE001 — Gate-1 wants the full red/green map
+            failed.append((name, type(exc).__name__, str(exc)[:200]))
+            print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
+    print(f"\n{len(passed)} passed, {len(failed)} failed")
+    print("Gate-1 tests-only: migration contracts EXPECTED RED until v4 production lands.")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_catalog_v4_lifecycle_migration.py
+++ b/tests/test_catalog_v4_lifecycle_migration.py
@@ -302,6 +302,32 @@ def test_newer_catalog_rejection_uses_schema_version_plus_one(tmp_path):
     raw.close()
 
 
+def test_fresh_drive_insert_defaults_to_active_enabled(tmp_path):
+    """Schema defaults (and thus registration upserts that omit the columns) → exactly active+enabled.
+
+    Does NOT pass lifecycle/eligibility in the INSERT — only the durable defaults may supply them.
+    """
+    _seed_v3(tmp_path)
+    con = db.connect()
+    assert con.execute("PRAGMA user_version").fetchone()[0] == 4, (
+        "v4 schema required for default pins (expected Gate-1 red)")
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    assert {"lifecycle", "eligibility"} <= dcols
+    # Omit the new columns entirely — registration-style minimal insert.
+    con.execute(
+        "INSERT INTO drives(drive_label,capacity_bytes,free_bytes,role,raid_backed) "
+        "VALUES('fresh-drive',2000,1500,'primary',0)")
+    row = con.execute(
+        "SELECT lifecycle, eligibility FROM drives WHERE drive_label='fresh-drive'").fetchone()
+    assert row == ("active", "enabled"), (
+        f"fresh drive without explicit lifecycle/eligibility must default to active+enabled; got {row}")
+    # Migrated pre-existing row also still active+enabled.
+    assert con.execute(
+        "SELECT lifecycle, eligibility FROM drives WHERE drive_label='drive-00'"
+    ).fetchone() == ("active", "enabled")
+    con.close()
+
+
 def main():
     import inspect
     import tempfile

--- a/tests/test_db_sqlite.py
+++ b/tests/test_db_sqlite.py
@@ -344,7 +344,9 @@ def test_v2_capacity_mode_migration_rolls_back_invalid_legacy_value(tmp_path):
 
 def test_newer_catalog_is_rejected_without_stamping_down(tmp_path):
     con = _fresh(tmp_path)
-    con.execute("PRAGMA user_version=4")             # a schema newer than this build (_SCHEMA_VERSION=3)
+    # Always one version ahead of the build — do not hard-code a frozen "v4" literal.
+    future = db._SCHEMA_VERSION + 1
+    con.execute(f"PRAGMA user_version={future}")
     con.close()
     before = db.DB_PATH.read_bytes()
     sidecars_before = {
@@ -357,7 +359,7 @@ def test_newer_catalog_is_rejected_without_stamping_down(tmp_path):
     except RuntimeError as exc:
         assert "newer than this ModelArk build" in str(exc), exc
     raw = sqlite3.connect(str(db.DB_PATH))
-    assert raw.execute("PRAGMA user_version").fetchone()[0] == 4
+    assert raw.execute("PRAGMA user_version").fetchone()[0] == future
     raw.close()
     assert db.DB_PATH.read_bytes() == before
     assert {

--- a/tests/test_drive_bootstrap.py
+++ b/tests/test_drive_bootstrap.py
@@ -70,7 +70,7 @@ def _catalog(tmp_path):
     db.DB_PATH = tmp_path / "catalog.sqlite"
     db.STATE_DIR = tmp_path / "state"
     con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture must be a v3 catalog"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, "fixture must be at current schema version"
     try:
         yield con
     finally:

--- a/tests/test_drive_mutation_envelope.py
+++ b/tests/test_drive_mutation_envelope.py
@@ -82,7 +82,7 @@ def _catalog(tmp_path):
     db.DB_PATH = tmp_path / "catalog.sqlite"
     db.STATE_DIR = tmp_path / "state"
     con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture must be a v3 catalog"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, "fixture must be at current schema version"
     try:
         yield con
     finally:

--- a/tests/test_lifecycle_eligibility.py
+++ b/tests/test_lifecycle_eligibility.py
@@ -1,0 +1,481 @@
+"""PR-07 / #37 lifecycle × eligibility pure matrix, bootstrap, and compatibility (tests-first).
+
+Gate 1 pins the accepted Gate-0 matrix BEFORE production:
+
+  Lifecycle   Eligibility    New placement   Verified copy satisfies   Bootstrap adds missing
+  active      enabled        yes             yes                       yes
+  active      excluded       no              yes                       no
+  lost        *              no              no                        no
+  retired     *              no              no                        no
+
+Presence (mounted/offline) must not rewrite this matrix. Retired row is the tombstone.
+
+RED until DriveFact carries lifecycle/eligibility, pure candidates filter placement vs satisfaction
+orthogonally, plan.bootstrap() only inserts missing active+enabled membership, and librarian
+placed_copies / queue totals agree with canonical satisfaction.
+"""
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+
+from modelark import archive_manifest, capacity, librarian, plan, reconcile, register
+from modelark.core import db
+
+try:
+    import modelark.candidates as candidates
+    _HAS = True
+except ModuleNotFoundError:
+    candidates = None
+    _HAS = False
+
+HW = "1" * 64
+_CFG = (("max_compress_ram_gb", 64), ("stream_compress", True), ("threads", 4))
+RATIO = capacity.DEFAULT_FLOAT_RATIO
+
+
+def _require():
+    if not _HAS:
+        raise AssertionError("modelark.candidates required for lifecycle matrix contracts")
+    fields = {f.name for f in dataclasses.fields(candidates.DriveFact)}
+    if not {"lifecycle", "eligibility"} <= fields:
+        raise AssertionError(
+            "DriveFact must carry durable lifecycle and eligibility (PR-07 / #37); "
+            f"got fields={sorted(fields)}")
+
+
+def _mf(name, size, sha256, *, fmt="safetensors", quant="bf16"):
+    action = "compress" if fmt == "safetensors" and quant in archive_manifest.FLOAT_QUANTS else "raw"
+    return archive_manifest.ManifestFile(
+        rfilename=name, size_bytes=size, sha256=sha256, format=fmt, quant=quant,
+        storage_action=action)
+
+
+def _drive(label, *, role="primary", raid=False, cap=10**12,
+           lifecycle="active", eligibility="enabled",
+           fs_uuid=None, annex_uuid=None, serial=None):
+    _require()
+    kwargs = dict(
+        drive_label=label, role=role, raid_backed=raid, capacity_bytes=cap,
+        filesystem_capacity_bytes=cap, identity_epoch=1,
+        fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=serial,
+    )
+    # Pass lifecycle/eligibility only when the type accepts them (Gate-2 will).
+    fields = {f.name for f in dataclasses.fields(candidates.DriveFact)}
+    if "lifecycle" in fields:
+        kwargs["lifecycle"] = lifecycle
+    if "eligibility" in fields:
+        kwargs["eligibility"] = eligibility
+    return candidates.DriveFact(**kwargs)
+
+
+def _arch(repo, drive, name, *, sha=None, obytes=None, sbytes=None, key=None):
+    return candidates.ArchivedFileFact(
+        repo_id=repo, drive_label=drive, rfilename=name,
+        orig_sha256=sha, orig_bytes=obytes, stored_bytes=sbytes, annex_key=key)
+
+
+def _input(*, selection, manifests, numcopies, drives, archived=(), cfg=_CFG, ratio=RATIO):
+    return candidates.PlannerInput(
+        plan_id="ark",
+        selection=tuple(selection),
+        manifests=tuple((repo, tuple(files)) for repo, files in manifests),
+        numcopies=tuple(numcopies),
+        drives=tuple(drives),
+        archived=tuple(archived),
+        compression_cfg=tuple(cfg),
+        float_ratio=ratio,
+    )
+
+
+def _run(inp):
+    graph = candidates.requirements(inp)
+    return graph, candidates.candidates(inp, graph)
+
+
+def _cands(cset, rid):
+    for req_id, cs in cset.by_requirement:
+        if req_id == rid:
+            return cs
+    return ()
+
+
+def _targets(cs):
+    return {c.target_drive for c in cs}
+
+
+def _satisfied_drives(cset, rid):
+    out = set()
+    for sat in cset.satisfied:
+        if sat.requirement_id == rid:
+            out |= {c.drive_label for c in sat.copies}
+    return out
+
+
+# --------------------------------------------------------------------------------------------------
+# Pure matrix — target eligibility (new placement)
+# --------------------------------------------------------------------------------------------------
+def test_matrix_new_placement_targets_active_enabled_only():
+    """Fresh placement candidates only on active+enabled; excluded/lost/retired never receive new work."""
+    _require()
+    drives = [
+        _drive("en", lifecycle="active", eligibility="enabled"),
+        _drive("ex", lifecycle="active", eligibility="excluded"),
+        _drive("lost", lifecycle="lost", eligibility="enabled"),
+        _drive("ret", lifecycle="retired", eligibility="enabled"),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 1)],
+        drives=drives,
+        archived=(),
+    )
+    _, cset = _run(inp)
+    cs = _cands(cset, "primary:org/m")
+    assert _targets(cs) == {"en"}, f"only active+enabled is placeable; got {_targets(cs)}"
+
+
+def test_matrix_verified_copy_satisfaction_active_including_excluded():
+    """A complete proven copy on active+excluded satisfies; lost/retired never do."""
+    _require()
+    drives = [
+        _drive("ex", lifecycle="active", eligibility="excluded"),
+        _drive("lost", lifecycle="lost", eligibility="enabled"),
+        _drive("ret", lifecycle="retired", eligibility="enabled"),
+        _drive("en", lifecycle="active", eligibility="enabled"),
+    ]
+    archived = [
+        _arch("org/m", "ex", "w.safetensors", sha=HW, obytes=100, sbytes=100),
+        _arch("org/m", "lost", "w.safetensors", sha=HW, obytes=100, sbytes=100),
+        _arch("org/m", "ret", "w.safetensors", sha=HW, obytes=100, sbytes=100),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 1)],
+        drives=drives,
+        archived=archived,
+    )
+    _, cset = _run(inp)
+    sat = _satisfied_drives(cset, "primary:org/m")
+    assert "ex" in sat, "active+excluded complete copy must still satisfy"
+    assert "lost" not in sat and "ret" not in sat
+    # No new placement on excluded when already satisfied; unsatisfied would only place on enabled.
+    assert _cands(cset, "primary:org/m") == () or "ex" not in _targets(_cands(cset, "primary:org/m"))
+
+
+def test_matrix_partial_reuse_omits_lost_retired_targets():
+    """Finish-in-place / partial reuse candidates only on active drives (enabled or excluded)."""
+    _require()
+    drives = [
+        _drive("ex", lifecycle="active", eligibility="excluded"),
+        _drive("lost", lifecycle="lost", eligibility="enabled"),
+        _drive("fresh", lifecycle="active", eligibility="enabled"),
+    ]
+    archived = [
+        _arch("org/m", "ex", "a.safetensors", sha=HW, obytes=100, sbytes=100),
+        _arch("org/m", "lost", "a.safetensors", sha=HW, obytes=100, sbytes=100),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [
+            _mf("a.safetensors", 100, HW),
+            _mf("b.safetensors", 100, "3" * 64),
+        ])],
+        numcopies=[("org/m", 1)],
+        drives=drives,
+        archived=archived,
+    )
+    _, cset = _run(inp)
+    targets = _targets(_cands(cset, "primary:org/m"))
+    assert "lost" not in targets
+    # Partial on excluded may appear as finish-in-place alternative; fresh enabled always may.
+    assert "fresh" in targets
+    # If excluded partial is emitted, it must not be the only forced pin — both can exist.
+    if "ex" in targets:
+        assert "fresh" in targets
+
+
+def test_matrix_protected_home_satisfaction_vs_placement_fallback():
+    """Active+excluded may satisfy home; fresh home placement only considers active+enabled."""
+    _require()
+    # Home complete on excluded RAID; replica still needs a domain-independent target.
+    drives = [
+        _drive("H-ex", role="primary", raid=True, lifecycle="active", eligibility="excluded",
+               fs_uuid="home-uuid"),
+        _drive("H-en", role="primary", raid=True, lifecycle="active", eligibility="enabled",
+               fs_uuid="other-home"),
+        _drive("R", role="replica", lifecycle="active", eligibility="enabled",
+               fs_uuid="rep-uuid"),
+    ]
+    archived = [
+        _arch("org/m", "H-ex", "w.safetensors", sha=HW, obytes=100, sbytes=100, key="k"),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=drives,
+        archived=archived,
+    )
+    graph, cset = _run(inp)
+    home_sat = _satisfied_drives(cset, "protected_home:org/m")
+    assert "H-ex" in home_sat, "excluded active home copy must satisfy protected_home"
+    # No new home placement on excluded; if home unsatisfied, only H-en.
+    home_place = _targets(_cands(cset, "protected_home:org/m"))
+    assert "H-ex" not in home_place
+    # Replica candidates must not source-place onto excluded for *new* work incorrectly —
+    # replica targets remain enabled replica tier.
+    rep = _cands(cset, "protected_replica:org/m")
+    if rep:
+        assert all(c.target_drive == "R" for c in rep)
+
+
+def test_matrix_lost_retired_not_repair_sources_for_placement():
+    """Lost/retired drives do not contribute as placement targets even with partial archives."""
+    _require()
+    drives = [
+        _drive("lost", lifecycle="lost", eligibility="enabled"),
+        _drive("ret", lifecycle="retired", eligibility="enabled"),
+        _drive("ok", lifecycle="active", eligibility="enabled"),
+    ]
+    archived = [
+        _arch("org/m", "lost", "w.safetensors", sha=HW, obytes=50, sbytes=50),
+        _arch("org/m", "ret", "w.safetensors", sha=HW, obytes=50, sbytes=50),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 1)],
+        drives=drives,
+        archived=archived,
+    )
+    _, cset = _run(inp)
+    assert _targets(_cands(cset, "primary:org/m")) == {"ok"}
+
+
+def test_matrix_shuffled_drive_order_deterministic():
+    _require()
+    def run(order):
+        drives = [
+            _drive(lab, lifecycle=lc, eligibility=el)
+            for lab, lc, el in order
+        ]
+        inp = _input(
+            selection=["org/a", "org/b"],
+            manifests=[
+                ("org/a", [_mf("a.safetensors", 10, HW)]),
+                ("org/b", [_mf("b.safetensors", 20, "3" * 64)]),
+            ],
+            numcopies=[("org/a", 1), ("org/b", 1)],
+            drives=drives,
+            archived=(),
+        )
+        return _run(inp)
+
+    a = [
+        ("z", "active", "enabled"),
+        ("a", "active", "excluded"),
+        ("m", "lost", "enabled"),
+    ]
+    b = list(reversed(a))
+    g1, c1 = run(a)
+    g2, c2 = run(b)
+    assert c1 == c2 and g1.requirement_set_hash == g2.requirement_set_hash
+
+
+# --------------------------------------------------------------------------------------------------
+# Bootstrap — plan.bootstrap() only
+# --------------------------------------------------------------------------------------------------
+def _mem():
+    con = sqlite3.connect(":memory:", isolation_level=None)
+    for stmt in db._statements(db.SCHEMA_PATH.read_text()):
+        con.execute(stmt)
+    return con
+
+
+def _insert_drive(con, label, *, lifecycle=None, eligibility=None, role="primary", raid=0):
+    cols = "drive_label,capacity_bytes,free_bytes,role,raid_backed"
+    vals = [label, 10_000, 10_000, role, raid]
+    # After Gate 2 these columns exist; Gate 1 red if missing when we try to set non-default.
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if "lifecycle" in dcols and "eligibility" in dcols:
+        cols += ",lifecycle,eligibility"
+        vals.extend([lifecycle or "active", eligibility or "enabled"])
+    elif lifecycle is not None or eligibility is not None:
+        raise AssertionError(
+            "cannot set lifecycle/eligibility: v4 columns missing (expected Gate-1 red)")
+    ph = ",".join("?" * len(vals))
+    con.execute(f"INSERT INTO drives({cols}) VALUES({ph})", vals)
+
+
+def test_bootstrap_adds_only_missing_active_enabled():
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError(
+            "v4 drives.lifecycle/eligibility columns required for bootstrap contract "
+            "(expected Gate-1 red)")
+    _insert_drive(con, "en", lifecycle="active", eligibility="enabled")
+    _insert_drive(con, "ex", lifecycle="active", eligibility="excluded")
+    _insert_drive(con, "lost", lifecycle="lost", eligibility="enabled")
+    _insert_drive(con, "ret", lifecycle="retired", eligibility="enabled")
+    # Pre-seed plan with excluded already a member — must be preserved, not re-added as "new".
+    plan.create(con, "ark", name="Ark")
+    plan.add_drive(con, "ark", "ex")
+    out = plan.bootstrap(con, "ark")
+    labels = set(plan.plan_drive_labels(con, "ark"))
+    assert "en" in labels, "active+enabled missing membership must be added"
+    assert "ex" in labels, "pre-existing excluded membership must be preserved"
+    assert "lost" not in labels and "ret" not in labels
+    # Second call idempotent.
+    plan.bootstrap(con, "ark")
+    assert set(plan.plan_drive_labels(con, "ark")) == labels
+    # Never mutated drive axes.
+    rows = dict(con.execute("SELECT drive_label, lifecycle, eligibility FROM drives").fetchall())
+    assert rows["en"] == ("active", "enabled")
+    assert rows["ex"] == ("active", "excluded")
+    assert rows["lost"][0] == "lost" and rows["ret"][0] == "retired"
+    assert out["plan_id"] == "ark"
+
+
+def test_bootstrap_does_not_delete_or_mutate_membership_axes():
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    _insert_drive(con, "kept-lost", lifecycle="lost", eligibility="enabled")
+    plan.create(con, "ark", name="Ark")
+    plan.add_drive(con, "ark", "kept-lost")  # historical membership of a now-lost drive
+    plan.bootstrap(con, "ark")
+    assert "kept-lost" in plan.plan_drive_labels(con, "ark"), (
+        "bootstrap must not delete existing plan_drives rows")
+    assert con.execute(
+        "SELECT lifecycle, eligibility FROM drives WHERE drive_label='kept-lost'"
+    ).fetchone() == ("lost", "enabled")
+
+
+# --------------------------------------------------------------------------------------------------
+# Compatibility totals / queue
+# --------------------------------------------------------------------------------------------------
+def test_placed_copies_respects_lifecycle_not_lost_or_retired():
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
+    con.execute(
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
+        "VALUES('org/m','model.safetensors',100,'safetensors','bf16')")
+    for lab, lc, el in (
+        ("ok", "active", "enabled"),
+        ("ex", "active", "excluded"),
+        ("lost", "lost", "enabled"),
+        ("ret", "retired", "enabled"),
+    ):
+        _insert_drive(con, lab, lifecycle=lc, eligibility=el)
+        con.execute(
+            "INSERT INTO archived(repo_id,rfilename,drive_label,orig_bytes,stored_bytes,compressed) "
+            "VALUES('org/m','model.safetensors',?,100,100,0)", [lab])
+    counts = librarian.placed_copies(con)
+    # Active complete copies (enabled + excluded) count; lost/retired do not.
+    assert counts.get("org/m") == 2, (
+        f"placed_copies must count only active complete drives; got {counts} "
+        "(expected Gate-1 red until lifecycle join exists)")
+
+
+def test_queue_completion_agrees_with_canonical_satisfaction():
+    """Portal/queue complete-copy signal must not count lost/retired while pure candidates do not."""
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
+    con.execute(
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant,sha256) "
+        "VALUES('org/m','model.safetensors',100,'safetensors','bf16',?)", [HW])
+    con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES('org/m','2026-01-01')")
+    _insert_drive(con, "lost", lifecycle="lost", eligibility="enabled")
+    con.execute(
+        "INSERT INTO archived(repo_id,rfilename,drive_label,orig_sha256,orig_bytes,stored_bytes,compressed) "
+        "VALUES('org/m','model.safetensors','lost',?,100,100,0)", [HW])
+    plan.bootstrap(con, "ark")
+    # Compatibility count
+    assert librarian.placed_copies(con).get("org/m", 0) == 0
+    # Canonical pure path (when capture includes lifecycle)
+    graph = reconcile.reconcile_plan(con, "ark")
+    sat_ids = {s.requirement_id for s in graph.candidates.satisfied}
+    assert "primary:org/m" not in sat_ids, (
+        "lost drive must not satisfy canonical requirement")
+
+
+# --------------------------------------------------------------------------------------------------
+# Reconcile → Gate-B fail-closed on state change
+# --------------------------------------------------------------------------------------------------
+def test_reconcile_to_gate_b_fails_closed_when_drive_becomes_ineligible():
+    """If a drive loses eligibility/lifecycle between capture and capacity, no false FEASIBLE assign."""
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
+    con.execute(
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
+        "VALUES('org/m','model.safetensors',100,'safetensors','bf16')")
+    con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES('org/m','2026-01-01')")
+    _insert_drive(con, "d0", lifecycle="active", eligibility="enabled")
+    plan.bootstrap(con, "ark")
+    graph = reconcile.reconcile_plan(con, "ark")
+    # Drive becomes retired after reconcile snapshot — revalidation must not place.
+    con.execute("UPDATE drives SET lifecycle='retired' WHERE drive_label='d0'")
+    from modelark import capacity_evidence
+    evidence = {
+        "d0": capacity_evidence.Evidence(
+            kind="live", executable=True, admissible_free=10**9,
+            optimistic_usable_max=10**9, observed_free=10**9),
+    }
+    result = capacity.plan_capacity(con, graph, evidence_by_drive=evidence)
+    assert result.feasible is False or not result.tasks, (
+        "state change to retired after reconcile must fail closed before assignment "
+        f"(gate={getattr(result, 'gate_b_code', None)} tasks={len(result.tasks)})")
+
+
+# --------------------------------------------------------------------------------------------------
+# Registration refuses existing retired label
+# --------------------------------------------------------------------------------------------------
+def test_retired_label_registration_still_refused_before_mutation():
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if "lifecycle" in dcols:
+        _insert_drive(con, "retired-drive", lifecycle="retired", eligibility="excluded")
+    else:
+        con.execute("INSERT INTO drives(drive_label) VALUES('retired-drive')")
+    # Existing-label guard is lifecycle-blind and must still refuse.
+    try:
+        register._guard_existing_label(con, "retired-drive")
+        raise AssertionError("retired label must be refused before physical/catalog mutation")
+    except RuntimeError as exc:
+        assert "retired-drive" in str(exc).lower() or "exist" in str(exc).lower(), exc
+
+
+def main():
+    tests = sorted((n, f) for n, f in globals().items()
+                   if n.startswith("test_") and callable(f))
+    passed, failed = [], []
+    for name, fn in tests:
+        try:
+            fn()
+            passed.append(name)
+            print(f"PASS  {name}")
+        except Exception as exc:  # noqa: BLE001
+            failed.append((name, type(exc).__name__, str(exc)[:220]))
+            print(f"FAIL  {name}  -> {type(exc).__name__}: {exc}")
+    print(f"\n{len(passed)} passed, {len(failed)} failed")
+    print("Gate-1 tests-only: lifecycle/eligibility contracts EXPECTED RED until PR-07 production.")
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lifecycle_eligibility.py
+++ b/tests/test_lifecycle_eligibility.py
@@ -276,6 +276,65 @@ def test_matrix_no_raid_fallback_skips_excluded_largest_primary():
         f"no-RAID fallback must not choose excluded largest primary; got {home_place}")
 
 
+def test_matrix_no_raid_smaller_primary_complete_does_not_satisfy_home():
+    """Finding 12: no-RAID protected-home satisfaction is the largest primary only — not any primary."""
+    _require()
+    drives = [
+        _drive("big", role="primary", raid=False, cap=10**15,
+               lifecycle="active", eligibility="enabled", fs_uuid="big"),
+        _drive("small", role="primary", raid=False, cap=10**12,
+               lifecycle="active", eligibility="enabled", fs_uuid="small"),
+        _drive("R", role="replica", lifecycle="active", eligibility="enabled",
+               fs_uuid="rep"),
+    ]
+    archived = [
+        _arch("org/m", "small", "w.safetensors", sha=HW, obytes=100, sbytes=100),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=drives,
+        archived=archived,
+    )
+    _, cset = _run(inp)
+    home_sat = _satisfied_drives(cset, "protected_home:org/m")
+    assert "small" not in home_sat, (
+        f"complete copy on smaller primary must not satisfy protected-home; sat={home_sat}")
+    assert "big" not in home_sat
+    # Unsatisfied home still places only on the canonical largest primary.
+    assert _targets(_cands(cset, "protected_home:org/m")) == {"big"}, (
+        f"home placement must target largest primary; got {_targets(_cands(cset, 'protected_home:org/m'))}")
+
+
+def test_matrix_excluded_raid_plus_plain_emits_plain_home_candidate():
+    """Finding 12: active+excluded RAID + placeable plain primary → plain is a home placement target."""
+    _require()
+    drives = [
+        _drive("raid-ex", role="primary", raid=True, cap=10**15,
+               lifecycle="active", eligibility="excluded", fs_uuid="raid"),
+        _drive("plain-en", role="primary", raid=False, cap=10**12,
+               lifecycle="active", eligibility="enabled", fs_uuid="plain"),
+        _drive("R", role="replica", lifecycle="active", eligibility="enabled",
+               fs_uuid="rep"),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=drives,
+        archived=(),
+    )
+    graph, cset = _run(inp)
+    home_req = next(r for r in graph.desired if r.requirement_id == "protected_home:org/m")
+    assert home_req.eligible_drives == ("plain-en",), home_req.eligible_drives
+    home_place = _targets(_cands(cset, "protected_home:org/m"))
+    assert home_place == {"plain-en"}, (
+        f"plain primary must be the home candidate when RAID is excluded; got {home_place} "
+        f"blocked={cset.blocked}")
+    assert "protected_home:org/m" not in {b.requirement_id for b in cset.blocked}
+
+
 def test_matrix_replica_sources_never_lost_or_retired():
     """Lost/retired proven copies never become SourceIdentity; active+excluded may."""
     _require()
@@ -602,6 +661,54 @@ def test_reconcile_to_gate_b_fails_closed_when_drive_becomes_excluded():
     assert result.feasible is False, (
         f"excluded post-reconcile must be non-feasible; gate={getattr(result, 'gate_b_code', None)}")
     assert result.tasks == (), "must not place onto a drive that lost eligibility after capture"
+    gate = getattr(result, "gate_b_code", None)
+    fail_codes = {
+        (f.code.value if hasattr(f.code, "value") else str(f.code)) for f in result.failures
+    }
+    assert gate == "TARGET_DRIVE_CHANGED" or "TARGET_DRIVE_CHANGED" in fail_codes, (
+        f"expected TARGET_DRIVE_CHANGED pin; gate={gate!r} failures={fail_codes}")
+
+
+def test_reconcile_to_gate_b_fails_closed_when_one_of_multiple_targets_loses_eligibility():
+    """Finding 13: multi-target race — any captured target losing placeability fails closed.
+
+    Captured candidates target both a and b; excluding only a must not leave assignment on a
+    (or silently drop a and assign b). Full fail-closed before assignment.
+    """
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
+    con.execute(
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
+        "VALUES('org/m','model.safetensors',100,'safetensors','bf16')")
+    con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES('org/m','2026-01-01')")
+    _insert_drive(con, "a", lifecycle="active", eligibility="enabled")
+    _insert_drive(con, "b", lifecycle="active", eligibility="enabled")
+    plan.bootstrap(con, "ark")
+    graph = reconcile.reconcile_plan(con, "ark")
+    targets = set()
+    for rid, cs in graph.candidates.by_requirement:
+        if rid == "primary:org/m":
+            targets = {c.target_drive for c in cs}
+    assert targets == {"a", "b"}, f"fixture must capture multi-target candidates; got {targets}"
+    # One of two targets loses eligibility after capture.
+    con.execute("UPDATE drives SET eligibility='excluded' WHERE drive_label='a'")
+    from modelark import capacity_evidence
+    evidence = {
+        lab: capacity_evidence.Evidence(
+            kind="live", executable=True, admissible_free=10**9,
+            optimistic_usable_max=10**9, observed_free=10**9)
+        for lab in ("a", "b")
+    }
+    result = capacity.plan_capacity(con, graph, evidence_by_drive=evidence)
+    assert result.feasible is False, (
+        f"partial placeability race must be non-feasible; gate={getattr(result, 'gate_b_code', None)} "
+        f"tasks={[t.target_drive for t in result.tasks]}")
+    assert result.tasks == (), (
+        f"must not assign after multi-target lifecycle/eligibility race; "
+        f"tasks={[t.target_drive for t in result.tasks]}")
     gate = getattr(result, "gate_b_code", None)
     fail_codes = {
         (f.code.value if hasattr(f.code, "value") else str(f.code)) for f in result.failures

--- a/tests/test_lifecycle_eligibility.py
+++ b/tests/test_lifecycle_eligibility.py
@@ -116,13 +116,15 @@ def _satisfied_drives(cset, rid):
 # Pure matrix — target eligibility (new placement)
 # --------------------------------------------------------------------------------------------------
 def test_matrix_new_placement_targets_active_enabled_only():
-    """Fresh placement candidates only on active+enabled; excluded/lost/retired never receive new work."""
+    """Fresh placement candidates only on active+enabled across the full 3×2 matrix."""
     _require()
     drives = [
         _drive("en", lifecycle="active", eligibility="enabled"),
         _drive("ex", lifecycle="active", eligibility="excluded"),
-        _drive("lost", lifecycle="lost", eligibility="enabled"),
-        _drive("ret", lifecycle="retired", eligibility="enabled"),
+        _drive("lost-en", lifecycle="lost", eligibility="enabled"),
+        _drive("lost-ex", lifecycle="lost", eligibility="excluded"),
+        _drive("ret-en", lifecycle="retired", eligibility="enabled"),
+        _drive("ret-ex", lifecycle="retired", eligibility="excluded"),
     ]
     inp = _input(
         selection=["org/m"],
@@ -137,18 +139,19 @@ def test_matrix_new_placement_targets_active_enabled_only():
 
 
 def test_matrix_verified_copy_satisfaction_active_including_excluded():
-    """A complete proven copy on active+excluded satisfies; lost/retired never do."""
+    """Complete proven copies: active (+enabled or +excluded) satisfy; lost/retired never do."""
     _require()
     drives = [
         _drive("ex", lifecycle="active", eligibility="excluded"),
-        _drive("lost", lifecycle="lost", eligibility="enabled"),
-        _drive("ret", lifecycle="retired", eligibility="enabled"),
+        _drive("lost-en", lifecycle="lost", eligibility="enabled"),
+        _drive("lost-ex", lifecycle="lost", eligibility="excluded"),
+        _drive("ret-en", lifecycle="retired", eligibility="enabled"),
+        _drive("ret-ex", lifecycle="retired", eligibility="excluded"),
         _drive("en", lifecycle="active", eligibility="enabled"),
     ]
     archived = [
-        _arch("org/m", "ex", "w.safetensors", sha=HW, obytes=100, sbytes=100),
-        _arch("org/m", "lost", "w.safetensors", sha=HW, obytes=100, sbytes=100),
-        _arch("org/m", "ret", "w.safetensors", sha=HW, obytes=100, sbytes=100),
+        _arch("org/m", lab, "w.safetensors", sha=HW, obytes=100, sbytes=100)
+        for lab in ("ex", "lost-en", "lost-ex", "ret-en", "ret-ex")
     ]
     inp = _input(
         selection=["org/m"],
@@ -160,13 +163,12 @@ def test_matrix_verified_copy_satisfaction_active_including_excluded():
     _, cset = _run(inp)
     sat = _satisfied_drives(cset, "primary:org/m")
     assert "ex" in sat, "active+excluded complete copy must still satisfy"
-    assert "lost" not in sat and "ret" not in sat
-    # No new placement on excluded when already satisfied; unsatisfied would only place on enabled.
-    assert _cands(cset, "primary:org/m") == () or "ex" not in _targets(_cands(cset, "primary:org/m"))
+    assert not (sat & {"lost-en", "lost-ex", "ret-en", "ret-ex"})
+    assert _cands(cset, "primary:org/m") == ()  # already satisfied; no new placement
 
 
-def test_matrix_partial_reuse_omits_lost_retired_targets():
-    """Finish-in-place / partial reuse candidates only on active drives (enabled or excluded)."""
+def test_matrix_partial_reuse_excludes_write_targets():
+    """Partial archives on excluded/lost are NOT finish-in-place write targets; only fresh enabled."""
     _require()
     drives = [
         _drive("ex", lifecycle="active", eligibility="excluded"),
@@ -188,29 +190,21 @@ def test_matrix_partial_reuse_omits_lost_retired_targets():
         archived=archived,
     )
     _, cset = _run(inp)
-    targets = _targets(_cands(cset, "primary:org/m"))
-    assert "lost" not in targets
-    # Partial on excluded may appear as finish-in-place alternative; fresh enabled always may.
-    assert "fresh" in targets
-    # If excluded partial is emitted, it must not be the only forced pin — both can exist.
-    if "ex" in targets:
-        assert "fresh" in targets
+    # New placement (including finish-in-place writes) only on active+enabled.
+    assert _targets(_cands(cset, "primary:org/m")) == {"fresh"}
 
 
-def test_matrix_protected_home_satisfaction_vs_placement_fallback():
-    """Active+excluded may satisfy home; fresh home placement only considers active+enabled."""
+def test_matrix_excluded_complete_home_satisfies_and_sources_replica():
+    """Active+excluded complete home satisfies and may be a replica SourceIdentity."""
     _require()
-    # Home complete on excluded RAID; replica still needs a domain-independent target.
     drives = [
         _drive("H-ex", role="primary", raid=True, lifecycle="active", eligibility="excluded",
                fs_uuid="home-uuid"),
-        _drive("H-en", role="primary", raid=True, lifecycle="active", eligibility="enabled",
-               fs_uuid="other-home"),
         _drive("R", role="replica", lifecycle="active", eligibility="enabled",
                fs_uuid="rep-uuid"),
     ]
     archived = [
-        _arch("org/m", "H-ex", "w.safetensors", sha=HW, obytes=100, sbytes=100, key="k"),
+        _arch("org/m", "H-ex", "w.safetensors", sha=HW, obytes=100, sbytes=100, key="annex-home"),
     ]
     inp = _input(
         selection=["org/m"],
@@ -219,40 +213,108 @@ def test_matrix_protected_home_satisfaction_vs_placement_fallback():
         drives=drives,
         archived=archived,
     )
-    graph, cset = _run(inp)
-    home_sat = _satisfied_drives(cset, "protected_home:org/m")
-    assert "H-ex" in home_sat, "excluded active home copy must satisfy protected_home"
-    # No new home placement on excluded; if home unsatisfied, only H-en.
-    home_place = _targets(_cands(cset, "protected_home:org/m"))
-    assert "H-ex" not in home_place
-    # Replica candidates must not source-place onto excluded for *new* work incorrectly —
-    # replica targets remain enabled replica tier.
+    _, cset = _run(inp)
+    assert "H-ex" in _satisfied_drives(cset, "protected_home:org/m")
     rep = _cands(cset, "protected_replica:org/m")
-    if rep:
-        assert all(c.target_drive == "R" for c in rep)
+    assert rep, "replica still needs placement on R"
+    assert {c.target_drive for c in rep} == {"R"}
+    # Proven home on excluded is a valid SourceIdentity for REPLICATE candidates.
+    for c in rep:
+        assert c.source is not None
+        assert not isinstance(c.source, candidates.PendingHome)
+        assert isinstance(c.source, candidates.SourceIdentity)
+        assert c.source.drive_label == "H-ex"
 
 
-def test_matrix_lost_retired_not_repair_sources_for_placement():
-    """Lost/retired drives do not contribute as placement targets even with partial archives."""
+def test_matrix_unsatisfied_home_targets_only_active_enabled():
+    """Unsatisfied protected home placement never targets excluded/lost/retired primaries."""
     _require()
     drives = [
-        _drive("lost", lifecycle="lost", eligibility="enabled"),
-        _drive("ret", lifecycle="retired", eligibility="enabled"),
-        _drive("ok", lifecycle="active", eligibility="enabled"),
-    ]
-    archived = [
-        _arch("org/m", "lost", "w.safetensors", sha=HW, obytes=50, sbytes=50),
-        _arch("org/m", "ret", "w.safetensors", sha=HW, obytes=50, sbytes=50),
+        _drive("H-ex", role="primary", raid=True, lifecycle="active", eligibility="excluded",
+               fs_uuid="ex-uuid"),
+        _drive("H-lost", role="primary", raid=True, lifecycle="lost", eligibility="enabled",
+               fs_uuid="lost-uuid"),
+        _drive("H-en", role="primary", raid=True, lifecycle="active", eligibility="enabled",
+               fs_uuid="en-uuid"),
+        _drive("R", role="replica", lifecycle="active", eligibility="enabled",
+               fs_uuid="rep-uuid"),
     ]
     inp = _input(
         selection=["org/m"],
         manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
-        numcopies=[("org/m", 1)],
+        numcopies=[("org/m", 2)],
+        drives=drives,
+        archived=(),
+    )
+    _, cset = _run(inp)
+    home_place = _targets(_cands(cset, "protected_home:org/m"))
+    assert home_place == {"H-en"}, f"fresh home only on active+enabled; got {home_place}"
+
+
+def test_matrix_no_raid_fallback_skips_excluded_largest_primary():
+    """No-RAID protected-home fallback must not select an excluded largest primary."""
+    _require()
+    drives = [
+        # Largest primary is excluded — fallback must skip it.
+        _drive("big-ex", role="primary", raid=False, cap=10**15,
+               lifecycle="active", eligibility="excluded", fs_uuid="big"),
+        _drive("small-en", role="primary", raid=False, cap=10**12,
+               lifecycle="active", eligibility="enabled", fs_uuid="small"),
+        _drive("R", role="replica", lifecycle="active", eligibility="enabled",
+               fs_uuid="rep"),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=drives,
+        archived=(),
+    )
+    _, cset = _run(inp)
+    home_place = _targets(_cands(cset, "protected_home:org/m"))
+    assert home_place == {"small-en"}, (
+        f"no-RAID fallback must not choose excluded largest primary; got {home_place}")
+
+
+def test_matrix_replica_sources_never_lost_or_retired():
+    """Lost/retired proven copies never become SourceIdentity; active+excluded may."""
+    _require()
+    drives = [
+        _drive("H-ex", role="primary", raid=True, lifecycle="active", eligibility="excluded",
+               fs_uuid="hex"),
+        _drive("H-lost", role="primary", raid=True, lifecycle="lost", eligibility="enabled",
+               fs_uuid="hlost"),
+        _drive("H-ret", role="primary", raid=True, lifecycle="retired", eligibility="excluded",
+               fs_uuid="hret"),
+        _drive("R", role="replica", lifecycle="active", eligibility="enabled",
+               fs_uuid="rep"),
+    ]
+    archived = [
+        _arch("org/m", "H-ex", "w.safetensors", sha=HW, obytes=100, sbytes=100, key="k-ex"),
+        _arch("org/m", "H-lost", "w.safetensors", sha=HW, obytes=100, sbytes=100, key="k-lost"),
+        _arch("org/m", "H-ret", "w.safetensors", sha=HW, obytes=100, sbytes=100, key="k-ret"),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
         drives=drives,
         archived=archived,
     )
     _, cset = _run(inp)
-    assert _targets(_cands(cset, "primary:org/m")) == {"ok"}
+    # Home satisfied only by active copies (excluded ok).
+    home_sat = _satisfied_drives(cset, "protected_home:org/m")
+    assert "H-ex" in home_sat
+    assert "H-lost" not in home_sat and "H-ret" not in home_sat
+    rep = _cands(cset, "protected_replica:org/m")
+    assert rep
+    source_labels = set()
+    for c in rep:
+        assert c.target_drive == "R"
+        assert isinstance(c.source, candidates.SourceIdentity)
+        source_labels.add(c.source.drive_label)
+    assert "H-ex" in source_labels
+    assert "H-lost" not in source_labels and "H-ret" not in source_labels
 
 
 def test_matrix_shuffled_drive_order_deterministic():
@@ -278,6 +340,8 @@ def test_matrix_shuffled_drive_order_deterministic():
         ("z", "active", "enabled"),
         ("a", "active", "excluded"),
         ("m", "lost", "enabled"),
+        ("n", "lost", "excluded"),
+        ("r", "retired", "excluded"),
     ]
     b = list(reversed(a))
     g1, c1 = run(a)
@@ -332,11 +396,16 @@ def test_bootstrap_adds_only_missing_active_enabled():
     # Second call idempotent.
     plan.bootstrap(con, "ark")
     assert set(plan.plan_drive_labels(con, "ark")) == labels
-    # Never mutated drive axes.
-    rows = dict(con.execute("SELECT drive_label, lifecycle, eligibility FROM drives").fetchall())
+    # Never mutated drive axes (three-column SELECT → label → (lifecycle, eligibility)).
+    rows = {
+        label: (lifecycle, eligibility)
+        for label, lifecycle, eligibility in con.execute(
+            "SELECT drive_label, lifecycle, eligibility FROM drives")
+    }
     assert rows["en"] == ("active", "enabled")
     assert rows["ex"] == ("active", "excluded")
-    assert rows["lost"][0] == "lost" and rows["ret"][0] == "retired"
+    assert rows["lost"] == ("lost", "enabled")
+    assert rows["ret"] == ("retired", "enabled")
     assert out["plan_id"] == "ark"
 
 
@@ -371,22 +440,28 @@ def test_placed_copies_respects_lifecycle_not_lost_or_retired():
     for lab, lc, el in (
         ("ok", "active", "enabled"),
         ("ex", "active", "excluded"),
-        ("lost", "lost", "enabled"),
-        ("ret", "retired", "enabled"),
+        ("lost-en", "lost", "enabled"),
+        ("lost-ex", "lost", "excluded"),
+        ("ret-en", "retired", "enabled"),
+        ("ret-ex", "retired", "excluded"),
     ):
         _insert_drive(con, lab, lifecycle=lc, eligibility=el)
         con.execute(
             "INSERT INTO archived(repo_id,rfilename,drive_label,orig_bytes,stored_bytes,compressed) "
             "VALUES('org/m','model.safetensors',?,100,100,0)", [lab])
     counts = librarian.placed_copies(con)
-    # Active complete copies (enabled + excluded) count; lost/retired do not.
+    # Active complete copies (enabled + excluded) count; all lost/retired pairs do not.
     assert counts.get("org/m") == 2, (
         f"placed_copies must count only active complete drives; got {counts} "
         "(expected Gate-1 red until lifecycle join exists)")
 
 
 def test_queue_completion_agrees_with_canonical_satisfaction():
-    """Portal/queue complete-copy signal must not count lost/retired while pure candidates do not."""
+    """Lifecycle — not membership absence — must prevent lost-drive satisfaction.
+
+    Pre-seed historical plan membership so bootstrap does not simply omit the drive; the
+    catalog still sees the complete archived copy, but lifecycle forbids counting it.
+    """
     con = _mem()
     dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
     if not {"lifecycle", "eligibility"} <= dcols:
@@ -400,21 +475,23 @@ def test_queue_completion_agrees_with_canonical_satisfaction():
     con.execute(
         "INSERT INTO archived(repo_id,rfilename,drive_label,orig_sha256,orig_bytes,stored_bytes,compressed) "
         "VALUES('org/m','model.safetensors','lost',?,100,100,0)", [HW])
+    plan.create(con, "ark", name="Ark")
+    plan.add_drive(con, "ark", "lost")  # historical membership — still on the plan
     plan.bootstrap(con, "ark")
-    # Compatibility count
-    assert librarian.placed_copies(con).get("org/m", 0) == 0
-    # Canonical pure path (when capture includes lifecycle)
+    assert "lost" in plan.plan_drive_labels(con, "ark")
+    assert librarian.placed_copies(con).get("org/m", 0) == 0, (
+        "placed_copies must not count complete copies on lost drives")
     graph = reconcile.reconcile_plan(con, "ark")
     sat_ids = {s.requirement_id for s in graph.candidates.satisfied}
     assert "primary:org/m" not in sat_ids, (
-        "lost drive must not satisfy canonical requirement")
+        "lost drive must not satisfy canonical requirement even with plan membership")
 
 
 # --------------------------------------------------------------------------------------------------
 # Reconcile → Gate-B fail-closed on state change
 # --------------------------------------------------------------------------------------------------
 def test_reconcile_to_gate_b_fails_closed_when_drive_becomes_ineligible():
-    """If a drive loses eligibility/lifecycle between capture and capacity, no false FEASIBLE assign."""
+    """If a drive is retired after reconcile capture, plan_capacity must not assign tasks."""
     con = _mem()
     dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
     if not {"lifecycle", "eligibility"} <= dcols:
@@ -436,9 +513,16 @@ def test_reconcile_to_gate_b_fails_closed_when_drive_becomes_ineligible():
             optimistic_usable_max=10**9, observed_free=10**9),
     }
     result = capacity.plan_capacity(con, graph, evidence_by_drive=evidence)
-    assert result.feasible is False or not result.tasks, (
-        "state change to retired after reconcile must fail closed before assignment "
-        f"(gate={getattr(result, 'gate_b_code', None)} tasks={len(result.tasks)})")
+    assert result.feasible is False, (
+        f"retired post-reconcile must be non-feasible; gate={getattr(result, 'gate_b_code', None)}")
+    assert result.tasks == (), "must not expose executable tasks after fail-closed revalidation"
+    # Prefer typed fail-closed for membership/target invalidation after snapshot.
+    gate = getattr(result, "gate_b_code", None)
+    fail_codes = {
+        (f.code.value if hasattr(f.code, "value") else str(f.code)) for f in result.failures
+    }
+    assert gate == "TARGET_DRIVE_CHANGED" or "TARGET_DRIVE_CHANGED" in fail_codes, (
+        f"expected TARGET_DRIVE_CHANGED pin; gate={gate!r} failures={fail_codes}")
 
 
 # --------------------------------------------------------------------------------------------------

--- a/tests/test_lifecycle_eligibility.py
+++ b/tests/test_lifecycle_eligibility.py
@@ -335,6 +335,52 @@ def test_matrix_excluded_raid_plus_plain_emits_plain_home_candidate():
     assert "protected_home:org/m" not in {b.requirement_id for b in cset.blocked}
 
 
+def test_matrix_complete_on_authorized_fallback_satisfies_home_and_sources_replica():
+    """Finding 15: complete copy on authorized plain fallback must satisfy home (not wrong_tier).
+
+    When the only active RAID primary is excluded, placement targets the plain primary. A verified
+    complete copy already on that plain fallback must satisfy protected-home, must not be
+    wrong_tier drift, and must be the replica's SourceIdentity (not PendingHome).
+    """
+    _require()
+    drives = [
+        _drive("raid-ex", role="primary", raid=True, cap=10**15,
+               lifecycle="active", eligibility="excluded", fs_uuid="raid"),
+        _drive("plain-en", role="primary", raid=False, cap=10**12,
+               lifecycle="active", eligibility="enabled", fs_uuid="plain"),
+        _drive("R", role="replica", lifecycle="active", eligibility="enabled",
+               fs_uuid="rep"),
+    ]
+    archived = [
+        _arch("org/m", "plain-en", "w.safetensors", sha=HW, obytes=100, sbytes=100, key="k-plain"),
+    ]
+    inp = _input(
+        selection=["org/m"],
+        manifests=[("org/m", [_mf("w.safetensors", 100, HW)])],
+        numcopies=[("org/m", 2)],
+        drives=drives,
+        archived=archived,
+    )
+    _, cset = _run(inp)
+    home_sat = _satisfied_drives(cset, "protected_home:org/m")
+    assert "plain-en" in home_sat, (
+        f"complete copy on authorized plain fallback must satisfy protected-home; sat={home_sat}")
+    assert _cands(cset, "protected_home:org/m") == ()
+    assert "protected_home:org/m" not in {b.requirement_id for b in cset.blocked}
+    home_drift = {
+        (d.drive_label, d.reason) for d in cset.drift if d.requirement_id == "protected_home:org/m"
+    }
+    assert ("plain-en", "wrong_tier") not in home_drift, (
+        f"authorized fallback complete must not be wrong_tier; drift={home_drift}")
+    rep = _cands(cset, "protected_replica:org/m")
+    assert rep, "replica still needs placement on R"
+    for c in rep:
+        assert c.target_drive == "R"
+        assert isinstance(c.source, candidates.SourceIdentity), (
+            f"replica source must be SourceIdentity from plain-en home, not {type(c.source).__name__}")
+        assert c.source.drive_label == "plain-en"
+
+
 def test_matrix_replica_sources_never_lost_or_retired():
     """Lost/retired proven copies never become SourceIdentity; active+excluded may."""
     _require()

--- a/tests/test_lifecycle_eligibility.py
+++ b/tests/test_lifecycle_eligibility.py
@@ -490,12 +490,72 @@ def test_queue_completion_agrees_with_canonical_satisfaction():
 # --------------------------------------------------------------------------------------------------
 # Reconcile → Gate-B fail-closed on state change
 # --------------------------------------------------------------------------------------------------
-def test_reconcile_to_gate_b_fails_closed_when_drive_becomes_ineligible():
-    """If a drive is retired after reconcile capture, plan_capacity must not assign tasks."""
+def test_drive_facts_capture_excluded_member_exactly():
+    """_drive_facts / reconcile capture eligibility+lifecycle; excluded complete copy satisfies,
+    but is never a fresh placement target."""
     con = _mem()
     dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
     if not {"lifecycle", "eligibility"} <= dcols:
         raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
+    con.execute(
+        "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant,sha256) "
+        "VALUES('org/m','model.safetensors',100,'safetensors','bf16',?)", [HW])
+    con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES('org/m','2026-01-01')")
+    _insert_drive(con, "ex", lifecycle="active", eligibility="excluded")
+    _insert_drive(con, "en", lifecycle="active", eligibility="enabled")
+    con.execute(
+        "INSERT INTO archived(repo_id,rfilename,drive_label,orig_sha256,orig_bytes,stored_bytes,compressed) "
+        "VALUES('org/m','model.safetensors','ex',?,100,100,0)", [HW])
+    plan.create(con, "ark", name="Ark")
+    plan.add_drive(con, "ark", "ex")  # existing plan member
+    plan.add_drive(con, "ark", "en")
+    facts = reconcile._drive_facts(con, "ark")
+    by_label = {f.drive_label: f for f in facts}
+    assert "ex" in by_label and "en" in by_label
+    assert getattr(by_label["ex"], "lifecycle") == "active"
+    assert getattr(by_label["ex"], "eligibility") == "excluded"
+    assert getattr(by_label["en"], "lifecycle") == "active"
+    assert getattr(by_label["en"], "eligibility") == "enabled"
+    graph = reconcile.reconcile_plan(con, "ark")
+    sat = {s.requirement_id for s in graph.candidates.satisfied}
+    assert "primary:org/m" in sat, "active+excluded complete copy must satisfy via capture"
+    # No unsatisfied placement targeting the excluded member.
+    for rid, cs in graph.candidates.by_requirement:
+        assert "ex" not in {c.target_drive for c in cs}, (
+            f"{rid} must not place onto excluded drive; targets={[c.target_drive for c in cs]}")
+
+
+def test_plan_capacity_counts_only_active_enabled_members():
+    """plan.capacity() usable fleet must ignore excluded/lost/retired historical members."""
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    # Equal nominal capacity so the active+enabled subset is a clean fraction of the all-members sum.
+    for lab, lc, el in (
+        ("en", "active", "enabled"),
+        ("ex", "active", "excluded"),
+        ("lost", "lost", "enabled"),
+        ("ret", "retired", "enabled"),
+    ):
+        _insert_drive(con, lab, lifecycle=lc, eligibility=el)
+        con.execute(
+            "UPDATE drives SET capacity_bytes=1000, free_bytes=1000 WHERE drive_label=?", [lab])
+    plan.create(con, "ark", name="Ark")
+    for lab in ("en", "ex", "lost", "ret"):
+        plan.add_drive(con, "ark", lab)
+    usable = plan.capacity(con, "ark")
+    # Only "en" contributes: capacity 1000 − headroom(1000, False).
+    only_en = plan._headroom(1000, False)
+    expected = max(0, 1000 - only_en)
+    assert usable == expected, (
+        f"plan.capacity must count only active+enabled members; got {usable}, expected {expected} "
+        f"(all four members would be ~{4 * expected})")
+
+
+def _gate_b_post_capture_state_change(con, *, column: str, value: str):
+    """Shared race: capture reconcile, mutate drive state, plan_capacity must not assign."""
     con.execute("INSERT INTO models(repo_id,numcopies) VALUES('org/m',1)")
     con.execute(
         "INSERT INTO files(repo_id,rfilename,size_bytes,format,quant) "
@@ -504,19 +564,44 @@ def test_reconcile_to_gate_b_fails_closed_when_drive_becomes_ineligible():
     _insert_drive(con, "d0", lifecycle="active", eligibility="enabled")
     plan.bootstrap(con, "ark")
     graph = reconcile.reconcile_plan(con, "ark")
-    # Drive becomes retired after reconcile snapshot — revalidation must not place.
-    con.execute("UPDATE drives SET lifecycle='retired' WHERE drive_label='d0'")
+    con.execute(f"UPDATE drives SET {column}=? WHERE drive_label='d0'", [value])
     from modelark import capacity_evidence
     evidence = {
         "d0": capacity_evidence.Evidence(
             kind="live", executable=True, admissible_free=10**9,
             optimistic_usable_max=10**9, observed_free=10**9),
     }
-    result = capacity.plan_capacity(con, graph, evidence_by_drive=evidence)
+    return capacity.plan_capacity(con, graph, evidence_by_drive=evidence)
+
+
+def test_reconcile_to_gate_b_fails_closed_when_drive_is_retired():
+    """If a drive is retired after reconcile capture, plan_capacity must not assign tasks."""
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    result = _gate_b_post_capture_state_change(con, column="lifecycle", value="retired")
     assert result.feasible is False, (
         f"retired post-reconcile must be non-feasible; gate={getattr(result, 'gate_b_code', None)}")
     assert result.tasks == (), "must not expose executable tasks after fail-closed revalidation"
-    # Prefer typed fail-closed for membership/target invalidation after snapshot.
+    gate = getattr(result, "gate_b_code", None)
+    fail_codes = {
+        (f.code.value if hasattr(f.code, "value") else str(f.code)) for f in result.failures
+    }
+    assert gate == "TARGET_DRIVE_CHANGED" or "TARGET_DRIVE_CHANGED" in fail_codes, (
+        f"expected TARGET_DRIVE_CHANGED pin; gate={gate!r} failures={fail_codes}")
+
+
+def test_reconcile_to_gate_b_fails_closed_when_drive_becomes_excluded():
+    """Eligibility flip to excluded after capture must also fail closed (no new placement tasks)."""
+    con = _mem()
+    dcols = {r[1] for r in con.execute("PRAGMA table_info(drives)").fetchall()}
+    if not {"lifecycle", "eligibility"} <= dcols:
+        raise AssertionError("v4 columns missing (expected Gate-1 red)")
+    result = _gate_b_post_capture_state_change(con, column="eligibility", value="excluded")
+    assert result.feasible is False, (
+        f"excluded post-reconcile must be non-feasible; gate={getattr(result, 'gate_b_code', None)}")
+    assert result.tasks == (), "must not place onto a drive that lost eligibility after capture"
     gate = getattr(result, "gate_b_code", None)
     fail_codes = {
         (f.code.value if hasattr(f.code, "value") else str(f.code)) for f in result.failures

--- a/tests/test_pr04_admission_copied_catalog.py
+++ b/tests/test_pr04_admission_copied_catalog.py
@@ -67,7 +67,7 @@ def _build_source(tmp_path):
         db.STATE_DIR = tmp_path / "state"
         con = db.connect()
         try:
-            assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture must be a v3 catalog"
+            assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, "fixture must be at current schema version"
             con.execute("INSERT INTO plans(plan_id,name,is_active) VALUES('ark','Ark',1)")
             con.execute("INSERT INTO drives(drive_label,capacity_bytes,free_bytes) "
                         "VALUES('drive-00',1000000,500000)")

--- a/tests/test_pr04_admission_transport.py
+++ b/tests/test_pr04_admission_transport.py
@@ -61,7 +61,7 @@ def _catalog(tmp_path):
     db.DB_PATH = tmp_path / "catalog.sqlite"
     db.STATE_DIR = tmp_path / "state"
     con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture must be a v3 catalog"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, "fixture must be at current schema version"
     try:
         yield con
     finally:

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -96,7 +96,7 @@ def _catalog(tmp_path):
     db.DB_PATH = tmp_path / "catalog.sqlite"
     db.STATE_DIR = tmp_path / "state"
     con = db.connect()
-    assert con.execute("PRAGMA user_version").fetchone()[0] == 3, "fixture must be a v3 catalog"
+    assert con.execute("PRAGMA user_version").fetchone()[0] == db._SCHEMA_VERSION, "fixture must be at current schema version"
     try:
         yield con
     finally:


### PR DESCRIPTION
## Summary

PR-07 / issue **#37** — durable drive **lifecycle** × **eligibility** schema and planner/bootstrap gating through Gate 2 production (Gate 1 accepted; findings **1–15** closed).

**Base:** `dd30c571b6440fd4e6113c6721a392a20c2aa4e7` on `fix/placement-capacity-hardening`  
**Exact tip (Gate 2 accepted):** `d5ce4c3b07b64938234b64e84e7b5a1258bfa166`  
**Phase branch:** `fix/placement-capacity-pr07-lifecycle-eligibility`

### Product contract (accepted matrix)

| Lifecycle | Eligibility | New placement | Verified copy satisfies | Bootstrap adds missing |
|---|---|---|---|---|
| active | enabled | yes | yes | yes |
| active | excluded | no | yes | no |
| lost | * | no | no | no |
| retired | * | no | no | no |

Presence (mounted/offline) is not stored as lifecycle. Fresh/partial **writes** remain placeable-only (`active+enabled`). **Accepted completion** = canonical active satisfaction tier ∪ authorized placement tier (finding 15) so a completed plain home fallback is recognized on the next reconcile.

### Production scope (Gate 2)

1. **Schema + v3→v4 migration** (`schema.sql`, `db.py`) — `drives.lifecycle` / `drives.eligibility` NOT NULL with safe defaults; backup-first transactional migration; stepwise version stamps; v4 cols excluded from v0 integrity rebuild.
2. **Planner capture / placement / satisfaction / source / Gate-B** (`candidates.py`, `reconcile.py`, `capacity.py`) — DriveFact axes; placeable-only targets; accepted-complete pool for satisfaction, wrong-tier, and replica `SourceIdentity`; multi-target lifecycle/eligibility race fail-closed (`TARGET_DRIVE_CHANGED`); state-only placeability from one `_drive_facts()` snapshot.
3. **Bootstrap / capacity / compatibility** (`plan.py`, `librarian.py`) — `plan.bootstrap` inserts only missing active+enabled; `plan.capacity` sums placeable members only; `placed_copies` counts complete copies on `lifecycle='active'` only (excluded may count; lost/retired do not).

Collateral: pre-v4 fixture version pins retargeted to `db._SCHEMA_VERSION`.

### Explicit non-goals (this PR)

- Lifecycle **operations** (exclude/include, lost/re-home/found, retire commands, drop-copy)
- New CLI/API/portal controls
- #39 proposal/session
- Transport / live cutover
- Handoff docs (operator-local, untracked)

## Commit map (high level)

| Range | Role |
|---|---|
| `c25b830`…`7276a4d` | Gate 1 tests-only (accepted) |
| `2d6db47` `f6fcce7` `0fc2fde` | Gate 2 production (schema → planner → bootstrap) |
| `bdbd80d` | Fixture version-pin alignment |
| `d095fbe`/`a2d68fa` | Amendment findings 12–14 |
| `888014b`/`d5ce4c3` | Amendment finding 15 |

## Test plan / evidence (local, Gate 2 accepted)

- [x] Migration suite **7/7**
- [x] Lifecycle matrix **21/21** (findings 1–15 closed)
- [x] Broader focused suite **99/99**
- [x] Ruff clean
- [x] Frozen 10k performance assertion pass
- [x] Diff checks clean
- [ ] Hosted required CI (this push)
- [ ] Greptile review (`@greptileai`)
- [ ] **Stop for explicit Gate-3 merge authorization** — do not merge until authorized

## Merge protocol

Merge-commit only into `fix/placement-capacity-hardening` when Gate 3 is separately authorized. Keep draft until then.