### PR TITLE
docs: lock archive-only Usable Slice boundary

### DIFF
--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2514,3 +2514,19 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: The first implementation stops at a non-executable gap report when archive evidence is absent. Spark catalog expansion proceeds separately, and a later composition can reuse its normal acquisition results without changing Usable Slice semantics.
 - `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md
 - `related`: DEC-081, DEF-041, DEF-CATALOG-005, DIS-005, DEC-098, BOT-006, DEC-101
+
+### DEC-102: Preserve slice progress with source-use gates and owned crash recovery
+- `id`: DEC-102
+- `date`: 2026-09-06
+- `status`: accepted
+- `triggered_by`: PR #67 lifecycle/checkpoint finding and completed Codex review of `1e09833`; operator agreement to resolve all five contracts and prepare development.
+- `decision`:
+  1. Check source lifecycle and exact clean generation/file evidence at each use under the archive mutation fence. A changed candidate becomes unavailable; use only a still-qualifying sealed alternative or retain the same transaction in a typed source block. Preserve completed digest-verified checkpoints and their provenance. Offline clean sources remain schedulable; dirty or unproven residency requires separate reconciliation.
+  2. Start combines an idempotent transaction CAS with exclusive local destination-device ownership. Persist unfinished-output ownership across stops and crashes, include surviving writer children in the fence, and prohibit takeover by another seal. The first implementation is single-host direct USB.
+  3. Persist transaction-bound creation intents before writes, verify and flush owned temporary files, publish without replacement, flush directory metadata, and record completion. Recovery authenticates ownership and operation records, reconciles interrupted publication, and revalidates bytes; matching names or digests cannot adopt unrelated output. Journal in-flight allocation for capacity recovery.
+  4. Keep destination operations rooted in a verified filesystem descriptor, revalidate identity at publication and resume boundaries, and refuse mount/symlink substitutions. Detachment must never redirect writes into the host filesystem.
+  5. Prepare development as domain contracts, transaction/recovery, then direct-USB integration with disposable fixtures. Finish the renewed bounded PR #67 review before operator merge and implementation. Real destination writes remain a separate attended gate.
+- `rationale`: Whole-seal invalidation for a source lifecycle change stranded verified output behind successor collision rules. Per-use eligibility preserves immutable approval and useful progress without silently approving new sources. Durable intents, exclusive ownership, and device-bound writes make resume safe across crashes, retries, and unplug events. Cross-successor checkpoint adoption is unnecessary for the first slice and remains unsupported.
+- `impact`: Resolves the five current architecture findings in the Usable Slice charter and defines testable development boundaries. No production implementation or live runtime action is included; the existing revision-11 Fill remains independent.
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md
+- `related`: DEC-045, DEC-049, DEC-081, DEC-098, DEC-101, DEF-041, DEF-043

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -1952,7 +1952,7 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 ### DEF-041: Defer Usable Slice implementation for subsection delivery
 - `id`: DEF-041
 - `date`: 2026-08-30
-- `status`: revisit triggered 2026-09-05; architecture review active, implementation pending
+- `status`: revisit triggered 2026-09-05; architecture accepted by DEC-101 on 2026-09-06, implementation pending
 - `triggered_by`: DEC-081 defines the needed DR delivery boundary while DEF-036's operator-facing proposal approval surface is still the current pre-Fill gate.
 - `decision`: Do not build the Usable Slice CLI/portal workflow in the current service-recovery and proposal-approval slice. Defer the subsection selector and dependency closure, consumer/layout profiles, destination-disk wizard, guided source-drive schedule, direct executor, scratch executor, local-USB scratch registry, R2 credential/cost/lifecycle policy, resumable delivery journal, final verifier, and receipt schema. Existing verified restore remains the available lower-level recovery mechanism in the meantime.
 - `rationale`: The live catalog is ready for canonical planning but still has no approved proposal, and the proposal-approval implementation is unfinished. Mixing a new multi-drive/object-store writer into that gate would widen the current trust boundary before the existing archive workflow is usable again. The DEC fixes the destination architecture now so the feature is not lost and ScintiLab does not grow an incompatible transfer path meanwhile.
@@ -2483,7 +2483,7 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `correction`: The operator separated the concerns. Spark discovery may add desired models through normal catalog selection and Fill, while Usable Slice may materialize only artifacts that already have sufficient ModelArk archive evidence. An offline archive drive is a valid source that the operator can be asked to load; an unarchived artifact is an explicit preview gap and must not be downloaded by the slice transaction.
 - `verified`: DEC-081 already makes delivery depend on a frozen, verified artifact closure, DEC-098 gives catalog change and archive mutation separate authority, and DIS-005 says Spark cache residency is not archive proof. The missing distinction was between an archived-but-offline source, which is schedulable, and no archived source, which is ineligible.
 - `lesson`: Never collapse catalog membership, machine-cache residency, archived evidence, and delivery eligibility into one state. A delivery transaction may schedule access to existing archive bytes but may not acquire absent bytes implicitly.
-- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, claudedocs/HANDOFF.md
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md
 - `related`: DEC-081, DEF-041, DEC-098, DEF-CATALOG-005, DIS-005
 
 ### DEC-101: Keep Usable Slice archive-only and fail closed on missing sources
@@ -2499,9 +2499,9 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
   5. Archive Reshape may later share the sealed materialization engine, but it retains the separate desired-set, placement, retention, and reclamation authority established by DEC-098.
 - `rationale`: Delivery must be predictable and fail closed: the operator can approve a complete source schedule without accidentally authorizing network acquisition or mutation of the disaster-recovery plan. Keeping offline availability distinct from archive absence preserves useful multi-drive operation while maintaining ModelArk's evidence boundaries.
 - `impact`: The implementation charter now defines archive-source eligibility, gap reporting, attended drive scheduling, transport-neutral execution, and a direct-mode first vertical slice. Spark catalog work, implicit hydration, Archive Reshape, scratch backends, and live-service changes remain outside the first implementation slice.
-- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, claudedocs/HANDOFF.md
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md
 - `related`: DEC-045, DEC-049, DEC-081, DEC-084, DEF-018, DEF-041, DEF-CATALOG-005, DIS-005, DEC-098, BOT-006
-- `scope_boundary`: Architecture, implementation charter, and handoff only. No catalog discovery or selection, remote fetch, plan/proposal/Fill mutation, archive-byte transfer, destination write, R2 allocation, service restart, deployment, merge, tag, or release is authorized or performed.
+- `scope_boundary`: Architecture and implementation charter only. No catalog discovery or selection, remote fetch, plan/proposal/Fill mutation, archive-byte transfer, destination write, R2 allocation, service restart, deployment, merge, tag, or release is authorized or performed.
 
 ### DEF-043: Defer hydrate-then-materialize composition
 - `id`: DEF-043
@@ -2512,5 +2512,5 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `rationale`: Hydration is technically solvable but would make a delivery approval authorize new remote bytes, archive placement, and possibly changed durability obligations. That is unnecessary for the first operator need and would obscure whether a slice is recoverable from the existing ark.
 - `revisit_when`: The operator explicitly requests a hydrate-then-materialize workflow, or repeated real slice requests show that the archive-only contract is insufficient and the prerequisite catalog/Fill transaction boundaries can be specified without implicit authority.
 - `impact`: The first implementation stops at a non-executable gap report when archive evidence is absent. Spark catalog expansion proceeds separately, and a later composition can reuse its normal acquisition results without changing Usable Slice semantics.
-- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, claudedocs/HANDOFF.md
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md
 - `related`: DEC-081, DEF-041, DEF-CATALOG-005, DIS-005, DEC-098, BOT-006, DEC-101

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2530,3 +2530,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Resolves the five current architecture findings in the Usable Slice charter and defines testable development boundaries. No production implementation or live runtime action is included; the existing revision-11 Fill remains independent.
 - `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md
 - `related`: DEC-045, DEC-049, DEC-081, DEC-098, DEC-101, DEF-041, DEF-043
