### PR TITLE
Prepare v0.3.0 release docs and attended Fill handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) wh
 
 ## 0.3.0 - 2026-08-30
 
+ModelArk 0.3.0 is the first schema-v7 public-alpha release. It adds substantial backend disk-safety
+and operator-workflow protection: when an issue occurs, the system is designed to stop with typed
+evidence, preserve completed work, and direct the operator toward a documented retry, migration,
+recovery, or rollback path rather than guessing. See the [v0.3.0 release notes](docs/releases/v0.3.0.md)
+for the brief operator-facing summary.
+
 ### Added
 
 - The Fill portal now authors one immutable placement proposal, presents every exact assignment for

--- a/README.md
+++ b/README.md
@@ -6,136 +6,118 @@
   <a href="pyproject.toml"><img alt="Python 3.10–3.12" src="https://img.shields.io/badge/python-3.10%E2%80%933.12-3776AB?logo=python&amp;logoColor=white"></a>
   <a href="docs/deployment.md"><img alt="Linux" src="https://img.shields.io/badge/platform-Linux-FCC624?logo=linux&amp;logoColor=black"></a>
   <a href="LICENSE"><img alt="Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
-  <a href="https://buymeacoffee.com/auspexlabs?new=1"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy_Me_a_Coffee-support-AuspexLabs-FFDD00?logo=buymeacoffee&amp;logoColor=black"></a>
-  <a href="https://www.greptile.com/?utm_source=oss_badge&amp;utm_medium=readme&amp;utm_campaign=greptile_for_open_source"><img alt="Greptile: The War on Bugs" src="https://www.greptile.com/badge.svg"></a>
 </p>
 
 > **ModelArk 0.3.0 is a public alpha.** It is usable today as an operator-attended archive and
-> disaster-recovery system for open model artifacts. Interfaces can still change before 1.0, and
-> consequential storage work remains explicit and reviewable.
+> disaster-recovery system for open model artifacts. Storage work remains explicit and reviewable,
+> and interfaces can still change before 1.0.
 
-ModelArk helps you **store now, prove what you have, and recover later**. It catalogs open model
-artifacts broadly, archives a curated set across offline or attached git-annex storage, records
-distinct evidence about those copies, and restores verified Hugging Face-compatible trees when you
-need them.
+ModelArk helps you **preserve selected model artifacts, prove what you have, and recover a verified
+working tree later**. It catalogs broadly, archives a curated set across offline or attached drives,
+keeps distinct evidence about every copy, and restores Hugging Face-compatible trees only after the
+complete result verifies.
 
-It does not turn a catalog row into a claim that a model is loadable, or a stale location record into
-a claim that a disk is healthy. That evidence boundary is the point of the project.
-
-## What it does
-
-- Seeds an offline catalog of roughly 4,100 classified models, or discovers current metadata from
-  the Hugging Face Hub.
-- Curates explicit plans and shows the exact placement proposal before an operator approves it.
-- Archives supported artifacts across a finite drive fleet with capacity admission, resumable work,
-  content hashes, and lossless compression where it is safe and useful.
-- Tracks physical locations through git-annex while keeping catalog, remote-header, ingestion,
-  copy-location, and physical-verification evidence distinct.
-- Reconciles attached drives against stable filesystem and annex identity without silently adopting
-  unrelated files.
-- Restores into a hidden staging tree, verifies original-byte hashes, and publishes the recovered
-  model only after the complete result passes.
-
-The normal lifecycle is:
+It is not an inference runtime and it does not turn a catalog row into a claim that a model is
+loadable. A stale location record is not presented as proof that a disk is healthy. Those evidence
+boundaries are the product.
 
 ```text
 catalog → curate → plan → review → approve → fill → verify → restore
 ```
 
-Approval and execution are separate. Approving a placement never starts Fill.
-
-## A storage primitive, not only an archive app
-
-Model weights are the first demanding workload, but the durable core is more general: artifact
-identity, manifests, placement, copy evidence, resumable movement, and verified materialization.
-That makes ModelArk a storage primitive for later local-model work rather than another cache tied to
-one inference engine.
-
-The same boundary can support future peer-to-peer work: exchange a sealed artifact set, preserve its
-evidence, and materialize a verified destination without pretending transport alone proves
-usability. **Usable Slice**, local delivery adapters, and P2P transport are future work, not shipped
-0.3.0 features.
+Approval and execution are separate. Approving an exact placement never starts Fill.
 
 ## Start here
 
-Detailed commands live in focused guides so this page can stay readable:
-
-- [Fresh install and first archive](docs/getting-started.md)
-- [Operating ModelArk: plans, drives, Fill, verification, and restore](docs/operations.md)
-- [Upgrade from 0.2.0 or another pre-v7 catalog](docs/upgrading.md)
-- [Supervised Linux deployment and rollback](docs/deployment.md)
-- [Stopped side-by-side provenance migration](docs/provenance-live-cutover.md)
-
-ModelArk runs locally and the portal binds to `http://127.0.0.1:8077`. There is deliberately no
-remote-listen mode until authentication exists.
-
-## The evidence contract
-
-ModelArk keeps several statements separate because they answer different questions:
-
-| Evidence | What it means |
+| I want to… | Use this guide |
 |---|---|
