### PR TITLE
Release ModelArk 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) wh
 
 ## Unreleased
 
+## 0.3.2 - 2026-09-02
+
+ModelArk 0.3.2 adds an operator-directed successor proposal for replacing an unavailable drive while
+retaining schema v7. It is an application-only update: deployment, proposal approval, and Fill start
+remain separate actions.
+
 ### Added
 
 - A current approved placement can now create a bounded successor proposal for an unavailable drive
@@ -14,6 +20,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) wh
 
 - Metadata and planning commands no longer initialize ZipNN and Torch just to read compression
   constants, preventing third-party codec warnings from polluting otherwise successful CLI output.
+- Successor proposal status, draft creation, execution-configuration identity, and Fill projection
+  now fail closed when their approved baseline or replacement context is stale or unavailable.
 
 ## 0.3.1 - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <p align="center">
   <a href="https://github.com/Auspex-Aerie/modelark/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Auspex-Aerie/modelark/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="CHANGELOG.md#031---2026-09-02"><img alt="Release: v0.3.1 Public Alpha" src="https://img.shields.io/badge/release-v0.3.1%20Public%20Alpha-orange"></a>
+  <a href="CHANGELOG.md#032---2026-09-02"><img alt="Release: v0.3.2 Public Alpha" src="https://img.shields.io/badge/release-v0.3.2%20Public%20Alpha-orange"></a>
   <a href="pyproject.toml"><img alt="Python 3.10–3.12" src="https://img.shields.io/badge/python-3.10%E2%80%933.12-3776AB?logo=python&amp;logoColor=white"></a>
   <a href="docs/deployment.md"><img alt="Linux" src="https://img.shields.io/badge/platform-Linux-FCC624?logo=linux&amp;logoColor=black"></a>
   <a href="LICENSE"><img alt="Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
 </p>
 
-> **ModelArk 0.3.1 is a public alpha.** It is usable today as an operator-attended archive and
+> **ModelArk 0.3.2 is a public alpha.** It is usable today as an operator-attended archive and
 > disaster-recovery system for open model artifacts. Storage work remains explicit and reviewable,
 > and interfaces can still change before 1.0.
 
@@ -78,14 +78,14 @@ the detailed contracts.
 - **No automatic deletion of extras.** Reconciliation reports unclaimed content but does not adopt
   or remove it.
 
-## What changed in v0.3.1
+## What changed in v0.3.2
 
-Version 0.3.1 is an application-only patch over the schema-v7 0.3.0 release. It separates planned
-work from archived occupancy in the Fill display, marks lost/excluded drives unambiguously, and
-hardens per-drive live occupancy refresh. Existing 0.3.0 catalogs need no migration, and updating
-still does not start or resume Fill automatically.
+Version 0.3.2 adds bounded successor planning for an unavailable drive and its identity-proven
+replacement. The operator sees every changed target before approving the new placement; creating or
+approving it never starts Fill. This application-only update keeps schema v7 and also tightens stale
+proposal enforcement at the Fill boundary.
 
-Read the [v0.3.1 release notes](docs/releases/v0.3.1.md) or the
+Read the [v0.3.2 release notes](docs/releases/v0.3.2.md) or the
 [changelog](CHANGELOG.md) for the complete patch record.
 
 ## What changed in v0.3.0

--- a/contributing/contributions.md
+++ b/contributing/contributions.md
@@ -1,7 +1,7 @@
 # Contributing to ModelArk
 
 ModelArk is built in public and pre-1.0 — bug reports, fixes, docs, and curation ideas are all