+
+### DEC-103: Separate offline source validation and placement exclusion from slice reads
+- `id`: DEC-103
+- `date`: 2026-09-06
+- `status`: accepted
+- `triggered_by`: Completed Codex review of PR #67 head `0e0001f` and verification against the existing lifecycle/eligibility matrix in `tests/test_lifecycle_eligibility.py`.
+- `decision`: Refine DEC-102's implementation contract: seal lexically safe offline source paths and prove descriptor confinement after attachment before each read; permit otherwise qualifying lifecycle-active sources whose placement eligibility is excluded; durably flush and checkpoint every created directory's parent entry before creating children or publishing completion; persist the actual source candidate and its epoch/generation, anchor, and file provenance with each prepared/completed file and receipt.
+- `rationale`: Offline scheduling cannot require an absent filesystem to resolve during preview. Placement exclusion does not revoke existing readable copies. File flushes alone do not make ancestor directory entries durable, and an approved list of alternatives does not identify which source supplied a delivered file.
+- `impact`: Corrects the charter's excluded-source and offline-resolution wording and completes its directory-durability and per-file provenance contracts. Adds acceptance cases within the existing three development slices; no production or runtime change.
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md
+- `related`: DEC-081, DEC-101, DEC-102, DEF-041, tests/test_lifecycle_eligibility.py

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2473,3 +2473,44 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `review_update_2026_09_05_iteration_3`: Greptile accepted exact HEAD `29c10bbc52d2b190785763a2a8f7f99287d7b918` at `5/5` with a completion thumbs-up, successful review check, and no actionable finding. The automatic Codex review completed afterward with one valid P2: `fill_api` preserved typed evidence for unsuccessful terminal results but discarded it when an executor successfully returned `PLAN_COMPLETE_WITH_FOLLOWUPS`, preventing content and dependency follow-ups from reaching the exact drive-state adapter. The operator explicitly authorized one bounded Greptile iteration-four exception for this new item. The adapter now preserves optional evidence, actions, failure detail, and gate metadata on successful terminals; regression coverage drives a successful content-plus-dependency follow-up result through `fill_api` and verifies the affected exact cards.
 - `review_update_2026_09_05_iteration_4`: Greptile accepted exact HEAD `613580759ba52119e1f893a92cfd3da756683734` at `5/5` with a completion thumbs-up and successful review check. The later automatic Codex review found three related fallback-boundary gaps: physical RAID identity was inferred from task kind, the combined replica write probe blamed the target when only its source failed, and exact-only cards had no retained render envelope for stack toggles or late category data. The operator authorized an architectural correction followed by up to three further Greptile iterations. The correction binds one coherent drive-registry and archived-occupancy snapshot to the admitted execution, records unavailable replica source and target endpoints independently before/under/during the mutation fence, and makes the browser's current display envelope first-class whether or not advisory reconciliation succeeds.
 - `review_update_2026_09_05_architecture_followup_1`: Greptile accepted exact HEAD `9e4eb3f51a2ebb4d83bd53e314b3810795a33cf6` at `5/5`, with a successful check, completion thumbs-up, and no actionable finding. The automatic Codex review then found one current-head P2 in the same execution-publication boundary: a transport batch could durably complete an earlier requirement and return a typed stop on a later item before publishing the completed requirement IDs. The shared post-runner path now re-derives exact durable work and publishes monotonic completion before interpreting any Fetch or replica early-terminal summary; focused regressions cover both a typed Fetch terminal after committed progress and a replica defer after an earlier committed copy.
+
+### BOT-006: Spark discovery was conflated with Usable Slice eligibility
+- `id`: BOT-006
+- `date`: 2026-09-06
+- `status`: logged
+- `triggered_by`: The proposed follow-up to use DGXSpark's missing model set as the first Usable Slice test after DEC-098 and DIS-005.
+- `claim`: The first slice could be defined from the Spark recipe/catalog gap and materialize models that ModelArk had not archived yet, making catalog expansion and delivery one workflow.
+- `correction`: The operator separated the concerns. Spark discovery may add desired models through normal catalog selection and Fill, while Usable Slice may materialize only artifacts that already have sufficient ModelArk archive evidence. An offline archive drive is a valid source that the operator can be asked to load; an unarchived artifact is an explicit preview gap and must not be downloaded by the slice transaction.
+- `verified`: DEC-081 already makes delivery depend on a frozen, verified artifact closure, DEC-098 gives catalog change and archive mutation separate authority, and DIS-005 says Spark cache residency is not archive proof. The missing distinction was between an archived-but-offline source, which is schedulable, and no archived source, which is ineligible.
+- `lesson`: Never collapse catalog membership, machine-cache residency, archived evidence, and delivery eligibility into one state. A delivery transaction may schedule access to existing archive bytes but may not acquire absent bytes implicitly.
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, claudedocs/HANDOFF.md
+- `related`: DEC-081, DEF-041, DEC-098, DEF-CATALOG-005, DIS-005
+
+### DEC-101: Keep Usable Slice archive-only and fail closed on missing sources
+- `id`: DEC-101
+- `date`: 2026-09-06
+- `status`: accepted
+- `triggered_by`: BOT-006, DEC-081, and DEC-098
+- `decision`:
+  1. Usable Slice is an outward delivery transaction over an exact artifact closure already preserved by ModelArk. Every required artifact must resolve to at least one archive source with sufficient identity, content, and provenance evidence before the preview is executable.
+  2. An archived source that is not currently attached remains eligible. The sealed transfer schedule names its known source drive and pauses with an attended request to load that drive. A required artifact with no qualifying archived source makes the preview non-executable and produces an explicit gap report; Usable Slice does not fetch it from a remote service.
+  3. Direct drive-to-destination, local USB scratch, and Cloudflare R2 scratch are transport topologies for the same already-archived bytes. Scratch can separate attended source and destination phases, but it does not create archive evidence, satisfy copy policy, or expand the slice closure.
+  4. DGXSpark recipe discovery and ModelArk catalog expansion remain a separate curation and Fill lane. Spark models become valid slice candidates only after that lane archives them with sufficient evidence. Initial slice qualification uses a small set of already-archived models.
+  5. Archive Reshape may later share the sealed materialization engine, but it retains the separate desired-set, placement, retention, and reclamation authority established by DEC-098.
+- `rationale`: Delivery must be predictable and fail closed: the operator can approve a complete source schedule without accidentally authorizing network acquisition or mutation of the disaster-recovery plan. Keeping offline availability distinct from archive absence preserves useful multi-drive operation while maintaining ModelArk's evidence boundaries.
+- `impact`: The implementation charter now defines archive-source eligibility, gap reporting, attended drive scheduling, transport-neutral execution, and a direct-mode first vertical slice. Spark catalog work, implicit hydration, Archive Reshape, scratch backends, and live-service changes remain outside the first implementation slice.
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, claudedocs/HANDOFF.md
+- `related`: DEC-045, DEC-049, DEC-081, DEC-084, DEF-018, DEF-041, DEF-CATALOG-005, DIS-005, DEC-098, BOT-006
+- `scope_boundary`: Architecture, implementation charter, and handoff only. No catalog discovery or selection, remote fetch, plan/proposal/Fill mutation, archive-byte transfer, destination write, R2 allocation, service restart, deployment, merge, tag, or release is authorized or performed.
+
+### DEF-043: Defer hydrate-then-materialize composition
+- `id`: DEF-043
+- `date`: 2026-09-06
+- `status`: active
+- `triggered_by`: BOT-006 and DEC-101's archive-only Usable Slice boundary
+- `decision`: Do not add implicit remote acquisition, catalog discovery, selection mutation, or Fill execution to Usable Slice. Report every artifact without a qualifying archived source as an exact blocking gap. A future workflow may explicitly compose an independently previewed and approved archive-acquisition transaction with a later Usable Slice transaction, but the two receipts and authorities must remain distinct.
+- `rationale`: Hydration is technically solvable but would make a delivery approval authorize new remote bytes, archive placement, and possibly changed durability obligations. That is unnecessary for the first operator need and would obscure whether a slice is recoverable from the existing ark.
+- `revisit_when`: The operator explicitly requests a hydrate-then-materialize workflow, or repeated real slice requests show that the archive-only contract is insufficient and the prerequisite catalog/Fill transaction boundaries can be specified without implicit authority.
+- `impact`: The first implementation stops at a non-executable gap report when archive evidence is absent. Spark catalog expansion proceeds separately, and a later composition can reuse its normal acquisition results without changing Usable Slice semantics.
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, claudedocs/HANDOFF.md
+- `related`: DEC-081, DEF-041, DEF-CATALOG-005, DIS-005, DEC-098, BOT-006, DEC-101

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -41,33 +41,47 @@ this charter's first implementation.
 Eligibility is evaluated for every file in the frozen closure, not merely for every repository.
 
 A file is **source-ready** when ModelArk can resolve at least one archive copy with the required