-| Catalog metadata | The repository and declared artifacts are known. |
-| Remote-header verification | The declared safetensors layout or basic GGUF header structure was checked without downloading all tensor bytes. |
-| Ingestion evidence | Downloaded original bytes matched the available digest and any compressed representation passed a round-trip canary. |
-| Copy/location evidence | git-annex records that a particular annex remote should hold the content. |
+| Install ModelArk on a new Linux host and create the first archive | [Fresh install and first archive](docs/getting-started.md) |
+| Operate plans, drives, Fill, verification, and restore | [Operating ModelArk](docs/operations.md) |
+| Upgrade a 0.2.0 or other pre-v7 catalog | [Upgrading ModelArk](docs/upgrading.md) |
+| Install or update the supervised user service | [Deploying ModelArk](docs/deployment.md) |
+| Perform the stopped side-by-side provenance migration | [Live cutover procedure](docs/provenance-live-cutover.md) |
+
+The portal is local-only at `http://127.0.0.1:8077`. ModelArk deliberately has no remote-listen mode
+until authentication exists.
+
+## What ModelArk protects
+
+- A broad metadata catalog and an explicitly curated archive plan.
+- Supported model artifacts placed across a finite git-annex drive fleet.
+- Original and stored-byte hashes, copy locations, and physical-verification results without
+  collapsing them into one vague “available” state.
+- Verified restores published only after the requested tree is complete.
+
+## Evidence, not assumptions
+
+| Evidence | What it actually means |
+|---|---|
+| Catalog metadata | The repository and its declared artifacts are known. |
+| Remote-header verification | The declared safetensors layout or basic GGUF structure was checked without downloading every tensor byte. |
+| Ingestion evidence | Downloaded original bytes matched available digests; compressed representations also passed a round-trip canary. |
+| Copy/location evidence | git-annex records that a specific annex remote should hold the content. |
 | Physical verification | A mounted copy was read and verified again. |
-| Verified restore | The complete requested tree was reconstructed and passed its recorded original-byte hashes before publication. |
+| Verified restore | The full requested tree was reconstructed and passed its recorded original-byte hashes before publication. |
 
 See [capacity evidence](docs/capacity-evidence.md) and the [Fill pipeline](docs/fill_pipeline.md) for
 the detailed contracts.
 
-## Safety by construction
+## Safety and recovery
 
-- **No in-place catalog upgrades.** ModelArk 0.3.0 refuses pre-v7 catalogs and directs the operator
-  through a stopped, backup-first, side-by-side migration.
+- **No in-place legacy upgrade.** Pre-v7 catalogs are migrated through a stopped, backup-first,
+  side-by-side procedure.
+- **No inferred disk identity.** Filesystem and annex identity—not an enclosure label—authorize a
+  registered drive.
+- **No silent under-replication.** Missing capacity, identity, or provenance evidence remains a
+  typed blocker.
+- **No automatic approval or Fill.** The operator reviews one immutable proposal, approves its exact
+  placement, and starts execution separately.
 - **No canary, no drop.** A compressed artifact cannot replace its original until decompression
   reproduces the original digest.
-- **No silent under-replication.** Required copies remain explicit requirements; missing capacity or
-  identity evidence blocks work.
-- **No inferred drive identity.** A stable filesystem UUID plus annex UUID is authoritative;
-  enclosure serials are supporting observations.
-- **No automatic approval or Fill.** The operator reviews one immutable proposal, approves it with
-  its exact phrase, and starts work separately.
 - **No automatic deletion of extras.** Reconciliation reports unclaimed content but does not adopt
   or remove it.
 
-## 0.3.0 status
+## What changed in v0.3.0
 
-Version 0.3.0 is the first schema-v7 release line. It adds the backup-first provenance migration,
-identity-bound capacity evidence, canonical placement and approval, execution-session fencing,
-drive lifecycle handling, and the operator-facing exact proposal review.
+There are **a lot of backend disk-safety and workflow additions** in this release. If you run into an
+issue, ModelArk is designed to stop with evidence, preserve completed work, and give you a documented
+recovery, retry, migration, or rollback path instead of guessing.
 
-The release path is covered by the full test suite, installed-wheel migration smoke, packaging,
-hostile-web checks, and standalone browser acceptance. Alpha still means operator attention matters:
-large downloads can be expensive to retry, some USB bridges report weak SMART identity, functional
-model loading is not a verification tier yet, and supported artifact policy remains intentionally
-conservative.
+In brief, v0.3.0 adds:
 
-The [changelog](CHANGELOG.md), [roadmap](docs/roadmap.md), and append-only
-[decision ledger](docs/decision_log.md) carry the detailed status and rationale.
+- backup-first schema-v7 migration with rehearsal, no-clobber publication, and retained rollback;
+- identity-bound capacity admission, drive lifecycle handling, and safer reconciliation;
+- canonical placement planning with exact proposal review and explicit approval;
+- resumable, fenced Fill sessions with attended drive-loading workflow;
+- stronger provenance, hash repair, physical verification, and staged restore contracts; and
+- focused install, operations, deployment, upgrade, migration, and recovery guides.
 
-## Project map
+Read the [v0.3.0 release notes](docs/releases/v0.3.0.md) or the
+[changelog](CHANGELOG.md) for the complete release record.
 