-welcome. Expect rough edges, and read the [0.3.1 status](../README.md#what-changed-in-v031) first.
+welcome. Expect rough edges, and read the [0.3.2 status](../README.md#what-changed-in-v032) first.
 
 By taking part you agree to the canonical [Code of Conduct](../CODE_OF_CONDUCT.md).
 

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2284,3 +2284,30 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `docs_updated`: docs/decision_log.md, modelark/execution_session.py, tests/test_def042_successor_plan.py
 - `related`: DEC-067, DEC-092, INC-058, PR-063
 - `scope_boundary`: Fill-time semantic revalidation and regression evidence only. No planner assignment, proposal content, schema, live proposal, planner revision, drive state, Fill session, archive bytes, service deployment, merge, tag, or publication is changed or authorized here.
+
+### INC-060: Merged successor behavior reused the deployed 0.3.1 identity
+- `id`: INC-060
+- `date`: 2026-09-02
+- `status`: remediated by DEC-093 before deployment
+- `triggered_by`: Pre-Fill deployment check after PR #63 merged as `dda3cbf`
+- `symptom`: Merged main contained the new successor planning workflow but still reported `modelark 0.3.1`, the same package/runtime version as the live retained `4a26d37` candidate.
+- `root_cause`: PR #63 advanced runtime behavior without advancing release surfaces. The existing release-identity regression proves that surfaces agree within one checkout, but cannot prove that a behavior-changing checkout differs from the currently deployed release.
+- `blast_radius`: Support and rollback identification only; the successor build was not deployed. The live 0.3.1 service remained healthy with revision 10 approved, Fill idle, and Drive #7 attached under exact identity.
+- `why_not_caught_earlier`: Successor qualification bound commit, proposal, planner, and execution identities but treated package versioning as separate release work, despite DEC-091 requiring behavior-changing retained candidates to advance their supported version surface.
+- `planned_remediation`: DEC-093 assigns version 0.3.2 and advances package metadata, runtime output, README, changelog, upgrade guidance, contributor pointer, release note, and retained candidate identity before service replacement.
+- `docs_updated`: docs/decision_log.md, README.md, CHANGELOG.md, docs/upgrading.md, docs/releases/v0.3.2.md, contributing/contributions.md, pyproject.toml, modelark/__init__.py, tests/test_release_identity.py
+- `related`: DEC-083, DEC-091, DEC-092, INC-055, PR-063
+
+### DEC-093: Assign version 0.3.2 to bounded successor planning
+- `id`: DEC-093
+- `date`: 2026-09-02
+- `status`: accepted; deployment pending
+- `triggered_by`: INC-060 and the operator's explicit selection of version 0.3.2
+- `decision`: Identify the reviewed successor-drive workflow and its stale-authority enforcement as patch version `0.3.2`. Advance build metadata, runtime output, README, changelog, upgrade guidance, contributor pointer, and a dedicated release note together. Keep schema v7 unchanged and require an application-only replacement using the exact existing data/state/config paths, automatic Fill resume absent, and the prior 0.3.1 candidate retained for rollback.
+- `rationale`: The successor workflow materially changes the runnable service and therefore must not reuse 0.3.1. The operator selected a patch increment to keep this attended recovery workflow on the existing 0.3 public-alpha line.
+- `impact`: A 0.3.2 candidate can be distinguished through the supported CLI/package version as well as its exact commit and artifact digests. Existing schema-v7 catalogs require no migration. Deployment, successor-draft creation, exact approval, and Start Fill remain separate operator boundaries.
+- `verification`: Release-identity, CLI-version, and successor focused tests pass nine tests; Ruff and `git diff --check` pass. The isolated package build produced wheel SHA-256 `caabbf8658f0c69d77d3528d652c33971953f0430a287460f4fd97da3b64ef89` and source-archive SHA-256 `60cbe8ca72798085a6271620f9a2369b54ce25b09f098c8a73066e88366a43b2`; installed metadata, `modelark.__version__`, and the CLI entry point all report `0.3.2`.
+- `resolves`: INC-060
+- `docs_updated`: docs/decision_log.md, README.md, CHANGELOG.md, docs/upgrading.md, docs/releases/v0.3.2.md, contributing/contributions.md, pyproject.toml, modelark/__init__.py, tests/test_release_identity.py
+- `related`: DEC-067, DEC-083, DEC-091, DEC-092, INC-055, INC-058, INC-059, PR-063
+- `scope_boundary`: Release identity and application-only upgrade guidance only. No schema migration, catalog/selection/plan/proposal mutation, drive state, Fill session, archive-byte operation, live service deployment, tag, publication, or merge is changed or authorized here.

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -1,0 +1,34 @@
+# ModelArk v0.3.2 — Public Alpha Patch
+
+ModelArk v0.3.2 adds an operator-directed, capacity-bounded successor proposal for moving work from
+an unavailable drive to an identity-proven replacement. It retains the schema-v7 catalog and is an
+application-only update from v0.3.1.
+
+## What changed
+
+- The Fill page offers **Use a replacement drive** when a current approved placement and suitable
+  unavailable/replacement pair exist.
+- The replacement inherits only the unavailable drive's policy-adjusted capacity lane. Extra space
+  on a larger replacement is not silently filled by this action.
+- Existing reusable content remains preferred, unaffected targets remain stable when feasible, and
+  the review shows every target change before approval.
+- Draft creation, historical status, execution configuration, and Fill revalidation reject stale or
+  missing successor authority instead of reconstructing it from an old proposal.
+- Metadata and planning commands defer ZipNN/Torch initialization until a codec operation needs it.
+
+## Upgrade from v0.3.1
+
+No catalog migration is required. Stop the current service, retain its unit and runtime as rollback,
+deploy v0.3.2 against the same explicit data, state, and config paths, and start without automatic
+Fill resume. Confirm the existing proposal, plan, Drives, and idle Fill state before creating a
+successor proposal.
+
+Creating a successor draft does not change the active approval. Approving it supersedes the earlier
+placement but still does not start Fill. Start Fill separately only while an operator can respond to
+its attended drive-loading prompts.
+
+See [Operating ModelArk](../operations.md) for the replacement-drive workflow and
+[Upgrading ModelArk](../upgrading.md) for the rollback boundary.
+
+Usable Slice, scratch delivery, and peer-to-peer transport remain future direction rather than
+features of this patch.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,6 +4,18 @@ ModelArk upgrades application code normally, but it never silently rewrites an e
 schema is older than the installed release. Existing data is migrated through an explicit,
 backup-first, side-by-side procedure so the old runtime remains a usable rollback point.
 
+## The 0.3.1 → 0.3.2 boundary
+
+ModelArk 0.3.2 retains schema v7 and requires no catalog migration. Stop the current service, retain
+its unit and runtime as rollback, and deploy 0.3.2 against the same explicit data, state, and config
+paths without automatic Fill resume. Confirm the existing proposal, plan, Drives, and idle Fill
+state after restart.
+
+The new replacement-drive action creates a separate bounded successor proposal from the current
+approval. Creating or approving that proposal does not start Fill. Review its exact target changes,
+approve it explicitly, and use the separate Start Fill action only while an operator can respond to
+drive-loading prompts.
+
 ## The 0.3.0 → 0.3.1 boundary
 
 ModelArk 0.3.1 uses the same schema-v7 catalog as 0.3.0. This is an application-only update: retain
@@ -38,8 +50,8 @@ If a new ModelArk binary is pointed at an existing pre-v7 catalog, it refuses be
 file and names `modelark-provenance-migrate`. This is expected protection, not catalog corruption.
 For source checkouts and pre-release builds, do not use the Python package version string alone to
 decide whether migration is needed: the catalog schema and the binary's refusal are authoritative.
-ModelArk 0.3.0 is the first public release line carrying schema v7; 0.3.1 retains that schema and is
-intentionally distinct from the released 0.2.0 schema-v2 line.
+ModelArk 0.3.0 is the first public release line carrying schema v7; 0.3.1 and 0.3.2 retain that schema
+and are intentionally distinct from the released 0.2.0 schema-v2 line.
 
 ## What the provenance migration does
 

--- a/modelark/__init__.py
+++ b/modelark/__init__.py
@@ -1,3 +1,3 @@
 """modelark — catalog, fetch, and verify open model weights from the Hub."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modelark"
-version = "0.3.1"
+version = "0.3.2"
 description = "Catalog, fetch, and verify open model weights across an offline drive library."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_release_identity.py
+++ b/tests/test_release_identity.py
@@ -1,4 +1,4 @@
-"""Release surfaces must identify one package/runtime artifact line (INC-055 / DEC-091)."""
+"""Release surfaces must identify one package/runtime artifact line (DEC-093)."""
 from __future__ import annotations
 
 import re
@@ -8,6 +8,7 @@ import modelark
 
 
 ROOT = Path(__file__).resolve().parents[1]
+CURRENT_RELEASE = "0.3.2"
 
 
 def _project_version() -> str:
@@ -20,6 +21,7 @@ def _project_version() -> str:
 
 def test_release_identity_surfaces_agree():
     expected = _project_version()
+    assert expected == CURRENT_RELEASE
     assert modelark.__version__ == expected
     assert f"## {expected} - " in (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     assert f"ModelArk {expected}" in (ROOT / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- assign package and runtime version 0.3.2 to the merged successor-drive workflow
- add the changelog, README status, upgrade boundary, contributor pointer, and dedicated release note
- record INC-060 and DEC-093 so the live 0.3.1 candidate is never confused with the new runtime

## Verification
- 9 focused release/CLI/successor tests passed
- Ruff and git diff checks passed
- isolated wheel and source archive build passed
- installed metadata, modelark.__version__, and CLI report 0.3.2

## Safety boundary
Schema remains v7. This PR does not deploy the service, mutate the catalog or proposal, start Fill, move archive bytes, tag, publish, or merge itself.