-artifact identity, content digest, provenance evidence, and stable physical drive identity. The
-drive does not need to be attached during preview.
+artifact identity, content digest, provenance evidence, stable physical drive identity, and an
+active lifecycle state. Lost, excluded, retired, or otherwise inactive drives retain historical
+evidence but cannot satisfy slice recoverability. The eligible drive does not need to be attached
+during preview.
 
 A source-ready file on an offline drive is **waiting for source**, not missing. Its source drive is
 included in the approved schedule, and execution pauses with a precise request to attach that drive.
 
 A file with no qualifying archive source is **archive-missing**. Preview is non-executable and
 reports the exact repository, path, required evidence, and reason. The transaction offers no remote
-fetch action. Catalog-only rows and machine-cache residency are insufficient.
+fetch action. Catalog-only rows and machine-cache residency are insufficient. Historical rows on
+inactive drives appear in the gap explanation but do not make it executable.
 
-Source choice must be deterministic under the evidence snapshot. Any source identity, closure,
-destination identity, or digest drift after approval invalidates the execution seal and requires a
-new preview. Before the first write, unexplained capacity drift does the same. After execution
-starts, remaining-capacity checks account for the transaction's own journaled writes and invalidate
-only unexplained external consumption or mutation.
+Source choice must be deterministic under the evidence snapshot. The seal may bind an ordered set
+of qualifying alternatives, but execution can use only those pre-approved identities. Any closure,
+destination identity, lifecycle, or digest drift after approval invalidates the execution seal and
+requires a new preview. Before the first write, unexplained capacity drift does the same. After
+execution starts, remaining-capacity checks account for the transaction's own journaled writes and
+invalidate only unexplained external consumption or mutation.
 
 ## Filesystem and device safety
 
 Every source and output path must pass lexical and resolved confinement before it enters a sealed
 closure or transfer plan. Reject absolute paths, parent traversal, platform-separator ambiguity,
 NULs, and any destination ancestor or symlink that escapes the approved root. Source reads use the
-existing archive/annex adapter so legitimate annex indirection remains supported without allowing
-catalog or database text to select an arbitrary host path.
+archive's local annex evidence but require a retrieval-disabled reader: it may resolve and read
+locally present annex content but must never run `git annex get`, contact a configured remote, or
+mutate the source archive. Missing local content makes that candidate unavailable; execution uses
+another sealed qualifying source or stops with an attended source gap.
 
 Destination and scratch identities are writable roles and must not match any registered ModelArk
 archive identity, alias, or stable physical-device evidence. Source, destination, and scratch roles
-must remain disjoint at preview and Start; a changed or ambiguous identity blocks execution.
+must remain disjoint at preview and Start; a changed or ambiguous identity blocks execution. A
+writable role must also be backed by a dedicated non-system device: reject any filesystem, partition,
+or parent device that backs the host root, boot, or another system-managed path.
+
+Preview binds the destination's stable device and filesystem identity, writable mount evidence,
+available capacity, per-file size limit, path/name limits, and other capabilities required by the
+chosen layout. Start revalidates them before writing. A read-only mount, unsupported filesystem, or
+layout whose files or paths exceed those limits is non-executable even when aggregate free space is
+sufficient. Scratch adapters must provide the equivalent capability evidence for their backend.
 
 The first implementation has no merge or overwrite mode. The approved consumer root is dedicated
 to the slice, every planned output path must be absent, and unexpected existing content or a path
@@ -80,9 +94,12 @@ The workflow is one resumable transaction with an immutable approved core:
 
 1. **Draft scope** — select repositories/artifacts and a consumer/layout profile.
 2. **Freeze closure** — resolve every required file and digest under one catalog/evidence snapshot.
+   The immutable file manifest is authoritative; a repository commit SHA is included only when it
+   was captured as trustworthy evidence and is never inferred by querying the current remote head.
 3. **Resolve sources** — choose qualifying archive copies and build an attended drive schedule.
-4. **Preview** — show exact bytes, source drives, destination writes, scratch use, capacity, gaps,
-   and verification policy. Any archive-missing file makes the preview non-executable.
+4. **Preview** — show exact bytes, lifecycle-active source drives, destination writes, scratch use,
+   device/filesystem capabilities, capacity, gaps, and verification policy. Any archive-missing file
+   makes the preview non-executable.
 5. **Approve** — bind the closure, evidence snapshot, source choices, transport, destination identity,
    capacity evidence, and layout to one seal. Approval does not begin transfer.
 6. **Execute** — copy checkpointed content; request only the source, scratch, or destination device
@@ -97,10 +114,12 @@ an invalidation requires a successor preview.
 ## Core records
 
 - **SliceSpec** — requested subsection, consumer profile, and destination intent.
-- **ArtifactClosure** — exact repository revisions, file identities, sizes, and digests.
-- **SourceEvidence** — qualifying archive copies and the evidence snapshot that supports them.
-- **TransferPlan** — deterministic source order, topology, capacity charges, checkpoints, and final
-  layout operations.
+- **ArtifactClosure** — repository identity plus the exact immutable file manifest, sizes, and
+  digests. Repository revision is optional evidence, not a value reconstructed from a mutable remote.
+- **SourceEvidence** — lifecycle-active qualifying archive copies, ordered sealed alternatives, and
+  the evidence snapshot that supports them.
+- **TransferPlan** — deterministic source order, topology, capacity and filesystem-capability
+  charges, checkpoints, and final layout operations.
 - **SliceApproval** — operator approval bound to the exact preview seal.
 - **SliceJournal** — append-only phase and file progress suitable for safe resume.
 - **SliceReceipt** — catalog snapshot, slice definition and consumer profile, closure, source