-```text
-modelark.core        catalog and database primitives
-modelark             discovery, planning, archive, verification, and restore
-git-annex map        private byte/location authority
-drive fleet          the actual offline, attached, or network-backed content
-```
+## Becoming a storage primitive
 
-Useful deeper references:
+Model weights are the first demanding workload, but the durable core is more general: artifact
+identity, manifests, placement, copy evidence, resumable movement, and verified materialization.
+ModelArk is becoming an evidence-preserving storage primitive for later local-model tools rather
+than another cache tied to one inference engine.
 
-- [Architecture and placement hardening](docs/plans/placement-capacity-hardening.md)
-- [Migration acceptance record](docs/rfcs/001-migrated-runtime-acceptance.md)
-- [First-class placement and approval design](docs/rfcs/002-first-class-placement-approval.md)
-- [Deferred artifact-format support](docs/deferred-artifact-support.md)
-- [Security policy](SECURITY.md)
+That same boundary supports two future directions:
 
-## Contributing and support
+- **Usable Slice:** ask for a named subset of the existing catalog, then materialize and verify it
+  for a specific consumer or machine.
+- **Peer-to-peer transport:** exchange sealed artifact sets while preserving evidence instead of
+  treating successful transport as proof of usability.
 
-Bug reports, migration feedback, documentation fixes, curation ideas, and code contributions are
-welcome. See [Contributing](contributing/contributions.md) before opening a change.
+Usable Slice, local delivery adapters, scratch transfer, and P2P transport are future work—not
+shipped v0.3.0 features.
+
+## Project and support
+
+The [roadmap](docs/roadmap.md), [architecture plan](docs/plans/placement-capacity-hardening.md), and
+append-only [decision ledger](docs/decision_log.md) carry deeper status and rationale. See
+[Contributing](contributing/contributions.md) before opening a change, and report vulnerabilities
+through the [security policy](SECURITY.md).
 
 If ModelArk helps preserve the models you care about, you can
 [support AuspexLabs](https://buymeacoffee.com/auspexlabs?new=1). Testing and thoughtful failure

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2066,7 +2066,7 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 ### DEC-085: Bound Greptile review loops and reference every iteration precisely
 - `id`: DEC-085
 - `date`: 2026-08-30
-- `status`: accepted
+- `status`: superseded by DEC-086
 - `triggered_by`: BOT-003 and the operator's explicit Greptile review-loop policy.
 - `decision`: Use the following project review protocol for Greptile:
   1. Start iteration 1 by commenting directly on the PR with `@greptileai review`, request review of the whole current PR, and name the exact HEAD under review.
@@ -2079,3 +2079,34 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `docs_updated`: docs/decision_log.md
 - `related`: BOT-003, DEC-061, PR-055, PR-057
 - `scope_boundary`: Review orchestration and documentation only. This policy never authorizes automatic merge, tag, release publication, deployment, proposal mutation, Start Fill, or archive-byte work.
+
+### BOT-004: A clean Greptile acceptance was incorrectly followed by a mandatory iteration
+- `id`: BOT-004
+- `date`: 2026-08-30
+- `status`: logged
+- `triggered_by`: Human PR #57 note: “iters are NOT mandatory. Iters are only needed on non-accept states.”
+- `claim`: DEC-085 treated every post-review ledger change as requiring another numbered Greptile iteration, so the agent requested iteration 2 even though iteration 1 already had the full accept state: exact current HEAD, `5/5`, no findings, successful check, and a thumbs-up completion reaction.
+- `correction`: Stop a Greptile loop immediately on a current-HEAD accept state. Additional iterations are remediation cycles only for non-accept states; they are not a quota to consume. Human-authored PR notes are part of review state and must be read and observed whenever encountered, before further polling, changes, or bot triggers.
+- `verified`: The human note was posted directly on PR #57 after iteration 2 was unnecessarily requested. Greptile iteration 2 also completed at `f0fbbb2d60c93f1f65b92054e3531ef0bfecd1d5` with `5/5`, no blocking failure, a successful check, and a thumbs-up reaction, confirming there is no basis for iteration 3.
+- `lesson`: A maximum is a ceiling, not a target. Evaluate accept/non-accept state before incrementing an iteration, and always include human comments in the state scan.
+- `docs_updated`: docs/decision_log.md
+- `related`: BOT-003, DEC-085, DEC-086, PR-057
+
+### DEC-086: Iterate Greptile only from a non-accept review state
+- `id`: DEC-086
+- `date`: 2026-08-30
+- `status`: accepted
+- `supersedes`: DEC-085
+- `triggered_by`: BOT-004 and the operator's human PR #57 note correcting mandatory-iteration behavior.
+- `decision`: Use the following bounded Greptile protocol:
+  1. Start iteration 1 by commenting directly on the PR with `@greptileai review`, request the whole current PR, and name the exact HEAD.
+  2. Poll at five-minute intervals. On every poll, read human-authored PR notes as well as the Greptile summary, score, inline findings, check state, last-reviewed commit, and emoji reactions. Observe human notes before taking another automated action; if a note conflicts with an earlier workflow assumption, the human note corrects it unless a higher safety boundary requires explicit escalation.
+  3. Define **accept** as Greptile completing against the current HEAD with `5/5`, no unresolved finding or blocking failure, a successful review check, and the thumbs-up completion reaction. On accept, stop the Greptile loop and return control to the operator. Do not request another iteration merely to reach the allowed maximum.
+  4. Define **non-accept** as an incomplete or stale-HEAD review, a score below `5/5`, a missing completion reaction, or any finding/nit requiring disposition. Follow findings, including nits, unless they conflict with explicit operator or safety authority; after a change, push one reviewable HEAD and request the next numbered iteration with exact prior finding, new HEAD, file/location, and diff range.
+  5. Permit at most three total review iterations. If the third iteration is still non-accept, stop and wait for the operator.
+  6. Independently, if three consecutive five-minute polls show no review-state change, stop polling and wait for the operator.
+- `rationale`: Greptile iterations exist to verify remediation, not to create ritual churn after acceptance. A precise accept predicate prevents unnecessary review-credit use, while the iteration and unchanged-poll ceilings retain the human stop. Reading human notes as first-class state prevents automation from continuing past an operator correction.
+- `impact`: PR #57's reviewed content is accepted by Greptile at iteration 2 with exact HEAD `f0fbbb2`, `5/5`, no findings, green review check, and thumbs up. This superseding policy record is the operator-directed response to the human note and is itself under direct human review; it does not manufacture iteration 3. Future handoffs report the current state as `accepted at iteration N/3` or `non-accept at iteration N/3`, plus the unchanged-poll counter only while polling is active.
+- `docs_updated`: docs/decision_log.md
+- `related`: BOT-003, BOT-004, DEC-061, DEC-085, PR-055, PR-057
+- `scope_boundary`: Review orchestration and documentation only. Accepting a Greptile review never authorizes merge, tag, release publication, deployment, proposal mutation, Start Fill, or archive-byte work.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2036,3 +2036,17 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `docs_updated`: docs/decision_log.md
 - `related`: DEC-049, DEC-067, DEC-076, DEC-081, DEC-082, DEF-041, RFC-002
 - `scope_boundary`: Deferral record only. No planner policy, drive identity/role, capacity evidence, assignment, planner revision, stored proposal, approval, Fill state, or archive byte changes here.
+
+### INC-053: Fill drive cards hid lost and excluded lifecycle state
+- `id`: INC-053
+- `date`: 2026-08-30
+- `status`: open; remediation prepared on follow-up branch, not deployed
+- `triggered_by`: Live operator review immediately after approving the revision-9 proposal
+- `symptom`: The Fill chart continued to show lost/excluded `drive-02` after approval with the same dashed, faded empty-card treatment as active/enabled but unused `drive-07`. It displayed no unavailable icon, lifecycle label, or struck-through identity, so retaining historical plan membership could be misread as current execution eligibility.
+- `root_cause`: `librarian.plan_view` already publishes exact per-drive `lifecycle` and `eligibility`, but `modelark/web/static/fill.js::driveCard` consumed only tier, capacity, archived bytes, and planned work. Its generic `empty` class collapsed “lost and excluded” into “active but currently unused.”
+- `blast_radius`: Operator interpretation of the Fill chart only. Canonical planning, proposal serialization, approval revalidation, and execution projection already exclude the lost drive; the approved proposal gives Drive #2 zero requirements, so no write authority or archive placement was incorrect.
+- `why_not_caught_earlier`: Projection tests asserted lifecycle fields in the backend payload, while portal E2E exercised Fill with active drives and exercised loss only on the separate Drives screen. No browser contract required a lost plan-member card to remain visible with an explicit unavailable state.
+- `planned_remediation`: Preserve the card for durable identity/history, render a red `LOST · EXCLUDED` status plus struck-through label from backend-authored fields, keep active-but-unused cards visually distinct, add browser coverage, and document the difference and attended Start boundary. Do not filter the drive out or teach the browser an alternate eligibility policy.
+- `docs_updated`: docs/decision_log.md, docs/operations.md, docs/provenance-migrate-copy-runbook.md, modelark/web/static/fill.js, tests/test_e2e_portal.py
+- `related`: DEC-049, DEC-067, DEC-069, DEC-082, DEF-042
+- `scope_boundary`: Fill-chart lifecycle presentation, regression coverage, and operator documentation only. No drive lifecycle/eligibility, plan membership, assignment, proposal, planner revision, Fill session, or archive byte changes.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2023,3 +2023,16 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `docs_updated`: docs/decision_log.md, modelark/register.py, tests/test_def029_gate2_contracts.py
 - `related`: DEC-006, DEC-076, DEC-078, PR-055
 - `scope_boundary`: Git authorship for ModelArk-managed map and drive metadata only. No global Git configuration, archive identity, registration receipt, drive/catalog record, proposal, Fill, or archive byte is mutated by this remediation.
+
+### DEF-042: Defer operator-directed replacement-drive advancement
+- `id`: DEF-042
+- `date`: 2026-08-30
+- `status`: active
+- `triggered_by`: Human review of the immutable revision-9 proposal showed `drive-07` active, enabled, primary, and capacity-qualified but assigned zero requirements, while its intended predecessor `drive-02` is lost/excluded. The operator observed that the replacement joined the back of the planner's line even though it could, and likely should, advance into Drive #2's former role.
+- `decision`: Defer a bound operator action that names a replacement/successor relationship and requests a partial replan which preferentially advances that drive into the predecessor's placement role while preserving unaffected assignments where feasible. Proceed with review of the unchanged revision-9 proposal; do not silently infer substitution from registration, capacity, label order, or hardware similarity, and do not mutate the current proposal or start Fill as part of this deferral.
+- `rationale`: Replacement affinity is operator intent, not a fact ModelArk can safely derive from an empty drive or a lost identity. It must become explicit versioned planner input, participate in deterministic feasibility and identity/capacity fences, explain any assignment changes, bump the planner revision, and produce a fresh canonical proposal for separate approval. Adding it inside the current approval dialog would invalidate the exact artifact already reviewed and reopen the completed migration/release gate. The present plan remains feasible and safely excludes Drive #2, so deferral costs utilization preference rather than correctness.
+- `impact`: Until resolved, an admitted replacement may remain unused when the canonical planner can satisfy the plan without it. Operators cannot say “advance Drive #7 into Drive #2's slot” or request a bounded successor replan; changing placement requires a later explicit planning workflow and fresh approval, never direct database edits or an execution-time override.
+- `revisit_when`: Revisit after the revision-9 approval/recovery cycle, and before the first plan where the operator wants Drive #7 populated as Drive #2's successor or replacement-drive affinity is needed for another lost/retired identity—whichever comes first.
+- `docs_updated`: docs/decision_log.md
+- `related`: DEC-049, DEC-067, DEC-076, DEC-081, DEC-082, DEF-041, RFC-002
+- `scope_boundary`: Deferral record only. No planner policy, drive identity/role, capacity evidence, assignment, planner revision, stored proposal, approval, Fill state, or archive byte changes here.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2050,3 +2050,32 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `docs_updated`: docs/decision_log.md, docs/operations.md, docs/provenance-migrate-copy-runbook.md, modelark/web/static/fill.js, tests/test_e2e_portal.py
 - `related`: DEC-049, DEC-067, DEC-069, DEC-082, DEF-042
 - `scope_boundary`: Fill-chart lifecycle presentation, regression coverage, and operator documentation only. No drive lifecycle/eligibility, plan membership, assignment, proposal, planner revision, Fill session, or archive byte changes.
+
+### BOT-003: Greptile was tagged but its completed review was not polled
+- `id`: BOT-003
+- `date`: 2026-08-30
+- `status`: logged
+- `triggered_by`: Operator correction after the agent posted the PR #57 Greptile trigger and reported only that no response had arrived yet.
+- `claim`: Posting `@greptileai review` and checking immediately afterward was treated as sufficient handoff, so the agent stopped polling and missed the completed review state.
+- `correction`: A Greptile trigger starts a bounded review loop; it does not complete one. Poll on a five-minute interval, inspect summary, inline comments, check state, exact reviewed HEAD, and reaction groups, and recognize the thumbs-up reaction as the completion signal. Bound both the review iterations and unchanged polls, then return control to the operator.
+- `verified`: PR #57 iteration 1 completed against exact HEAD `5f2dcae3240cf590f382cca6de8130609b3207f4` with Greptile confidence `5/5`, no correctness or safety defect, a successful Greptile check, and a `THUMBS_UP` reaction on the trigger comment. Python 3.10, Python 3.12, and E2E were also green. The operator, not the agent's polling, surfaced that completed state.
+- `lesson`: Never infer review state from elapsed time or the absence of an immediate reply. Persist and report explicit iteration/poll counters, exact HEADs, review findings, and the completion emoji.
+- `docs_updated`: docs/decision_log.md
+- `related`: DEC-061, DEC-085, PR-057
+
+### DEC-085: Bound Greptile review loops and reference every iteration precisely
+- `id`: DEC-085
+- `date`: 2026-08-30
+- `status`: accepted
+- `triggered_by`: BOT-003 and the operator's explicit Greptile review-loop policy.
+- `decision`: Use the following project review protocol for Greptile:
+  1. Start iteration 1 by commenting directly on the PR with `@greptileai review`, request review of the whole current PR, and name the exact HEAD under review.
+  2. Poll at five-minute intervals. Read the Greptile summary, score, inline comments, check result, last-reviewed commit, and emoji reactions. A thumbs-up reaction signals completion, but never substitutes for reading and dispositioning the actual findings.
+  3. Follow Greptile findings, including nits, unless they conflict with an explicit operator instruction or a higher safety/correctness boundary; surface such a conflict instead of silently ignoring either authority.
+  4. After changes, push one reviewable HEAD and start the next numbered iteration with the exact new HEAD, prior finding, changed file/location, and relevant diff range so Greptile reviews the remediation rather than drifting across unrelated history.
+  5. Stop and return control to the operator after at most three Greptile review iterations, whether findings remain or not. Independently, if three consecutive five-minute polls show no review-state change, stop polling and wait for the operator.
+- `rationale`: Greptile is useful and sometimes intentionally exacting, but unbounded bot loops waste review credits and can drift from operator intent. Explicit commit/location references make each remediation auditable; bounded iteration and unchanged-poll ceilings guarantee a human gate. Emoji completion must be observed rather than assumed, while DEC-061's partial-review rule still prevents a badge or reaction from being mistaken for disposition when a requested question was not answered.
+- `impact`: PR review handoffs now carry two counters (`iteration N/3`, `unchanged poll N/3`), exact reviewed commits, focused remediation references, and an explicit operator stop. PR #57's substantive release/UI review completed at iteration `1/3` with zero findings; the policy-only ledger append that follows that reviewed HEAD is presented as iteration `2/3` with its exact location rather than being left outside the review record.
+- `docs_updated`: docs/decision_log.md
+- `related`: BOT-003, DEC-061, PR-055, PR-057
+- `scope_boundary`: Review orchestration and documentation only. This policy never authorizes automatic merge, tag, release publication, deployment, proposal mutation, Start Fill, or archive-byte work.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -73,6 +73,15 @@ Changing selection, plan membership, capacity policy, or relevant execution conf
 an approval stale. Return to **Review exact placement** and approve the newly authored proposal; do
 not reuse an earlier phrase or edit planner tables directly.
 
+The Fill chart retains every drive identity in the active plan so loss history is not erased. A
+`lost`, `retired`, or `excluded` drive remains visible with an unavailable marker and contributes no
+executable capacity or target work. An ordinary empty card instead means the drive is still eligible
+but the current proposal does not need it.
+
+Start Fill only while an operator can respond to its attended drive-loading prompts. If nobody is
+physically available, leave the current approval in place and Fill idle; approval alone moves no
+bytes, and a service started without explicit resume does not begin the session.
+
 Do not run two Fill controllers against one runtime. Stop a portal-owned worker before using any CLI
 execution surface. Completed files are durable, but the in-flight file may need another download.
 

--- a/docs/provenance-migrate-copy-runbook.md
+++ b/docs/provenance-migrate-copy-runbook.md
@@ -1077,3 +1077,26 @@ and it is already selected; the other 23 remain a later catalog/Usable Slice wav
 DEF-CATALOG-005. They are already resident on the Sparks and their weights/recipes are changing
 daily, so they do not delay revision-9 review. Any later Spark selection change must advance the
 planner revision and invalidate the old approval; revision 9 never covers those additions.
+
+## Executed live revision-9 proposal approval; Fill deliberately idle — 2026-08-30
+
+The operator opened **Review exact placement** in candidate `a574d6b` and personally reviewed the
+complete 500-row docket. Stored proposal `8f41c6b6-211a-4f90-9d5f-54ffbc75da2a` is based on revision
+`9`, uses `guaranteed` capacity and `state_truncated` derivation, reports `FEASIBLE`, and has canonical
+seal `471b2ec32bda25a1eefb0b1773f1112e54d96d0a3b637854ffe1787bb6b91769`. Its totals are 396
+repositories, 500 requirements, 183 baseline-satisfied requirements, 317 executable requirements,
+20,014,224,990,197 guaranteed bytes, and 18,975,902,645,626 expected bytes.
+
+The operator entered the backend-issued exact phrase and selected **Approve exact placement**. The
+live status is `approved_current`; semantic input and execution configuration both match. Approval
+advanced the planner revision to `10` atomically while retaining the immutable proposal's
+`based_on_revision=9`, as designed for `adopt_current`. Fill remains `idle`, no execution session was
+started, and the service remains without automatic resume. **Start Fill** is deliberately postponed
+until the operator is physically present to answer drive-loading prompts.
+
+The attended review also exposed two follow-ups without invalidating approval. DEF-042 records the
+future operator-directed ability to advance replacement Drive #7 into lost Drive #2's former role.
+INC-053 records that the Fill chart retained Drive #2, correctly, but rendered no visible
+`lost/excluded` distinction even though the backend already supplied both fields. The UI remediation
+is prepared separately and changes presentation only; the approved proposal assigns Drive #2 zero
+requirements and receives no execution authority from the chart.

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,61 @@
+# ModelArk v0.3.0 — Public Alpha
+
+ModelArk v0.3.0 is the first schema-v7 public-alpha release. It turns the project into an
+operator-attended disaster-recovery system for open model artifacts: catalog broadly, archive a
+curated set onto storage you control, preserve exact evidence about those copies, and restore a
+verified working tree later.
+
+There are **a lot of backend disk-safety and workflow additions** in this release. If you run into
+an issue, ModelArk is designed to stop with evidence, preserve completed work, and give you a
+documented recovery, retry, migration, or rollback path instead of guessing.
+
+## Highlights
+
+- **Backup-first migration.** Existing pre-v7 catalogs move through a stopped, rehearsed,
+  side-by-side schema-v7 publication with no-clobber checks and retained rollback evidence.
+- **Safer disk authority.** Filesystem and annex identity, lifecycle state, fresh capacity evidence,
+  and drive fences determine whether a disk can receive work.
+- **One exact placement workflow.** CLI, Library, preview, proposal, approval, and execution share
+  one canonical plan. The operator reviews every assignment before approval.
+- **Approval never starts Fill.** Starting multi-terabyte work remains a separate attended action,
+  with explicit drive-loading prompts and resumable session state.
+- **More useful recovery evidence.** Reconciliation, original-byte provenance, hash repair,
+  physical verification, and staged restore paths now fail closed without silently adopting or
+  deleting unrelated content.
+- **Focused operator guides.** Fresh install, everyday use, deployment, upgrade, stopped migration,
+  and rollback procedures live in separate linked documents.
+
+## If something goes wrong
+
+ModelArk favors a typed refusal or retained checkpoint over an optimistic guess:
+
+- a new binary refuses an older catalog instead of migrating it in place;
+- stale identity, capacity, proposal, or execution evidence blocks work;
+- completed Fill files remain durable when a session stops;
+- failed migration publication never overwrites an existing destination;
+- reconciliation reports missing, debris, and extra content without deleting it; and
+- restore publishes only after the requested tree passes its recorded original-byte hashes.
+
+The system is still a public alpha. Large downloads can be expensive to retry, some storage bridges
+expose weak health identity, supported artifact policy remains conservative, and functional model
+loading is not yet a verification tier.
+
+## Install or upgrade
+
+- [Fresh install and first archive](https://github.com/Auspex-Aerie/modelark/blob/v0.3.0/docs/getting-started.md)
+- [Operating ModelArk](https://github.com/Auspex-Aerie/modelark/blob/v0.3.0/docs/operations.md)
+- [Upgrade from 0.2.0 or another pre-v7 catalog](https://github.com/Auspex-Aerie/modelark/blob/v0.3.0/docs/upgrading.md)
+- [Stopped side-by-side migration](https://github.com/Auspex-Aerie/modelark/blob/v0.3.0/docs/provenance-live-cutover.md)
+- [Complete changelog](https://github.com/Auspex-Aerie/modelark/blob/v0.3.0/CHANGELOG.md)
+
+Do not start v0.3.0 against a pre-v7 data directory. Follow the upgrade guide and keep the old
+runtime plus the complete catalog/WAL/SHM bundle until the migrated system has passed its chosen
+recovery checkpoint.
+
+## What comes later
+
+Model weights are the first workload for a more general evidence-preserving storage primitive.
+**Usable Slice** will let another local-model tool request a named, verified subset of the existing
+catalog. Future P2P transport can move sealed artifact sets without treating transport as proof of
+usability. Usable Slice, scratch delivery, and P2P transport are direction—not shipped v0.3.0
+features.

--- a/modelark/web/static/fill.js
+++ b/modelark/web/static/fill.js
@@ -37,10 +37,14 @@
       .tierrow{display:flex;flex-wrap:wrap;gap:14px}
       .drivecard{flex:1 1 258px;max-width:340px;background:#fff;border:1px solid #d5dbe4;border-radius:6px;padding:13px 14px}
       .drivecard.empty{opacity:.55;border-style:dashed}
+      .drivecard.unavailable{opacity:1;border-color:#d9a5a1;background:#fff7f6}
+      .drivecard.unavailable .dclabel{color:#8f2d27;text-decoration:line-through;text-decoration-thickness:2px}
       .dchead{display:flex;justify-content:space-between;align-items:center;margin-bottom:9px}
       .dclabel{font:600 14px ui-monospace,Menlo,monospace}
+      .dcstatus{display:flex;align-items:center;justify-content:flex-end;gap:6px;flex-wrap:wrap}
       .dcbadge{font:600 10px/1 ui-monospace,monospace;letter-spacing:.06em;padding:3px 7px;border-radius:3px;color:#fff}
       .dcbadge.raid{background:#0f766e}.dcbadge.primary{background:#2c5f8f}.dcbadge.replica{background:#a8620a}
+      .dcstate{font:700 10px/1 ui-monospace,monospace;letter-spacing:.04em;padding:4px 7px;border-radius:3px;color:#fff;background:#a4342c}
       .dcbar{height:22px;background:#eef1f6;border-radius:4px;overflow:hidden;border:1px solid #e0e5ec}
       .dcbarfill{display:flex;height:100%}
       .seg{height:100%;min-width:1px;flex:0 0 auto}
@@ -153,10 +157,15 @@
     const segs = Object.entries(groups).sort((a, b) => b[1] - a[1]).map(([k, b]) =>
       `<div class="seg" style="width:${(100 * b / usable).toFixed(2)}%;background:${color(k)}" title="${esc(keyLabel(k))} (planned): ${esc(MA.gb(b))}"></div>`).join("");
     const badge = { raid: "RAID", primary: "PRIMARY", replica: "REPLICA" }[d.tier] || d.tier;
+    const lifecycle = d.lifecycle || "unknown";
+    const eligibility = d.eligibility || "unknown";
+    const unavailable = lifecycle !== "active" || eligibility !== "enabled";
+    const state = [lifecycle !== "active" ? lifecycle : "", eligibility !== "enabled" ? eligibility : ""]
+      .filter(Boolean).join(" · ").toUpperCase();
     const total = archived + (d.planned_bytes || 0);
     const totalPct = usable ? Math.min(100, Math.round(100 * total / usable)) : 0;
-    return `<div class="drivecard${(d.n_models || archived) ? "" : " empty"}" id="dc-${esc(d.label)}">
-      <div class="dchead"><span class="dclabel">${esc(d.label)}</span><span class="dcbadge ${esc(d.tier)}">${esc(badge)}</span></div>
+    return `<div class="drivecard${(d.n_models || archived) ? "" : " empty"}${unavailable ? " unavailable" : ""}" id="dc-${esc(d.label)}" data-lifecycle="${esc(lifecycle)}" data-eligibility="${esc(eligibility)}">
+      <div class="dchead"><span class="dclabel">${esc(d.label)}</span><span class="dcstatus"><span class="dcbadge ${esc(d.tier)}">${esc(badge)}</span>${unavailable ? `<span class="dcstate">⛔ ${esc(state)}</span>` : ""}</span></div>
       <div class="dcbar"><div class="dcbarfill">${segs}${archSeg}</div></div>
       <div class="dcfoot"><span>${totalPct}% · ${MA.gb(total)}/${MA.gb(usable)}</span><span>${d.n_models} planned</span></div>
       <div class="dcdone" id="done-${esc(d.label)}"${archived ? "" : " hidden"}>${archived ? doneRowHTML(archived, usable) : ""}</div>

--- a/tests/test_e2e_portal.py
+++ b/tests/test_e2e_portal.py
@@ -19,6 +19,7 @@ import time
 import urllib.request
 from pathlib import Path
 
+from modelark import plan
 from modelark.core import db
 
 PORT = 8099
@@ -82,6 +83,10 @@ def _seed(con) -> None:
         "VALUES('drive-replica','replica',0,1000000000,1000000000)"
     )
     con.execute(
+        "INSERT INTO drives(drive_label,role,raid_backed,capacity_bytes,free_bytes) "
+        "VALUES('drive-02','primary',0,4000000000000,0)"
+    )
+    con.execute(
         "INSERT INTO archived(repo_id,rfilename,stored_name,stored_relpath,drive_label,"
         "orig_bytes,stored_bytes,compressed,annex_key) VALUES("
         "'demo/small-llm','model.safetensors','model.safetensors','model.safetensors',"
@@ -107,6 +112,14 @@ def _seed(con) -> None:
                     "identity_proof,fence_proof,observed_at) "
                     "VALUES(?,1,1,?,?,?, 'dedicated_local','proof','fence','2026-07-15 00:00:00')",
                     (label, cap, cap, fp))
+
+    # Model the production history precisely: Drive 2 belonged to the Ark while placeable, then
+    # became lost/excluded. Startup bootstrap preserves that historical membership and must not
+    # silently make the unavailable drive disappear from the Fill projection.
+    plan.bootstrap(con)
+    con.execute(
+        "UPDATE drives SET lifecycle='lost',eligibility='excluded' WHERE drive_label='drive-02'"
+    )
 
 
 def _wait_port(port: int, timeout: int = 40) -> bool:
@@ -891,6 +904,14 @@ def _browser_flow() -> None:
             fill_note = pg.inner_text("#fillNote")
             assert "1 to place" in fill_note and "3 blocked" in fill_note, fill_note
             assert pg.locator("#fillStart").is_disabled()
+            lost = pg.locator("#dc-drive-02")
+            assert lost.count() == 1, "lost plan-member drive must remain visible"
+            assert "unavailable" in (lost.get_attribute("class") or "")
+            assert lost.get_attribute("data-lifecycle") == "lost"
+            assert lost.get_attribute("data-eligibility") == "excluded"
+            assert "LOST · EXCLUDED" in lost.inner_text()
+            assert "unavailable" not in (pg.locator("#dc-drive-00").get_attribute("class") or "")
+            print("  lost/excluded drive stayed visible with explicit unavailable status")
             print("  policy + capacity blockers rendered with disjoint totals; Start fill disabled")
 
             # ------------------------------------------------------------------
@@ -1125,9 +1146,11 @@ def main() -> None:
         assert db.DB_PATH.parent == data_dir and db.DB_PATH.is_file()
         print("  seeded models (giant, policy + capacity + hostile blockers) in an isolated catalog")
 
-        serve = Path(sys.executable).with_name("modelark")  # .venv-dev/bin/modelark
+        # Launch the exact checked-out source even when this test runs from a Git worktree whose
+        # shared development environment was installed editable from a different checkout.
+        serve = [sys.executable, "-m", "modelark"]
         proc = subprocess.Popen(
-            [str(serve), "--data-dir", str(data_dir), "--state-dir", str(state_dir),
+            [*serve, "--data-dir", str(data_dir), "--state-dir", str(state_dir),
              "serve", "--no-open", "--port", str(PORT)],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         try:


### PR DESCRIPTION
## Summary

- reshape README into an approachable operator front door with audience-based instruction links
- add release-ready v0.3.0 notes covering backend disk safety, workflow recovery, and future scope
- record DEF-042 for future operator-directed replacement-drive advancement and partial replan
- distinguish lost/excluded historical plan members from active but unused drives in Fill
- add browser coverage for the production Drive 2 lifecycle sequence
- record the live revision-9 approval and the deliberately idle, attended Start Fill boundary
- clarify the same operator boundary in the focused operations guide

The README now keeps product identity, evidence, safety, current-release context, and the future
storage-primitive teaser in one place while routing install, operation, upgrade, deployment, and
stopped migration procedures to focused linked guides. The v0.3.0 notes are ready to become the
GitHub release body after this PR is reviewed and merged and the resulting main commit is tagged.

## Validation

- `ruff check tests/test_e2e_portal.py`
- `node --check modelark/web/static/fill.js`
- `pytest -q tests/test_library_projection.py` — 5 passed
- exact-source standalone portal/browser acceptance — all passed
- `git diff --check`
- local Markdown link audit — passed
- linked local HTML README review — operator approved

## Hold boundary

This PR remains a draft during Greptile review. Do not merge it, create the `v0.3.0` tag, publish the
GitHub release, deploy it to the live service, or select **Start Fill** without the operator's next
explicit gate. The approved revision-9 proposal remains current and Fill remains idle; this branch
does not change proposal, execution, drive, or archive state.
