### PR TITLE
Stabilize the 10k-candidate performance gate

### DIFF
--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -397,7 +397,9 @@ def test_phase2_candidate_cross_product_stays_bounded():
         # #36a: the candidate cross-product (one shared-seam budget per requirement×eligible-target) is
         # built in reconcile_plan -> candidates(); placement wraps them without recomputation. Count the
         # per-file budget calls there: 1000 repos × 10 eligible primaries × 1 missing file = 10k, bounded.
-        with mock.patch.object(budgets, "file_budget", side_effect=counted):
+        # Keep the performance gate focused on planning. A Mock(side_effect=...) adds bookkeeping to
+        # every one of these 10k calls and makes the wall-clock bound depend on CI mock overhead.
+        with mock.patch.object(budgets, "file_budget", new=counted):
             graph = reconcile.reconcile_plan(con, "ark", compression_cfg=_cfg())
             result = capacity.plan_capacity(con, graph)
         elapsed = time.perf_counter() - started


### PR DESCRIPTION
## Summary

- replace the MagicMock side-effect trampoline with the test's direct counting wrapper
- keep the existing 10,000-candidate workload and two-second ceiling unchanged
- retain exact assertions for 10,000 budget calls and 1,000 feasible tasks

## Root cause

The timed region routed every budget call through MagicMock bookkeeping. On shared Python 3.10 runners, that instrumentation pushed the test just over its two-second contract: 2.017s and 2.042s on consecutive PRs, while unchanged reruns passed. Local A/B measurements reduced the five-run mean from about 0.405s to 0.269s without changing production code or weakening the gate.

## Validation

- targeted test in 10 fresh Python processes: 10/10 passed
- tests/test_capacity.py: 17 passed
- complete non-E2E suite: 956 passed, 1 skipped
- Ruff: passed
- git diff --check: passed