@@ -157,6 +176,7 @@ The first implementation milestone is intentionally narrow:
 - fail preview with a structured gap when one test artifact lacks archive evidence;
 - support direct copy, attended offline-source requests, stop/resume, final digest/layout
   verification, and a receipt;
+- read only locally present archive content through a retrieval-disabled source adapter;
 - prove that preview and execution perform no network acquisition and do not mutate catalog,
   selection, plan, proposal, Fill, placement, or archive-copy evidence.
 
@@ -167,16 +187,25 @@ Archive Reshape follows as a separate transaction after the materialization core
 
 - Every executable preview has a qualifying archived source for every closure file.
 - Catalog-only and cache-only fixtures produce exact blocking gaps and zero remote fetch attempts.
+- A fixture whose only historical archive row belongs to a lost or inactive drive produces a
+  blocking gap rather than an impossible drive request.
 - Offline qualifying sources produce attended drive requests and resume without replanning completed
   work.
+- Closure identity is the immutable per-file manifest and digests; absent historical commit SHAs are
+  never synthesized from a current remote lookup.
 - Approval and Start are separate; drift cannot silently substitute a source or destination.
 - Destination and scratch identities cannot resolve to ModelArk archive drives, and their writable
   roles remain disjoint from every source identity.
+- Destination and scratch backing devices cannot be the host root, boot, or another system device.
+- Preview and Start reject read-only or incompatible filesystems and layouts exceeding per-file,
+  path, or name limits, even when aggregate capacity is adequate.
 - Unsafe or escaping paths, existing destination content, and unjournaled path collisions block
   preview or Start; the first implementation never merges or overwrites.
 - Capacity revalidation subtracts sealed journaled writes, while unexplained external consumption
   invalidates the transaction.
 - Interrupted transfers resume from durable checkpoints and never publish an unverified receipt.
+- A locally absent annex object never invokes `git annex get` or any remote; execution uses only a
+  sealed locally present alternative or stops.
 - Destination verification covers both content and the chosen consumer layout.
 - A completed receipt cannot satisfy ModelArk replica policy or mutate archive placement.
 - Existing Fill behavior and a running approved Fill remain untouched.

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -52,8 +52,27 @@ reports the exact repository, path, required evidence, and reason. The transacti
 fetch action. Catalog-only rows and machine-cache residency are insufficient.
 
 Source choice must be deterministic under the evidence snapshot. Any source identity, closure,
-capacity, destination, or digest drift after approval invalidates the execution seal and requires a
-new preview.
+destination identity, or digest drift after approval invalidates the execution seal and requires a
+new preview. Before the first write, unexplained capacity drift does the same. After execution
+starts, remaining-capacity checks account for the transaction's own journaled writes and invalidate
+only unexplained external consumption or mutation.
+
+## Filesystem and device safety
+
+Every source and output path must pass lexical and resolved confinement before it enters a sealed
+closure or transfer plan. Reject absolute paths, parent traversal, platform-separator ambiguity,
+NULs, and any destination ancestor or symlink that escapes the approved root. Source reads use the
+existing archive/annex adapter so legitimate annex indirection remains supported without allowing
+catalog or database text to select an arbitrary host path.
+
+Destination and scratch identities are writable roles and must not match any registered ModelArk
+archive identity, alias, or stable physical-device evidence. Source, destination, and scratch roles
+must remain disjoint at preview and Start; a changed or ambiguous identity blocks execution.
+
+The first implementation has no merge or overwrite mode. The approved consumer root is dedicated
+to the slice, every planned output path must be absent, and unexpected existing content or a path
+collision blocks preview or Start. Resume may recognize only exact paths and checkpoints written by
+the same sealed transaction; everything else remains a collision.
 
 ## Transaction and state model
 
@@ -84,8 +103,9 @@ an invalidation requires a successor preview.
   layout operations.
 - **SliceApproval** — operator approval bound to the exact preview seal.
 - **SliceJournal** — append-only phase and file progress suitable for safe resume.
-- **SliceReceipt** — closure, source evidence, topology, destination identity, verification results,
-  and terminal status. It is delivery evidence, never ModelArk replica evidence.
+- **SliceReceipt** — catalog snapshot, slice definition and consumer profile, closure, source
+  evidence, topology, destination identity, verification results, and terminal status. It is
+  delivery evidence, never ModelArk replica evidence.
 
 These records should be transport-neutral. USB direct, local scratch, and R2 scratch adapters must
 not reinterpret closure, evidence, approval, or receipt semantics.
@@ -150,6 +170,12 @@ Archive Reshape follows as a separate transaction after the materialization core
 - Offline qualifying sources produce attended drive requests and resume without replanning completed
   work.
 - Approval and Start are separate; drift cannot silently substitute a source or destination.
+- Destination and scratch identities cannot resolve to ModelArk archive drives, and their writable
+  roles remain disjoint from every source identity.
+- Unsafe or escaping paths, existing destination content, and unjournaled path collisions block
+  preview or Start; the first implementation never merges or overwrites.
+- Capacity revalidation subtracts sealed journaled writes, while unexplained external consumption
+  invalidates the transaction.
 - Interrupted transfers resume from durable checkpoints and never publish an unverified receipt.
 - Destination verification covers both content and the chosen consumer layout.
 - A completed receipt cannot satisfy ModelArk replica policy or mutate archive placement.

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -2,7 +2,7 @@
 
 Status: architecture locked; implementation has not started  
 Updated: 2026-09-06  
-Decision anchors: DEC-081, DEC-098, BOT-006, DEC-101, DEF-041, DEF-043
+Decision anchors: DEC-081, DEC-098, BOT-006, DEC-101, DEC-102, DEF-041, DEF-043
 
 ## Outcome
 
@@ -46,6 +46,15 @@ active lifecycle state. Lost, excluded, retired, or otherwise inactive drives re
 evidence but cannot satisfy slice recoverability. The eligible drive does not need to be attached
 during preview.
 
+Qualifying residency requires both the per-file archive/provenance record and a clean anchor for
+the drive's exact current identity epoch and write generation, with matching identity fingerprint
+and dedicated-local write authority. A clean capacity anchor alone is not proof of file contents;
+original-byte digest verification is still required during delivery. Historical rows on a dirty,
+unanchored, or identity-mismatched generation cannot establish source readiness, even if the drive
+is mounted. If no alternative qualifies, report `SOURCE_RECONCILIATION_REQUIRED` with the exact
+file and drive evidence. Reconciliation belongs to the separate archive workflow; preview never
+performs it or interrupts an active Fill to obtain a clean source.
+
 A source-ready file on an offline drive is **waiting for source**, not missing. Its source drive is
 included in the approved schedule, and execution pauses with a precise request to attach that drive.
 
@@ -55,10 +64,19 @@ fetch action. Catalog-only rows and machine-cache residency are insufficient. Hi
 inactive drives appear in the gap explanation but do not make it executable.
 
 Source choice must be deterministic under the evidence snapshot. The seal may bind an ordered set
-of qualifying alternatives, but execution can use only those pre-approved identities. Any closure,
-destination identity, lifecycle, or digest drift after approval invalidates the execution seal and
-requires a new preview. Before the first write, unexplained capacity drift does the same. After
-execution starts, remaining-capacity checks account for the transaction's own journaled writes and
+of qualifying alternatives, but execution can use only those pre-approved identities. Changed
+closure, destination identity, or required digest invalidates the execution seal and requires a
+new preview. Source lifecycle and residency validity are instead checked at each source use, under
+the existing archive-drive mutation fence through the read. Acquire that fence without blocking
+the live Fill; contention produces `SOURCE_BUSY`. Re-read the lifecycle, identity, generation,
+anchor, and file evidence under the fence. An inactive, changed, dirty, or locally missing candidate
+becomes unavailable; use the next qualifying sealed alternative or preserve the transaction in
+`blocked_source` with a typed reason. A qualifying but offline candidate produces `waiting_source`.
+Never add a newly discovered source to an approved seal. Source changes do not revoke completed
+digest-verified checkpoints or retrospectively invalidate their recorded provenance; final
+destination verification remains mandatory. Before the first write, unexplained capacity drift
+invalidates the seal. After execution starts, remaining-capacity checks account for the
+transaction's own journaled writes and
 invalidate only unexplained external consumption or mutation.
 
 ## Filesystem and device safety
@@ -83,10 +101,74 @@ chosen layout. Start revalidates them before writing. A read-only mount, unsuppo
 layout whose files or paths exceed those limits is non-executable even when aggregate free space is
 sufficient. Scratch adapters must provide the equivalent capability evidence for their backend.
 
+Execution holds descriptor-relative access rooted in the verified destination filesystem; later
+writes never reopen an absolute mountpoint path. Bind device, filesystem, and mount identity for
+the execution, revalidate before each file publication and resumed phase, and reject symlink or
+nested-mount substitutions. Descriptor confinement must close the check/open race rather than
+relying on a path check followed by an unrestricted open. Detachment stops in `waiting_destination`;
+a replacement identity blocks writes. The same device may resume only after identity, writable
+capabilities, ownership, journal, and capacity checks pass again. A vanished USB must never redirect
+output into the host filesystem below its uncovered mountpoint.
+
 The first implementation has no merge or overwrite mode. The approved consumer root is dedicated
 to the slice, every planned output path must be absent, and unexpected existing content or a path
 collision blocks preview or Start. Resume may recognize only exact paths and checkpoints written by
-the same sealed transaction; everything else remains a collision.
+the same sealed transaction, including recoverable in-flight intents defined below; everything else
+remains a collision. Recognizing transaction control files is a narrowly defined exception, not a
+general existing-content allowance.
+
+## Execution ownership and durable publication
+
+The first implementation is single-host and direct-USB. Start claims an approved transaction with
+an atomic compare-and-swap and takes a nonblocking exclusive destination-device lock shared by all
+local slice workers, independent of catalog path, transaction ID, mount alias, and consumer root.
+Both claims must succeed before any output mutation; a partial claim is recoverable without
+starting a writer. Repeated Start for the same active seal returns that execution idempotently;
+another owner receives `DESTINATION_BUSY`. The conservative whole-device lock also prevents
+overlapping roots and competing capacity consumption by local slices.
+
+A durable ownership record binds destination identity, root, transaction, and seal. It reserves
+unfinished output across stops or process death; another transaction cannot reclaim it by elapsed
+time or by replacing a lock file. Resume reacquires the process lock, proves prior workers and
+children are gone, and reconciles the durable record before writing. Any child capable of writing
+must retain the execution fence until it exits. Graceful stop quiesces writers before releasing the
+process lock. Completion releases ownership only after final verification and durable receipt
+publication; completed output still triggers the collision rule. Cross-host concurrent execution,
+ownership takeover, and automatic abandoned-output cleanup are outside this first slice.
+
+The journal and ownership metadata live in a private durable slice state store outside the catalog
+and archive, with a transaction-bound control record on the destination. Before creating that
+record, persist the host-side reservation and creation intent; exclusive creation under the device
+lock makes interrupted initialization recoverable. An unrelated existing control record blocks
+Start. Journal records bind the seal, destination identity, relative path, operation sequence,
+expected digest/size, and transaction-owned temporary name. Names or matching hashes alone never
+establish ownership of unrelated existing content.
+
+Each directory creation, file publication, and receipt publication follows a recoverable protocol:
+
+1. Durably append an intent before creating a transaction-owned path. Create directories and
+   temporary files exclusively through the bound destination descriptor; record parent/child
+   ownership, including creation of the consumer root. Unexpected content is a collision.
+2. Stream into the owned temporary file, verify the required original-byte digest and size, flush
+   the file, and durably record its prepared state. Journal in-flight allocation as well as completed
+   files so crash recovery can reconcile the transaction's own capacity consumption.
+3. Publish with an atomic **no-replace** operation on the same filesystem, flush the containing
+   directory, then durably append completion. A filesystem without the required durability and
+   no-replace semantics is rejected at preflight. The receipt uses the same publication protocol.
+4. On recovery, hold exclusive ownership and validate the seal, destination, and intent/prepared
+   records before inspecting exact owned paths. Reconcile an interrupted directory creation or
+   rename against those records; rehash a published file before completing a missing checkpoint.
+   Resume or recreate incomplete temporary data only within authenticated ownership. A checkpoint
+   without its expected output is not completion: restore that file from a still-valid sealed
+   source, or block. Contradictory records, digest mismatch, or unrelated content stop with a typed
+   recovery/collision error and never authorize overwrite or deletion of unknown bytes.
+
+Authentication here means provenance from the private state store plus matching destination
+ownership and sealed operation records, not a self-asserted filename or an imported journal. The
+first slice does not support checkpoint adoption across successor transactions. A source block
+retains its original seal and progress; changing the approved source set requires a separately
+approved transaction on an empty destination root, leaving earlier output intact. Other seal
+invalidations likewise preserve evidence without promising automatic successor resume.
 
 ## Transaction and state model
 
@@ -102,13 +184,14 @@ The workflow is one resumable transaction with an immutable approved core:
    makes the preview non-executable.
 5. **Approve** — bind the closure, evidence snapshot, source choices, transport, destination identity,
    capacity evidence, and layout to one seal. Approval does not begin transfer.
-6. **Execute** — copy checkpointed content; request only the source, scratch, or destination device
-   required for the next phase; preserve completed evidence across stops.
+6. **Execute** — claim exclusive ownership, recover the journal, and copy checkpointed content;
+   request only the source, scratch, or destination device required for the next phase; preserve
+   completed evidence across stops.
 7. **Verify and publish** — validate destination content and layout before publishing a receipt.
 
 Public transaction states should distinguish at least `draft`, `blocked_gaps`, `ready`, `approved`,
-`waiting_source`, `waiting_scratch`, `waiting_destination`, `transferring`, `verifying`, `complete`,
-`stopped`, `invalidated`, and `failed`. A wait is resumable and names the missing physical resource;
+`waiting_source`, `blocked_source`, `waiting_scratch`, `waiting_destination`, `transferring`,
+`verifying`, `complete`, `stopped`, `invalidated`, and `failed`. A wait is resumable and names the missing physical resource;
 an invalidation requires a successor preview.
 
 ## Core records
@@ -121,7 +204,8 @@ an invalidation requires a successor preview.
 - **TransferPlan** — deterministic source order, topology, capacity and filesystem-capability
   charges, checkpoints, and final layout operations.
 - **SliceApproval** — operator approval bound to the exact preview seal.
-- **SliceJournal** — append-only phase and file progress suitable for safe resume.
+- **SliceJournal** — durable ownership, creation intents, prepared publications, and append-only
+  phase/file progress bound to the transaction, suitable for crash reconciliation and safe resume.
 - **SliceReceipt** — catalog snapshot, slice definition and consumer profile, closure, source
   evidence, topology, destination identity, verification results, and terminal status. It is
   delivery evidence, never ModelArk replica evidence.
@@ -189,6 +273,13 @@ Archive Reshape follows as a separate transaction after the materialization core
 - Catalog-only and cache-only fixtures produce exact blocking gaps and zero remote fetch attempts.
 - A fixture whose only historical archive row belongs to a lost or inactive drive produces a
   blocking gap rather than an impossible drive request.
+- Dirty, missing-anchor, old-epoch, old-generation, and mismatched-fingerprint sources cannot
+  establish readiness from retained archive rows; a clean alternate may qualify. A capacity anchor
+  without qualifying per-file provenance is insufficient. No source check repairs the archive.
+- Lifecycle or residency changes before a source read preserve the seal and verified checkpoints;
+  only a still-qualifying sealed alternative may be used. Otherwise return a typed source block,
+  with no new source approval, implicit fetch, or successor adoption. Source-fence contention waits
+  without interrupting Fill. Source digest mismatch never produces a completed checkpoint.
 - Offline qualifying sources produce attended drive requests and resume without replanning completed
   work.
 - Closure identity is the immutable per-file manifest and digests; absent historical commit SHAs are
@@ -204,6 +295,16 @@ Archive Reshape follows as a separate transaction after the materialization core
 - Capacity revalidation subtracts sealed journaled writes, while unexplained external consumption
   invalidates the transaction.
 - Interrupted transfers resume from durable checkpoints and never publish an unverified receipt.
+- Fault injection covers intent persistence, directory/root creation, partial temporary writes,
+  file flush, prepared record, no-replace publication, directory flush, completion append, and
+  receipt publication. Recovery recognizes only owned intents, revalidates bytes, accounts for
+  temporary allocations, and rejects unknown content even when its digest matches.
+- Concurrent/retried Start, different roots or aliases on one device, a crashed owner, and a
+  surviving child prove at most one writer. Stopped ownership cannot be stolen by another seal;
+  failed partial acquisition is recoverable and a duplicate Start is idempotent.
+- Unplug, mount replacement, symlink/nested-mount substitution, and resume between write boundaries
+  produce no host-filesystem writes and no wrong-device receipt; the original device resumes only
+  after identity and ownership are reproved.
 - A locally absent annex object never invokes `git annex get` or any remote; execution uses only a
   sealed locally present alternative or stops.
 - Destination verification covers both content and the chosen consumer layout.
@@ -235,3 +336,29 @@ This charter and its ledger decisions are the stopping point. No implementation,
 service restart, Fill action, catalog expansion, or archive/destination byte movement is part of
 this change. The next implementation session starts with domain contracts and expected-red tests
 for eligibility, exact gap reporting, and the sealed direct-USB transaction.
+
+## Development entry and review slices
+
+Finish PR #67's renewed bounded review (up to three iterations) at its exact pushed head and let the
+operator merge it. Then branch from that merged charter for implementation. The first test commit
+defines expected-red domain contracts; failures must identify missing behavior rather than broken
+fixtures. Preserve separate test and implementation commits so the contracts remain reviewable.
+
+| Slice | Deliverable | Required evidence before advancing |
+|------|-------------|------------------------------------|
+| 1 — Domain | Immutable closure/source facts, exact gaps, deterministic alternatives, canonical preview seal and explicit approval; pure core with a read-only catalog adapter. | Synthetic clean/dirty/offline/inactive matrices, shuffled-order seal stability, tampered/stale approval refusal, no catalog writes or remote access. |
+| 2 — Transaction | Private state store, idempotent Start, device ownership, source-use gates, journal and recoverable publication. | Disposable filesystem and multi-process fixtures for every crash/concurrency boundary above; no real mounts, live state, or archive paths. |
+| 3 — Direct USB | Retrieval-disabled source reader, device-bound destination adapter, stop/resume, final verifier and receipt, minimal operator entry point. | Two or three tiny archived fixtures, exact gap and drive-wait demonstrations, isolated end-to-end and installed-wheel checks; full existing regression and static checks. |
+
+Candidate code seams are a new `modelark/slice/` package and `tests/test_slice_*.py`. Inspect
+`modelark/restore.py` for confined paths and original-byte verification, `modelark/drive_fence.py`
+for mutation exclusion, and catalog generation/anchor readers for evidence. Reuse only helpers
+whose contracts fit: the materializer must not inherit restore's optional annex retrieval or
+turn capacity evidence into file verification. Keep durable slice state out of catalog schema and
+keep production Fill wiring unchanged. Decide any API/CLI integration details against the proven
+domain core in slice 3, rather than coupling the first tests to a UI.
+
+An attended trial with real archived models and a real USB destination is a later operator gate,
+after these disposable-fixture checks. Return with the exact source schedule, destination identity,
+byte/capacity preview, and stop/recovery evidence before any real destination write. Formatting,
+erasure, archive mutation, deployment, and live Fill changes require their own explicit direction.

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -1,0 +1,182 @@
+# Usable Slice implementation charter
+
+Status: architecture locked; implementation has not started  
+Updated: 2026-09-06  
+Decision anchors: DEC-081, DEC-098, BOT-006, DEC-101, DEF-041, DEF-043
+
+## Outcome
+
+Usable Slice turns a named subset of artifacts already protected by ModelArk into a verified,
+consumer-ready destination. It guides the operator through attaching known source drives, resumes
+across attended swaps, verifies the final layout, and writes a durable delivery receipt.
+
+The first usable result is deliberately small: materialize a few already-archived models directly
+onto one USB destination. It does not acquire new models, alter the ark, or depend on the DGXSpark
+catalog-expansion work.
+
+## Product boundary
+
+Usable Slice owns:
+
+- an explicit catalog subsection and consumer/layout profile;
+- a frozen artifact closure with canonical identities and digests;
+- proof that every artifact has at least one qualifying ModelArk archive source;
+- an immutable source, transport, and destination schedule;
+- attended drive requests, resumable transfer, destination verification, and a delivery receipt.
+
+Usable Slice does not own:
+
+- discovery, selection, remote download, or Fill;
+- ModelArk placement, desired-copy satisfaction, retention, or reclamation;
+- treating a Spark cache, catalog row, scratch copy, or destination copy as archive evidence;
+- silently widening the closure when an artifact is absent;
+- formatting, erasing, or repurposing a destination without a separate explicit operator action.
+
+Archive Reshape may eventually call the same sealed materialization core, but it is a separate
+transaction with authority over ModelArk's desired set and placement. That authority is not part of
+this charter's first implementation.
+
+## Eligibility and source truth
+
+Eligibility is evaluated for every file in the frozen closure, not merely for every repository.
+
+A file is **source-ready** when ModelArk can resolve at least one archive copy with the required
+artifact identity, content digest, provenance evidence, and stable physical drive identity. The
+drive does not need to be attached during preview.
+
+A source-ready file on an offline drive is **waiting for source**, not missing. Its source drive is
+included in the approved schedule, and execution pauses with a precise request to attach that drive.
+
+A file with no qualifying archive source is **archive-missing**. Preview is non-executable and
+reports the exact repository, path, required evidence, and reason. The transaction offers no remote
+fetch action. Catalog-only rows and machine-cache residency are insufficient.
+
+Source choice must be deterministic under the evidence snapshot. Any source identity, closure,
+capacity, destination, or digest drift after approval invalidates the execution seal and requires a
+new preview.
+
+## Transaction and state model
+
+The workflow is one resumable transaction with an immutable approved core:
+
+1. **Draft scope** — select repositories/artifacts and a consumer/layout profile.
+2. **Freeze closure** — resolve every required file and digest under one catalog/evidence snapshot.
+3. **Resolve sources** — choose qualifying archive copies and build an attended drive schedule.
+4. **Preview** — show exact bytes, source drives, destination writes, scratch use, capacity, gaps,
+   and verification policy. Any archive-missing file makes the preview non-executable.
+5. **Approve** — bind the closure, evidence snapshot, source choices, transport, destination identity,
+   capacity evidence, and layout to one seal. Approval does not begin transfer.
+6. **Execute** — copy checkpointed content; request only the source, scratch, or destination device
+   required for the next phase; preserve completed evidence across stops.
+7. **Verify and publish** — validate destination content and layout before publishing a receipt.
+
+Public transaction states should distinguish at least `draft`, `blocked_gaps`, `ready`, `approved`,
+`waiting_source`, `waiting_scratch`, `waiting_destination`, `transferring`, `verifying`, `complete`,
+`stopped`, `invalidated`, and `failed`. A wait is resumable and names the missing physical resource;
+an invalidation requires a successor preview.
+
+## Core records
+
+- **SliceSpec** — requested subsection, consumer profile, and destination intent.
+- **ArtifactClosure** — exact repository revisions, file identities, sizes, and digests.
+- **SourceEvidence** — qualifying archive copies and the evidence snapshot that supports them.
+- **TransferPlan** — deterministic source order, topology, capacity charges, checkpoints, and final
+  layout operations.
+- **SliceApproval** — operator approval bound to the exact preview seal.
+- **SliceJournal** — append-only phase and file progress suitable for safe resume.
+- **SliceReceipt** — closure, source evidence, topology, destination identity, verification results,
+  and terminal status. It is delivery evidence, never ModelArk replica evidence.
+
+These records should be transport-neutral. USB direct, local scratch, and R2 scratch adapters must
+not reinterpret closure, evidence, approval, or receipt semantics.
+
+## Transport modes
+
+### Direct USB
+
+The source archive drive and destination are attached together. Verified bytes stream directly to
+the destination with bounded temporary state. This is the first implementation target.
+
+### Local USB scratch
+
+Verified bytes stage onto an explicitly identified scratch volume so source reads and destination
+writes can happen in separate attended phases. Scratch has its own capacity and identity gates and
+may be discarded only after destination verification and receipt publication.
+
+### Cloudflare R2 scratch
+
+R2 provides the same staged topology across machines or time. The adapter must bind bucket/object
+identity, encryption and credential policy, lifecycle/cleanup, cost preview, multipart resume, and
+digest verification. R2 objects remain transport state, not archive copies.
+
+Scratch adapters follow the direct-mode core; they are not prerequisites for proving the first
+vertical slice.
+
+## Operator workflow
+
+The operator should be able to:
+
+1. choose a named subset from the current catalog and a target layout;
+2. see whether the entire closure is recoverable from the existing ark;
+3. inspect exact gaps, bytes, source drives, swaps, scratch use, and destination impact;
+4. approve the exact stored preview without starting it;
+5. start when physically present, attach each requested device, and resume after safe stops;
+6. receive a verified destination and a receipt that states precisely what was delivered.
+
+The UI must never turn `archive-missing` into an invitation that implicitly downloads content. It
+may link to the separate catalog/Fill workflow as explanatory next work, but that workflow requires
+its own planning and approval.
+
+## First vertical slice
+
+The first implementation milestone is intentionally narrow:
+
+- choose two or three small, already-archived model repositories;
+- support one minimal consumer/layout profile and one explicitly identified USB destination;
+- derive and seal the exact closure and source-drive schedule;
+- fail preview with a structured gap when one test artifact lacks archive evidence;
+- support direct copy, attended offline-source requests, stop/resume, final digest/layout
+  verification, and a receipt;
+- prove that preview and execution perform no network acquisition and do not mutate catalog,
+  selection, plan, proposal, Fill, placement, or archive-copy evidence.
+
+Local USB scratch and R2 scratch follow only after the journal, verifier, and receipt are stable.
+Archive Reshape follows as a separate transaction after the materialization core is proven.
+
+## Acceptance gates
+
+- Every executable preview has a qualifying archived source for every closure file.
+- Catalog-only and cache-only fixtures produce exact blocking gaps and zero remote fetch attempts.
+- Offline qualifying sources produce attended drive requests and resume without replanning completed
+  work.
+- Approval and Start are separate; drift cannot silently substitute a source or destination.
+- Interrupted transfers resume from durable checkpoints and never publish an unverified receipt.
+- Destination verification covers both content and the chosen consumer layout.
+- A completed receipt cannot satisfy ModelArk replica policy or mutate archive placement.
+- Existing Fill behavior and a running approved Fill remain untouched.
+
+## Independent Spark catalog lane
+
+DGXSpark recipes and caches are discovery inputs. The separate lane freezes a named Spark profile,
+discovers missing repositories, reviews selection, and archives approved artifacts through normal
+ModelArk planning and Fill. Only after those artifacts carry sufficient archive evidence may a
+Usable Slice include them.
+
+This separation allows catalog work to follow fast-changing weights and recipes without changing
+the delivery contract or making the first slice depend on content ModelArk does not yet protect.
+
+## Explicitly deferred
+
+- hydrate-then-materialize composition (DEF-043);
+- local USB and R2 scratch adapters beyond their stable interfaces;
+- Archive Reshape authority and physical reclamation;
+- P2P transport and trust policy;
+- multiple consumer profiles and automatic destination preparation;
+- treating any delivery or scratch copy as archive durability evidence.
+
+## Safe stopping point
+
+This charter and its ledger decisions are the stopping point. No implementation, live deployment,
+service restart, Fill action, catalog expansion, or archive/destination byte movement is part of
+this change. The next implementation session starts with domain contracts and expected-red tests
+for eligibility, exact gap reporting, and the sealed direct-USB transaction.

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -2,7 +2,7 @@
 
 Status: architecture locked; implementation has not started  
 Updated: 2026-09-06  
-Decision anchors: DEC-081, DEC-098, BOT-006, DEC-101, DEC-102, DEF-041, DEF-043
+Decision anchors: DEC-081, DEC-098, BOT-006, DEC-101, DEC-102, DEC-103, DEF-041, DEF-043
 
 ## Outcome
 
@@ -42,9 +42,10 @@ Eligibility is evaluated for every file in the frozen closure, not merely for ev
 
 A file is **source-ready** when ModelArk can resolve at least one archive copy with the required
 artifact identity, content digest, provenance evidence, stable physical drive identity, and an
-active lifecycle state. Lost, excluded, retired, or otherwise inactive drives retain historical
-evidence but cannot satisfy slice recoverability. The eligible drive does not need to be attached
-during preview.
+active lifecycle state. Lost, retired, or otherwise inactive drives retain historical evidence but
+cannot satisfy slice recoverability. Placement eligibility is separate: an `active + excluded`
+drive remains a valid read source if its other evidence qualifies; exclusion only forbids new
+archive placement. The eligible drive does not need to be attached during preview.
 
 Qualifying residency requires both the per-file archive/provenance record and a clean anchor for
 the drive's exact current identity epoch and write generation, with matching identity fingerprint
@@ -76,14 +77,19 @@ Never add a newly discovered source to an approved seal. Source changes do not r
 digest-verified checkpoints or retrospectively invalidate their recorded provenance; final
 destination verification remains mandatory. Before the first write, unexplained capacity drift
 invalidates the seal. After execution starts, remaining-capacity checks account for the
-transaction's own journaled writes and
-invalidate only unexplained external consumption or mutation.
+transaction's own journaled writes and invalidate only unexplained external consumption or mutation.
 
 ## Filesystem and device safety
 
-Every source and output path must pass lexical and resolved confinement before it enters a sealed
-closure or transfer plan. Reject absolute paths, parent traversal, platform-separator ambiguity,
-NULs, and any destination ancestor or symlink that escapes the approved root. Source reads use the
+Every source and output path must pass lexical confinement before it enters a sealed closure or
+transfer plan. Reject absolute paths, parent traversal, platform-separator ambiguity, and NULs.
+For offline sources, seal the safe relative catalog path and proven archive identity without
+resolving an unavailable filesystem. On attachment, under the source fence and before each read,
+prove device identity and descriptor-relative confinement, including annex link targets; reject
+escaping symlinks and mount substitutions without a check/open race. Attached source observations
+at preview do not replace this execution check. Destination paths additionally require resolved
+confinement of their existing ancestors at preview/Start and bound descriptor access during writes;
+reject any ancestor or symlink that escapes the approved root. Source reads use the
 archive's local annex evidence but require a retrieval-disabled reader: it may resolve and read
 locally present annex content but must never run `git annex get`, contact a configured remote, or
 mutate the source archive. Missing local content makes that candidate unavailable; execution uses
@@ -144,11 +150,23 @@ Start. Journal records bind the seal, destination identity, relative path, opera
 expected digest/size, and transaction-owned temporary name. Names or matching hashes alone never
 establish ownership of unrelated existing content.
 
+Each file's prepared/completed record also binds the actual sealed source candidate read: archive
+drive identity, identity epoch, write generation, clean-anchor reference, annex/artifact identity,
+and per-file provenance/digest evidence observed under the source fence. A fallback records the
+chosen alternative, not merely the candidate list. Completion references the durable prepared
+record, and the final receipt carries these actual per-file sources alongside the approved source
+set. Later lifecycle changes cannot rewrite that history. Incomplete data with no authenticated
+source record cannot become completion merely by matching a digest; restart that file from a
+currently qualifying sealed source or block.
+
 Each directory creation, file publication, and receipt publication follows a recoverable protocol:
 
 1. Durably append an intent before creating a transaction-owned path. Create directories and
    temporary files exclusively through the bound destination descriptor; record parent/child
-   ownership, including creation of the consumer root. Unexpected content is a collision.
+   ownership, including creation of the consumer root. For every new directory, flush its metadata
+   and its entry in the parent directory, then durably append directory completion before creating
+   children. Apply this to the private state/control directories as well as the consumer layout;
+   the pre-existing destination root is the durability boundary. Unexpected content is a collision.
 2. Stream into the owned temporary file, verify the required original-byte digest and size, flush
    the file, and durably record its prepared state. Journal in-flight allocation as well as completed
    files so crash recovery can reconcile the transaction's own capacity consumption.
@@ -273,6 +291,8 @@ Archive Reshape follows as a separate transaction after the materialization core
 - Catalog-only and cache-only fixtures produce exact blocking gaps and zero remote fetch attempts.
 - A fixture whose only historical archive row belongs to a lost or inactive drive produces a
   blocking gap rather than an impossible drive request.
+- An otherwise qualifying `active + excluded` drive remains an executable read source, mounted or
+  offline. Toggling placement eligibility alone neither invalidates the slice nor blocks reads.
 - Dirty, missing-anchor, old-epoch, old-generation, and mismatched-fingerprint sources cannot
   establish readiness from retained archive rows; a clean alternate may qualify. A capacity anchor
   without qualifying per-file provenance is insufficient. No source check repairs the archive.
@@ -281,7 +301,8 @@ Archive Reshape follows as a separate transaction after the materialization core
   with no new source approval, implicit fetch, or successor adoption. Source-fence contention waits
   without interrupting Fill. Source digest mismatch never produces a completed checkpoint.
 - Offline qualifying sources produce attended drive requests and resume without replanning completed
-  work.
+  work. Preview never resolves paths on an offline source; attachment performs confined descriptor
+  resolution before reads and rejects escaping annex links or replaced mounts.
 - Closure identity is the immutable per-file manifest and digests; absent historical commit SHAs are
   never synthesized from a current remote lookup.
 - Approval and Start are separate; drift cannot silently substitute a source or destination.
@@ -298,7 +319,11 @@ Archive Reshape follows as a separate transaction after the materialization core
 - Fault injection covers intent persistence, directory/root creation, partial temporary writes,
   file flush, prepared record, no-replace publication, directory flush, completion append, and
   receipt publication. Recovery recognizes only owned intents, revalidates bytes, accounts for
-  temporary allocations, and rejects unknown content even when its digest matches.
+  temporary allocations, and rejects unknown content even when its digest matches. Inject failure
+  before/after each new directory's parent flush and completion append, including consumer-root
+  and state/control-directory creation; no durable receipt may depend on uncommitted directory entries.
+- Sealed-alternative fallback followed by stop/resume and a source lifecycle change retains the
+  actual per-file source identity, epoch/generation, anchor, and provenance in checkpoints and receipt.
 - Concurrent/retried Start, different roots or aliases on one device, a crashed owner, and a
   surviving child prove at most one writer. Stopped ownership cannot be stolen by another seal;
   failed partial acquisition is recoverable and a duplicate Start is idempotent.


### PR DESCRIPTION
Usable Slice delivers an immutable set of already-archived artifacts to a verified destination. Catalog-only and cache-only artifacts produce exact blocking gaps; qualifying offline archive drives produce attended attachment requests. Spark discovery and normal catalog/Fill acquisition remain separate.

The charter defines source eligibility, per-use lifecycle and residency checks, exclusive destination ownership, recoverable file/checkpoint publication, and device-bound writes across unplug and resume. Verified progress stays with the approved transaction when a source becomes unavailable. Offline path resolution happens after attachment; active drives excluded from placement remain readable; directory durability and actual per-file source provenance are explicit. DEC-101 through DEC-103 record these boundaries; BOT-006 and DEF-043 preserve the acquisition/delivery distinction.

Development is sequenced as domain contracts, transaction recovery, then a small direct-USB integration, using disposable fixtures before an attended real-device trial. This PR changes documentation only; production implementation and live runtime actions are outside its scope.

Validation at `0502aa3`: `git diff --check` and all 21 existing lifecycle matrix tests pass. Python 3.10/3.12 CI and browser E2E pass. Greptile approves at 5/5; Codex completed with no new findings. All review threads are resolved. Ready for operator merge, followed by the domain-contract development slice.
