### PR TITLE
feat: add archive-only Usable Slice domain core

### DIFF
--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2574,3 +2574,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Narrows only the Slice 1 fallback, with positive foreign-format and negative incomplete-manifest contracts. Existing restore behavior, acquisition policy, durable copy provenance, and live runtime are unchanged.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-domain.md
 - `related`: DEC-101, DEC-104, DEC-105, modelark/slice/catalog.py
+
+### DEC-107: Recognize exact legacy foreign-weight extensions without reclassifying the catalog
+- `id`: DEC-107
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: PR #68 review of `f3a2705`, confirmed against `tests/test_def033_gate1_contracts.py`'s legacy `model.onnx` row tagged `other` and four failing adapter regressions.
+- `decision`: Extend DEC-106's positive ONNX/MLX evidence to exact `.onnx`, `.npz`, and `.npy` extensions when catalog format is `other` or NULL. Preserve original catalog annotations and the full declared fallback scope. Do not infer weight evidence from directory/stem heuristics or generic `other` classification.
+- `rationale`: Durable legacy copies may predate format classification. Exact recognized extensions recover that compatibility without reintroducing auxiliary-only approval through names such as `mlx/config.json` or `model.onnx.json`.
+- `impact`: Slice 1 reader and positive/negative fallback contracts only; no catalog mutation, acquisition change, or live archive access.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-domain.md
+- `related`: DEC-105, DEC-106, tests/test_def033_gate1_contracts.py

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2563,3 +2563,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Completes Slice 1 compatibility tests for non-annex/other-backend copies, durable Hub provenance, and ONNX/MLX/other archived artifacts with partial and absent copies. No acquisition policy, schema, execution authority, or live archive changes.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-domain.md
 - `related`: DEC-053, DEC-101, DEC-103, DEC-104, DEF-041
+
+### DEC-106: Require positive weight-format evidence for slice manifest fallback
+- `id`: DEC-106
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: PR #68's review of `77615f4` and four failing regression cases showing auxiliary-only, index-only, unknown, and unclassified repositories becoming source-ready.
+- `decision`: Refine DEC-105's fallback eligibility: require catalog rows positively classified as ONNX or MLX weights, the recognized weight formats outside the acquisition selector. For eligible repositories, continue freezing every declared file to retain exact gaps. Otherwise retain the blocking `MANIFEST_UNAVAILABLE` error even if remaining rows have proven archive copies.
+- `rationale`: A shared acquisition-policy exception does not distinguish recoverable foreign weights from missing weight metadata. Generic `other` classification cannot establish a repository manifest. Copy-level provenance remains valid but cannot by itself prove repository scope.
+- `impact`: Narrows only the Slice 1 fallback, with positive foreign-format and negative incomplete-manifest contracts. Existing restore behavior, acquisition policy, durable copy provenance, and live runtime are unchanged.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-domain.md
+- `related`: DEC-101, DEC-104, DEC-105, modelark/slice/catalog.py

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2541,3 +2541,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Corrects the charter's excluded-source and offline-resolution wording and completes its directory-durability and per-file provenance contracts. Adds acceptance cases within the existing three development slices; no production or runtime change.
 - `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md
 - `related`: DEC-081, DEC-101, DEC-102, DEF-041, tests/test_lifecycle_eligibility.py
+
+### DEC-104: Implement the slice domain as an internal immutable proposal boundary
+- `id`: DEC-104
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: Operator authorization to implement Slice 1 after PR #67 merged at `c371884`.
+- `decision`: Introduce `modelark.slice.domain` with frozen catalog/source facts, exact per-file gaps, deterministic closure and alternatives, a versioned canonical domain seal, and explicit pure approval validation. Introduce `modelark.slice.catalog` as an explicit-path, schema-v7, read-only transactional reader using the established recovery manifest. Keep `execution_ready` false and approval tagged `domain` until later slices add hardware preflight and durable execution authority. Raw SHA256 annex keys may independently establish original-byte digest evidence without modifying stored provenance; compressed keys may not.
+- `rationale`: The first implementation should prove archive eligibility and immutable intent without exposing half-implemented execution or coupling domain tests to the live portal. Separate source evidence retains the distinction between original-byte provenance, clean residency, and later physical verification. A dedicated read-only snapshot prevents global catalog configuration changes and mixed evidence during concurrent Fill commits.
+- `impact`: Adds the internal Slice 1 package, focused domain/catalog tests, and API documentation. Durable state, CAS/ownership, source-use recovery, filesystem preflight, CLI/portal integration, byte transfer, and real-device trials remain in their accepted later slices. Existing Fill behavior and catalog schema are unchanged.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-domain.md, docs/plans/usable-slice-implementation-charter.md
+- `related`: DEC-081, DEC-101, DEC-102, DEC-103, DEF-041

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2552,3 +2552,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Adds the internal Slice 1 package, focused domain/catalog tests, and API documentation. Durable state, CAS/ownership, source-use recovery, filesystem preflight, CLI/portal integration, byte transfer, and real-device trials remain in their accepted later slices. Existing Fill behavior and catalog schema are unchanged.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-domain.md, docs/plans/usable-slice-implementation-charter.md
 - `related`: DEC-081, DEC-101, DEC-102, DEC-103, DEF-041
+
+### DEC-105: Preserve proven legacy slice sources without suppressing catalog gaps
+- `id`: DEC-105
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: PR #68's completed review of `24db4f3`, checked against `restore.restore_repo`, the non-annex fetch path, and the durable original-digest provenance contract.
+- `decision`: A safe stored path on a clean, proven drive may qualify through its durable original-byte digest/provenance without a current SHA256 annex key or current catalog digest. Use raw SHA256 annex keys as independent digest evidence when available; compressed object keys never replace original-byte evidence. If the acquisition manifest cannot describe a foreign/legacy repository, freeze all its declared catalog files as the slice recovery scope and evaluate each for archive evidence.
+- `rationale`: Acquisition format policy and current storage backend must not strand previously accepted, provable archive bytes. Restore's archived-only fallback cannot be copied literally into a gap-reporting preview because it could silently omit declared but unarchived files. The full declared fallback preserves both recovery compatibility and exact missing-file reporting.
+- `impact`: Completes Slice 1 compatibility tests for non-annex/other-backend copies, durable Hub provenance, and ONNX/MLX/other archived artifacts with partial and absent copies. No acquisition policy, schema, execution authority, or live archive changes.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-domain.md
+- `related`: DEC-053, DEC-101, DEC-103, DEC-104, DEF-041

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -1,8 +1,10 @@
 # Usable Slice implementation charter
 
-Status: architecture locked; implementation has not started  
-Updated: 2026-09-06  
-Decision anchors: DEC-081, DEC-098, BOT-006, DEC-101, DEC-102, DEC-103, DEF-041, DEF-043
+Status: architecture locked; Slice 1 domain implementation under review
+
+Updated: 2026-09-07
+
+Decision anchors: DEC-081, DEC-098, BOT-006, DEC-101, DEC-102, DEC-103, DEC-104, DEF-041, DEF-043
 
 ## Outcome
 
@@ -363,6 +365,10 @@ this change. The next implementation session starts with domain contracts and ex
 for eligibility, exact gap reporting, and the sealed direct-USB transaction.
 
 ## Development entry and review slices
+
+Slice 1's internal API and limits are documented in [Usable Slice domain](../usable-slice-domain.md).
+Its domain approval binds intent and archive evidence; execution readiness stays false until the
+later hardware preflight and durable ownership contracts are implemented.
 
 Finish PR #67's renewed bounded review (up to three iterations) at its exact pushed head and let the
 operator merge it. Then branch from that merged charter for implementation. The first test commit

--- a/docs/usable-slice-domain.md
+++ b/docs/usable-slice-domain.md
@@ -34,9 +34,12 @@ They must never treat this domain artifact alone as permission to write.
 
 `hf-tree-v1` freezes the existing recovery manifest with repository-relative paths, sizes, original
 SHA-256 digests, and format/quant metadata. It is a layout profile, not a functional model-loading
-claim. If current acquisition formats cannot describe a foreign/legacy repository, its full
-declared catalog file set becomes the recovery scope; this retains declared-but-unarchived gaps
-instead of reducing the closure to the subset already archived. No acquisition policy is changed.
+claim. If current acquisition formats cannot describe a repository with positively classified
+ONNX/MLX weights, its full declared catalog file set becomes the recovery scope; this retains
+declared-but-unarchived gaps instead of reducing the closure to the subset already archived.
+A manifest error alone is not legacy-format evidence: auxiliary-only repositories and unknown
+or unclassified `other` formats retain a blocking `MANIFEST_UNAVAILABLE` gap. No acquisition policy
+is changed.
 Catalog-only files yield exact gaps. Missing file sizes stay unknown instead of becoming
 zero. A missing catalog digest may be supplied by unambiguous qualifying archive evidence; a
 missing repository commit SHA is never inferred from a remote head.

--- a/docs/usable-slice-domain.md
+++ b/docs/usable-slice-domain.md
@@ -34,12 +34,14 @@ They must never treat this domain artifact alone as permission to write.
 
 `hf-tree-v1` freezes the existing recovery manifest with repository-relative paths, sizes, original
 SHA-256 digests, and format/quant metadata. It is a layout profile, not a functional model-loading
-claim. If current acquisition formats cannot describe a repository with positively classified
-ONNX/MLX weights, its full declared catalog file set becomes the recovery scope; this retains
+claim. If current acquisition formats cannot describe a repository with positive ONNX/MLX weight
+evidence, its full declared catalog file set becomes the recovery scope; this retains
 declared-but-unarchived gaps instead of reducing the closure to the subset already archived.
-A manifest error alone is not legacy-format evidence: auxiliary-only repositories and unknown
-or unclassified `other` formats retain a blocking `MANIFEST_UNAVAILABLE` gap. No acquisition policy
-is changed.
+A manifest error alone is not legacy-format evidence. Accept ONNX/MLX catalog classification or,
+for legacy `other`/NULL classifications, exact `.onnx`, `.npz`, or `.npy` filename extensions.
+Directory names and prefixes are not weight evidence. Auxiliary-only repositories and unknown
+formats without that evidence retain a blocking `MANIFEST_UNAVAILABLE` gap. Catalog annotations
+are preserved, not rewritten. No acquisition policy is changed.
 Catalog-only files yield exact gaps. Missing file sizes stay unknown instead of becoming
 zero. A missing catalog digest may be supplied by unambiguous qualifying archive evidence; a
 missing repository commit SHA is never inferred from a remote head.

--- a/docs/usable-slice-domain.md
+++ b/docs/usable-slice-domain.md
@@ -34,7 +34,10 @@ They must never treat this domain artifact alone as permission to write.
 
 `hf-tree-v1` freezes the existing recovery manifest with repository-relative paths, sizes, original
 SHA-256 digests, and format/quant metadata. It is a layout profile, not a functional model-loading
-claim. Catalog-only files yield exact gaps. Missing file sizes stay unknown instead of becoming
+claim. If current acquisition formats cannot describe a foreign/legacy repository, its full
+declared catalog file set becomes the recovery scope; this retains declared-but-unarchived gaps
+instead of reducing the closure to the subset already archived. No acquisition policy is changed.
+Catalog-only files yield exact gaps. Missing file sizes stay unknown instead of becoming
 zero. A missing catalog digest may be supplied by unambiguous qualifying archive evidence; a
 missing repository commit SHA is never inferred from a remote head.
 
@@ -43,10 +46,15 @@ digest evidence used. Identity follows the existing reconciliation contract: at 
 filesystem or annex UUID, with every recorded UUID bound by the matching fingerprint and epoch;
 a serial alone is insufficient. Lifecycle-active excluded drives remain readable. Dirty/unanchored,
 lost/retired, explicitly absent, identity-mismatched, or conflicting copies cannot satisfy a file.
-Replica metadata alone is insufficient. For raw SHA256 annex objects, the key is independent
+Replica metadata alone is insufficient. A safe stored path on the proven drive may qualify using
+a valid original digest with durable `hub_confirmed`, `ingestion_computed`, `annex_key`, or
+`archive-head-blob` provenance even if its current annex key is absent or uses another backend.
+Durable original-byte provenance does not disappear when current catalog metadata omits its digest.
+For raw SHA256 annex objects, the key is independent
 original-byte evidence, even when the stored provenance is absent; the derived proof is recorded
 in the proposal without repairing the catalog. A compressed object's annex hash cannot stand in
-for its original-byte digest. Multiple qualifying but disagreeing originals block closure when
+for its original-byte digest; a separately recorded original digest with durable provenance still
+qualifies. Multiple qualifying but disagreeing originals block closure when
 the catalog does not disambiguate them.
 
 Offline sources need no filesystem access at this stage. Preview validates lexical paths; source

--- a/docs/usable-slice-domain.md
+++ b/docs/usable-slice-domain.md
@@ -39,7 +39,9 @@ zero. A missing catalog digest may be supplied by unambiguous qualifying archive
 missing repository commit SHA is never inferred from a remote head.
 
 Each source carries its recorded copy, physical identity, exact current clean anchor, and the
-digest evidence used. Lifecycle-active excluded drives remain readable. Dirty/unanchored,
+digest evidence used. Identity follows the existing reconciliation contract: at least one proven
+filesystem or annex UUID, with every recorded UUID bound by the matching fingerprint and epoch;
+a serial alone is insufficient. Lifecycle-active excluded drives remain readable. Dirty/unanchored,
 lost/retired, explicitly absent, identity-mismatched, or conflicting copies cannot satisfy a file.
 Replica metadata alone is insufficient. For raw SHA256 annex objects, the key is independent
 original-byte evidence, even when the stored provenance is absent; the derived proof is recorded
@@ -56,7 +58,10 @@ the globally configured catalog connector nor creates/migrates a missing/older d
 
 Canonical JSON is versioned as `modelark.slice.domain.v1` and hashed with SHA-256. Ordering of input
 facts does not affect the result. The seal binds the spec, relevant catalog snapshot content and
-identity, exact closure, alternatives, and gaps. `approve` detects tampering, rejects blocked
+identity, exact closure, alternatives, and gaps. Only requested manifests, their recorded source
+candidates, and those candidates' current drive/anchor facts affect approval freshness. Unrelated
+fleet activity and historical anchors do not. Placement eligibility is retained as captured
+annotation but excluded from read-source seal authority. `approve` detects tampering, rejects blocked
 proposals and mismatched reviewed seals, and rederives against freshly supplied evidence to reject
 stale proposals. The hash detects accidental modification; it is not a signature or an untrusted
 client's authorization credential. Durable concurrency control belongs to Slice 2.

--- a/docs/usable-slice-domain.md
+++ b/docs/usable-slice-domain.md
@@ -1,0 +1,72 @@
+# Usable Slice domain API
+
+Slice 1 implements an internal, pure proposal contract and an explicit read-only catalog reader.
+There is no CLI, portal endpoint, hardware preflight, state store, Start, or byte-transfer path.
+The accepted implementation sequence is in [the charter](plans/usable-slice-implementation-charter.md).
+
+```python
+from modelark.slice.catalog import read_catalog
+from modelark.slice.domain import SliceSpec, approve, preview, validate_approval
+
+spec = SliceSpec(
+    repo_ids=("organization/model",),
+    destination_id="operator-selected-usb-identity",
+    destination_root="models",
+)
+snapshot = read_catalog("/explicit/path/catalog.sqlite", spec)
+proposal = preview(spec, snapshot)
+# Present proposal.closure, proposal.gaps, proposal.required_drives and proposal.seal for review.
+# After explicit approval, supply the seal the operator actually reviewed and a fresh snapshot:
+approval = approve(
+    proposal,
+    expected_seal=proposal.seal,
+    current_snapshot=read_catalog("/explicit/path/catalog.sqlite", spec),
+)
+validate_approval(proposal, approval)
+```
+
+The example illustrates the internal call sequence, not an automatic-approval workflow. Callers
+must obtain operator intent before `approve`. Pure approval is a value transformation: it cannot
+authenticate a client, persist ownership, perform a CAS, or start work. `SliceApproval.stage` is
+`domain`; `SlicePreview.execution_ready` is always false. Later slices must seal the actual
+destination preflight and persist execution authority before a real transfer can be approved.
+They must never treat this domain artifact alone as permission to write.
+
+`hf-tree-v1` freezes the existing recovery manifest with repository-relative paths, sizes, original
+SHA-256 digests, and format/quant metadata. It is a layout profile, not a functional model-loading
+claim. Catalog-only files yield exact gaps. Missing file sizes stay unknown instead of becoming
+zero. A missing catalog digest may be supplied by unambiguous qualifying archive evidence; a
+missing repository commit SHA is never inferred from a remote head.
+
+Each source carries its recorded copy, physical identity, exact current clean anchor, and the
+digest evidence used. Lifecycle-active excluded drives remain readable. Dirty/unanchored,
+lost/retired, explicitly absent, identity-mismatched, or conflicting copies cannot satisfy a file.
+Replica metadata alone is insufficient. For raw SHA256 annex objects, the key is independent
+original-byte evidence, even when the stored provenance is absent; the derived proof is recorded
+in the proposal without repairing the catalog. A compressed object's annex hash cannot stand in
+for its original-byte digest. Multiple qualifying but disagreeing originals block closure when
+the catalog does not disambiguate them.
+
+Offline sources need no filesystem access at this stage. Preview validates lexical paths; source
+attachment, descriptor confinement, and digest verification are execution requirements. The domain
+core accepts immutable facts and performs no SQL, filesystem operations, subprocesses, or network
+access. The catalog adapter opens only the explicitly supplied SQLite path with `mode=ro` and
+`query_only`, reads schema v7 in one transaction, and closes it on every exit. It neither calls
+the globally configured catalog connector nor creates/migrates a missing/older database.
+
+Canonical JSON is versioned as `modelark.slice.domain.v1` and hashed with SHA-256. Ordering of input
+facts does not affect the result. The seal binds the spec, relevant catalog snapshot content and
+identity, exact closure, alternatives, and gaps. `approve` detects tampering, rejects blocked
+proposals and mismatched reviewed seals, and rederives against freshly supplied evidence to reject
+stale proposals. The hash detects accidental modification; it is not a signature or an untrusted
+client's authorization credential. Durable concurrency control belongs to Slice 2.
+
+`source_ready` means every frozen manifest file has a qualifying source. On a blocked preview,
+`closure` and `total_bytes` contain only resolved files; they are not the total requested size.
+`required_drives` is the deterministic preferred-source schedule, with all approved alternatives
+retained on each artifact. `validate_approval` checks the original immutable pair and does not
+replan it when a source later changes: execution must apply the charter's per-use source gates.
+
+Validation uses synthetic evidence and disposable SQLite databases. The concurrent-WAL test proves
+that a committing writer does not mix catalog generations inside a preview, and that the reader
+refuses writes. No test or development action needs a live archive or USB destination.

--- a/modelark/slice/__init__.py
+++ b/modelark/slice/__init__.py
@@ -1,0 +1,1 @@
+"""Internal Usable Slice domain API. No CLI, hardware adapter, or execution authority yet."""

--- a/modelark/slice/catalog.py
+++ b/modelark/slice/catalog.py
@@ -36,7 +36,11 @@ def read_catalog(path: str | Path, spec: SliceSpec) -> CatalogSnapshot:
             # Like restore, acquisition policy must not strand foreign/legacy archive bytes.
             # Unlike restore's archived-only fallback, retain every declared catalog file so
             # a partially archived foreign repository produces exact gaps instead of shrinking.
-            fallback_repos = {row[0] for row in rows if row[0] in manifests.errors}
+            # A policy error is not itself proof of a legacy weight manifest. ONNX/MLX
+            # are recognized catalog weight formats outside acquisition's selector;
+            # auxiliary-only, unknown, and unclassified "other" data must stay blocked.
+            fallback_repos = {row[0] for row in rows
+                              if row[0] in manifests.errors and row[4] in {"onnx", "mlx"}}
             names.update((row[0], row[1]) for row in rows if row[0] in fallback_repos)
             files.extend(FileFact(*row) for row in rows if (row[0], row[1]) in names)
             issues.extend(Gap(repo, None, "MANIFEST_UNAVAILABLE", detail=str(error))

--- a/modelark/slice/catalog.py
+++ b/modelark/slice/catalog.py
@@ -1,0 +1,69 @@
+"""One explicit, read-only SQLite snapshot for a Usable Slice domain proposal.
+
+Never configures the global catalog, bootstraps schemas, resolves source paths, calls annex,
+or acquires archive mutation fences. Mount availability is deliberately not a catalog fact.
+"""
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+import sqlite3
+
+from modelark import archive_manifest
+from .domain import AnchorFact, CatalogSnapshot, CopyFact, DriveFact, FileFact, Gap, SliceRefusal, SliceSpec
+
+
+def read_catalog(path: str | Path, spec: SliceSpec) -> CatalogSnapshot:
+    catalog = Path(path).expanduser().resolve()
+    con = None
+    try:
+        con = sqlite3.connect(f"{catalog.as_uri()}?mode=ro", uri=True, isolation_level=None)
+        con.execute("PRAGMA query_only=ON")
+        con.execute("BEGIN")
+        version = con.execute("PRAGMA user_version").fetchone()[0]
+        if version != 7:
+            raise SliceRefusal("CATALOG_VERSION_UNSUPPORTED", f"expected 7, observed {version}")
+        files, copies, issues = [], [], []
+        # Bounded batches avoid SQLite's variable limit for large explicit subsections.
+        for start in range(0, len(spec.repo_ids), 400):
+            repos = spec.repo_ids[start:start + 400]
+            marks = ",".join("?" for _ in repos)
+            rows = con.execute(
+                "SELECT repo_id,rfilename,size_bytes,sha256,format,quant FROM files "
+                f"WHERE repo_id IN ({marks})", repos).fetchall()
+            manifests = archive_manifest.inspect_manifests_for_repos(
+                con, repos, archive_manifest.recovery_policy())
+            names = {(repo, f.rfilename) for repo, manifest in manifests.manifests.items() for f in manifest}
+            files.extend(FileFact(*row) for row in rows if (row[0], row[1]) in names)
+            issues.extend(Gap(repo, None, "MANIFEST_UNAVAILABLE", detail=str(error))
+                          for repo, error in manifests.errors.items())
+            rows = con.execute(
+                "SELECT a.repo_id,a.rfilename,a.drive_label,a.stored_relpath,a.stored_name,"
+                "a.orig_bytes,a.stored_bytes,a.orig_sha256,a.orig_sha256_provenance,a.annex_key,"
+                "a.compressed,r.present FROM archived a LEFT JOIN replicas r "
+                "ON r.repo_id=a.repo_id AND r.rfilename=a.rfilename AND r.drive_label=a.drive_label "
+                f"WHERE a.repo_id IN ({marks})", repos).fetchall()
+            for repo, name, label, rel, legacy, orig_size, stored_size, digest, provenance, key, compressed, present in rows:
+                if (repo, name) not in names:
+                    continue
+                # Match existing restore's legacy basename layout, without touching its source adapter.
+                if rel is None and legacy:
+                    rel = str(PurePosixPath(name).parent / legacy)
+                copies.append(CopyFact(repo, name, label, rel, orig_size, stored_size, digest,
+                                       provenance, key, bool(compressed),
+                                       None if present is None else bool(present)))
+        drives = tuple(DriveFact(*row) for row in con.execute(
+            "SELECT drive_label,fs_uuid,annex_uuid,serial,identity_epoch,write_generation,"
+            "identity_fingerprint,filesystem_capacity_bytes,write_authority,lifecycle,eligibility "
+            "FROM drives"))
+        anchors = tuple(AnchorFact(*row[:-1], str(row[-1])) for row in con.execute(
+            "SELECT a.drive_label,a.identity_epoch,a.generation,a.identity_fingerprint,"
+            "a.filesystem_capacity_bytes,a.write_authority,a.anchor_id FROM drive_clean_anchors a "
+            "JOIN drives d ON d.drive_label=a.drive_label AND d.identity_epoch=a.identity_epoch "
+            "AND d.write_generation=a.generation"))
+        return CatalogSnapshot(catalog.as_uri(), tuple(files), tuple(copies), drives, anchors,
+                               tuple(issues), version)
+    except sqlite3.Error as exc:
+        raise SliceRefusal("CATALOG_UNAVAILABLE", str(exc)) from exc
+    finally:
+        if con is not None:
+            con.close()  # Rolls back the read transaction, including on schema/query failure.

--- a/modelark/slice/catalog.py
+++ b/modelark/slice/catalog.py
@@ -51,15 +51,16 @@ def read_catalog(path: str | Path, spec: SliceSpec) -> CatalogSnapshot:
                 copies.append(CopyFact(repo, name, label, rel, orig_size, stored_size, digest,
                                        provenance, key, bool(compressed),
                                        None if present is None else bool(present)))
+        labels = {copy.drive_label for copy in copies}
         drives = tuple(DriveFact(*row) for row in con.execute(
             "SELECT drive_label,fs_uuid,annex_uuid,serial,identity_epoch,write_generation,"
             "identity_fingerprint,filesystem_capacity_bytes,write_authority,lifecycle,eligibility "
-            "FROM drives"))
+            "FROM drives") if row[0] in labels)
         anchors = tuple(AnchorFact(*row[:-1], str(row[-1])) for row in con.execute(
             "SELECT a.drive_label,a.identity_epoch,a.generation,a.identity_fingerprint,"
             "a.filesystem_capacity_bytes,a.write_authority,a.anchor_id FROM drive_clean_anchors a "
             "JOIN drives d ON d.drive_label=a.drive_label AND d.identity_epoch=a.identity_epoch "
-            "AND d.write_generation=a.generation"))
+            "AND d.write_generation=a.generation") if row[0] in labels)
         return CatalogSnapshot(catalog.as_uri(), tuple(files), tuple(copies), drives, anchors,
                                tuple(issues), version)
     except sqlite3.Error as exc:

--- a/modelark/slice/catalog.py
+++ b/modelark/slice/catalog.py
@@ -33,9 +33,14 @@ def read_catalog(path: str | Path, spec: SliceSpec) -> CatalogSnapshot:
             manifests = archive_manifest.inspect_manifests_for_repos(
                 con, repos, archive_manifest.recovery_policy())
             names = {(repo, f.rfilename) for repo, manifest in manifests.manifests.items() for f in manifest}
+            # Like restore, acquisition policy must not strand foreign/legacy archive bytes.
+            # Unlike restore's archived-only fallback, retain every declared catalog file so
+            # a partially archived foreign repository produces exact gaps instead of shrinking.
+            fallback_repos = {row[0] for row in rows if row[0] in manifests.errors}
+            names.update((row[0], row[1]) for row in rows if row[0] in fallback_repos)
             files.extend(FileFact(*row) for row in rows if (row[0], row[1]) in names)
             issues.extend(Gap(repo, None, "MANIFEST_UNAVAILABLE", detail=str(error))
-                          for repo, error in manifests.errors.items())
+                          for repo, error in manifests.errors.items() if repo not in fallback_repos)
             rows = con.execute(
                 "SELECT a.repo_id,a.rfilename,a.drive_label,a.stored_relpath,a.stored_name,"
                 "a.orig_bytes,a.stored_bytes,a.orig_sha256,a.orig_sha256_provenance,a.annex_key,"

--- a/modelark/slice/catalog.py
+++ b/modelark/slice/catalog.py
@@ -12,6 +12,13 @@ from modelark import archive_manifest
 from .domain import AnchorFact, CatalogSnapshot, CopyFact, DriveFact, FileFact, Gap, SliceRefusal, SliceSpec
 
 
+def _foreign_weight(name: str, format: str | None) -> bool:
+    # Legacy catalogs may predate classification. Use exact weight extensions, not
+    # directory/stem heuristics that would also label e.g. mlx/config.json as weights.
+    return (format in {"onnx", "mlx"}
+            or (format in {None, "other"} and name.lower().endswith((".onnx", ".npz", ".npy"))))
+
+
 def read_catalog(path: str | Path, spec: SliceSpec) -> CatalogSnapshot:
     catalog = Path(path).expanduser().resolve()
     con = None
@@ -37,10 +44,10 @@ def read_catalog(path: str | Path, spec: SliceSpec) -> CatalogSnapshot:
             # Unlike restore's archived-only fallback, retain every declared catalog file so
             # a partially archived foreign repository produces exact gaps instead of shrinking.
             # A policy error is not itself proof of a legacy weight manifest. ONNX/MLX
-            # are recognized catalog weight formats outside acquisition's selector;
-            # auxiliary-only, unknown, and unclassified "other" data must stay blocked.
+            # are recognized weight formats outside acquisition's selector. Legacy
+            # extension evidence may qualify; auxiliary-only/unknown data stays blocked.
             fallback_repos = {row[0] for row in rows
-                              if row[0] in manifests.errors and row[4] in {"onnx", "mlx"}}
+                              if row[0] in manifests.errors and _foreign_weight(row[1], row[4])}
             names.update((row[0], row[1]) for row in rows if row[0] in fallback_repos)
             files.extend(FileFact(*row) for row in rows if (row[0], row[1]) in names)
             issues.extend(Gap(repo, None, "MANIFEST_UNAVAILABLE", detail=str(error))

--- a/modelark/slice/domain.py
+++ b/modelark/slice/domain.py
@@ -217,6 +217,10 @@ class SlicePreview:
     def canonical_bytes(self) -> bytes:
         payload = asdict(self)
         del payload["seal"]
+        for item in payload["closure"]:
+            for source in item["sources"]:
+                # Placement eligibility is captured annotation, never read-source authority.
+                del source["drive"]["eligibility"]
         return _json(payload)
 
 
@@ -237,6 +241,26 @@ def _index(items, key):
     return result
 
 
+def _scope(snapshot: CatalogSnapshot, spec: SliceSpec) -> CatalogSnapshot:
+    files = tuple(f for f in snapshot.files if f.repo_id in spec.repo_ids)
+    keys = {(f.repo_id, f.rfilename) for f in files}
+    copies = tuple(c for c in snapshot.copies if (c.repo_id, c.rfilename) in keys)
+    labels = {c.drive_label for c in copies}
+    drives = tuple(d for d in snapshot.drives if d.drive_label in labels)
+    current = {(d.drive_label, d.identity_epoch, d.write_generation) for d in drives}
+    anchors = tuple(a for a in snapshot.anchors
+                    if (a.drive_label, a.identity_epoch, a.generation) in current)
+    return replace(snapshot, files=files, copies=copies, drives=drives, anchors=anchors,
+                   issues=tuple(g for g in snapshot.issues if g.repo_id in spec.repo_ids))
+
+
+def _source_snapshot_id(snapshot: CatalogSnapshot) -> str:
+    payload = asdict(snapshot)
+    for drive in payload["drives"]:
+        del drive["eligibility"]
+    return _hash(payload)
+
+
 def _source(file, copy, drive, anchors):
     """Return a (digest, evidence) pair or one exact candidate refusal."""
     def fail(code, detail=""):
@@ -244,7 +268,9 @@ def _source(file, copy, drive, anchors):
 
     if copy.present is False:
         return fail("SOURCE_COPY_ABSENT")
-    if drive is None or not drive.fs_uuid or not drive.annex_uuid:
+    if (drive is None
+            or any(v is not None and not isinstance(v, str) for v in (drive.fs_uuid, drive.annex_uuid))
+            or not any(v and v.strip() for v in (drive.fs_uuid, drive.annex_uuid))):
         return fail("SOURCE_IDENTITY_UNPROVEN")
     if drive.lifecycle != "active":
         return fail("SOURCE_INACTIVE", drive.lifecycle)
@@ -298,6 +324,7 @@ def _source(file, copy, drive, anchors):
 def preview(spec: SliceSpec, snapshot: CatalogSnapshot) -> SlicePreview:
     if snapshot.schema_version != 7 or not snapshot.catalog_id:
         raise SliceRefusal("INVALID_SNAPSHOT", "schema v7 and snapshot provenance required")
+    snapshot = _scope(snapshot, spec)
     files = _index(snapshot.files, lambda f: (f.repo_id, f.rfilename))
     _index(snapshot.copies, lambda c: (c.repo_id, c.rfilename, c.drive_label))
     drives = _index(snapshot.drives, lambda d: d.drive_label)
@@ -345,7 +372,7 @@ def preview(spec: SliceSpec, snapshot: CatalogSnapshot) -> SlicePreview:
         sources = tuple(sorted((src for _, src in available), key=lambda src: src.drive.drive_label))
         closure.append(Artifact(file.repo_id, file.rfilename, file.size_bytes, available[0][0],
                                 file.format, file.quant, sources))
-    p = SlicePreview(spec, snapshot.snapshot_id, tuple(closure),
+    p = SlicePreview(spec, _source_snapshot_id(snapshot), tuple(closure),
                      tuple(sorted(gaps, key=lambda g: _json(asdict(g)))), "")
     return replace(p, seal=hashlib.sha256(p.canonical_bytes()).hexdigest())
 

--- a/modelark/slice/domain.py
+++ b/modelark/slice/domain.py
@@ -1,0 +1,381 @@
+"""Pure archive-only slice proposal and approval contracts (DEC-101 through DEC-103).
+
+A domain seal binds catalog evidence and destination *intent*. It is not a transfer approval:
+hardware preflight and durable execution ownership must be added in the later implementation
+slices. These objects are internal trusted-process values, not signed capabilities from clients.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+import hashlib
+import json
+from pathlib import PurePosixPath, PureWindowsPath
+import re
+
+from modelark import archive_hash
+from modelark.capacity_evidence import identity_fingerprint_v1
+
+
+DOMAIN_VERSION = "modelark.slice.domain.v1"
+PROFILE = "hf-tree-v1"
+_SHA256 = re.compile(r"[0-9a-fA-F]{64}\Z")
+_ANNEX = re.compile(r"SHA256E?-s(\d+)--[0-9a-f]{64}(?:\.[^/\\\x00]*)?\Z")
+
+
+class SliceRefusal(ValueError):
+    def __init__(self, code: str, detail: str = ""):
+        self.code, self.detail = code, detail
+        super().__init__(f"{code}: {detail}")
+
+
+def _path(value: str) -> bool:
+    if not isinstance(value, str) or not value or "\\" in value or "\0" in value:
+        return False
+    rel = PurePosixPath(value)
+    return (not rel.is_absolute() and not PureWindowsPath(value).drive
+            and ".." not in rel.parts and value != "." and value == rel.as_posix())
+
+
+def _digest(value) -> bool:
+    return isinstance(value, str) and _SHA256.fullmatch(value) is not None
+
+
+def _integer(value) -> bool:
+    return type(value) is int and value >= 0
+
+
+def _json(value) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=True, allow_nan=False).encode("utf-8")
+
+
+def _hash(value) -> str:
+    return hashlib.sha256(_json(value)).hexdigest()
+
+
+@dataclass(frozen=True)
+class SliceSpec:
+    repo_ids: tuple[str, ...]
+    destination_id: str
+    destination_root: str
+    consumer_profile: str = PROFILE
+
+    def __post_init__(self):
+        if not isinstance(self.repo_ids, (tuple, list)):
+            raise SliceRefusal("INVALID_SPEC", "repositories must be an explicit sequence")
+        repos = tuple(self.repo_ids)
+        if (not repos
+                or any(not _path(r) or len(PurePosixPath(r).parts) != 2 for r in repos)
+                or not isinstance(self.destination_id, str) or not self.destination_id.strip()
+                or not _path(self.destination_root)):
+            raise SliceRefusal("INVALID_SPEC", "explicit repositories and safe destination intent required")
+        object.__setattr__(self, "repo_ids", tuple(sorted(set(repos))))
+        if self.consumer_profile != PROFILE:
+            raise SliceRefusal("UNSUPPORTED_PROFILE", str(self.consumer_profile))
+
+
+@dataclass(frozen=True)
+class FileFact:
+    repo_id: str
+    rfilename: str
+    size_bytes: int | None
+    sha256: str | None
+    format: str | None
+    quant: str | None
+
+
+@dataclass(frozen=True)
+class CopyFact:
+    repo_id: str
+    rfilename: str
+    drive_label: str
+    stored_relpath: str | None
+    orig_bytes: int | None
+    stored_bytes: int | None
+    orig_sha256: str | None
+    provenance: str | None
+    annex_key: str | None
+    compressed: bool
+    present: bool | None = None
+
+
+@dataclass(frozen=True)
+class DriveFact:
+    drive_label: str
+    fs_uuid: str | None
+    annex_uuid: str | None
+    serial: str | None
+    identity_epoch: int
+    write_generation: int
+    identity_fingerprint: str | None
+    filesystem_capacity_bytes: int | None
+    write_authority: str
+    lifecycle: str
+    eligibility: str
+
+
+@dataclass(frozen=True)
+class AnchorFact:
+    drive_label: str
+    identity_epoch: int
+    generation: int
+    identity_fingerprint: str
+    filesystem_capacity_bytes: int
+    write_authority: str
+    anchor_id: str
+
+
+@dataclass(frozen=True)
+class Gap:
+    repo_id: str
+    rfilename: str | None
+    code: str
+    drive_label: str | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class CatalogSnapshot:
+    catalog_id: str
+    files: tuple[FileFact, ...]
+    copies: tuple[CopyFact, ...]
+    drives: tuple[DriveFact, ...]
+    anchors: tuple[AnchorFact, ...]
+    issues: tuple[Gap, ...] = ()
+    schema_version: int = 7
+
+    def __post_init__(self):
+        # Copy caller-owned containers; facts themselves are frozen scalar records.
+        for name, cls in (("files", FileFact), ("copies", CopyFact), ("drives", DriveFact),
+                          ("anchors", AnchorFact), ("issues", Gap)):
+            items = tuple(getattr(self, name))
+            if any(type(item) is not cls for item in items):
+                raise SliceRefusal("INVALID_SNAPSHOT", name)
+            if any(type(value) not in (str, int, bool, type(None))
+                   for item in items for value in asdict(item).values()):
+                raise SliceRefusal("INVALID_SNAPSHOT", f"non-scalar {name} evidence")
+            object.__setattr__(self, name, tuple(sorted(items, key=lambda item: _json(asdict(item)))))
+
+    @property
+    def snapshot_id(self) -> str:
+        return _hash(asdict(self))
+
+
+@dataclass(frozen=True)
+class SourceEvidence:
+    copy: CopyFact
+    drive: DriveFact
+    anchor: AnchorFact
+    digest_provenance: str
+
+
+@dataclass(frozen=True)
+class Artifact:
+    repo_id: str
+    rfilename: str
+    size_bytes: int
+    sha256: str
+    format: str | None
+    quant: str | None
+    sources: tuple[SourceEvidence, ...]
+
+    def __post_init__(self):
+        object.__setattr__(self, "sources", tuple(self.sources))
+
+
+@dataclass(frozen=True)
+class SlicePreview:
+    spec: SliceSpec
+    snapshot_id: str
+    closure: tuple[Artifact, ...]
+    gaps: tuple[Gap, ...]
+    seal: str
+    version: str = DOMAIN_VERSION
+
+    def __post_init__(self):
+        object.__setattr__(self, "closure", tuple(self.closure))
+        object.__setattr__(self, "gaps", tuple(self.gaps))
+
+    @property
+    def source_ready(self) -> bool:
+        return bool(self.closure) and not self.gaps
+
+    @property
+    def execution_ready(self) -> bool:
+        return False  # No hardware preflight or durable execution owner in Slice 1.
+
+    @property
+    def total_bytes(self) -> int:
+        """Resolved original bytes only; blocked previews may have a partial closure."""
+        return sum(item.size_bytes for item in self.closure)
+
+    @property
+    def required_drives(self) -> tuple[str, ...]:
+        """Preferred source schedule; each artifact retains its sealed alternatives."""
+        return tuple(sorted({item.sources[0].drive.drive_label for item in self.closure}))
+
+    def canonical_bytes(self) -> bytes:
+        payload = asdict(self)
+        del payload["seal"]
+        return _json(payload)
+
+
+@dataclass(frozen=True)
+class SliceApproval:
+    preview_seal: str
+    stage: str = "domain"
+    version: str = DOMAIN_VERSION
+
+
+def _index(items, key):
+    result = {}
+    for item in items:
+        identity = key(item)
+        if identity in result:
+            raise SliceRefusal("INVALID_SNAPSHOT", f"duplicate evidence: {identity}")
+        result[identity] = item
+    return result
+
+
+def _source(file, copy, drive, anchors):
+    """Return a (digest, evidence) pair or one exact candidate refusal."""
+    def fail(code, detail=""):
+        return Gap(file.repo_id, file.rfilename, code, copy.drive_label, detail)
+
+    if copy.present is False:
+        return fail("SOURCE_COPY_ABSENT")
+    if drive is None or not drive.fs_uuid or not drive.annex_uuid:
+        return fail("SOURCE_IDENTITY_UNPROVEN")
+    if drive.lifecycle != "active":
+        return fail("SOURCE_INACTIVE", drive.lifecycle)
+    if (not _integer(drive.identity_epoch) or drive.identity_epoch < 1
+            or not _integer(drive.write_generation) or not drive.write_generation
+            or not _integer(drive.filesystem_capacity_bytes)
+            or drive.write_authority != "dedicated_local"):
+        return fail("SOURCE_RECONCILIATION_REQUIRED", "current clean generation required")
+    fingerprint = identity_fingerprint_v1(
+        fs_uuid=drive.fs_uuid, annex_uuid=drive.annex_uuid, serial=drive.serial,
+        filesystem_capacity_bytes=drive.filesystem_capacity_bytes)
+    anchor = anchors.get((drive.drive_label, drive.identity_epoch, drive.write_generation))
+    if (drive.identity_fingerprint != fingerprint or anchor is None or not anchor.anchor_id
+            or anchor.identity_fingerprint != fingerprint
+            or anchor.filesystem_capacity_bytes != drive.filesystem_capacity_bytes
+            or anchor.write_authority != "dedicated_local"):
+        return fail("SOURCE_RECONCILIATION_REQUIRED", "anchor does not bind current identity/generation")
+    if not _path(copy.stored_relpath):
+        return fail("SOURCE_PATH_UNSAFE", str(copy.stored_relpath))
+    key = _ANNEX.fullmatch(copy.annex_key or "")
+    if key is None:
+        return fail("SOURCE_IDENTITY_UNPROVEN", "canonical SHA256 annex identity required")
+    if (not _integer(copy.orig_bytes) or copy.orig_bytes != file.size_bytes
+            or not _integer(copy.stored_bytes) or int(key[1]) != copy.stored_bytes
+            or (copy.compressed is False and copy.orig_bytes != copy.stored_bytes)):
+        return fail("SOURCE_SIZE_MISMATCH")
+    if type(copy.compressed) is not bool:
+        return fail("SOURCE_PROVENANCE_UNPROVEN", "compression state unknown")
+    if copy.orig_sha256 is not None and not _digest(copy.orig_sha256):
+        return fail("SOURCE_PROVENANCE_UNPROVEN", "malformed original digest")
+    try:
+        digest = archive_hash.expected_sha256(
+            catalog_sha=file.sha256, orig_sha256=copy.orig_sha256,
+            compressed=copy.compressed, annex_key=copy.annex_key)
+    except archive_hash.DigestEvidenceError as exc:
+        return fail("SOURCE_DIGEST_CONFLICT", str(exc))
+    provenance = copy.provenance
+    if (copy.orig_sha256 is not None and provenance in {"ingestion_computed", "hub_confirmed", "archive-head-blob"}
+            and (provenance != "hub_confirmed" or file.sha256 is not None)
+            and (provenance != "archive-head-blob" or not copy.compressed)):
+        proof = provenance
+    elif not copy.compressed:
+        proof = "annex_key"  # Independent raw original-byte identity, not a database backfill.
+    else:
+        return fail("SOURCE_PROVENANCE_UNPROVEN", "no independently established original-byte digest")
+    if not _digest(digest):
+        return fail("SOURCE_PROVENANCE_UNPROVEN", "original digest unknown")
+    return digest.lower(), SourceEvidence(copy, drive, anchor, proof)
+
+
+def preview(spec: SliceSpec, snapshot: CatalogSnapshot) -> SlicePreview:
+    if snapshot.schema_version != 7 or not snapshot.catalog_id:
+        raise SliceRefusal("INVALID_SNAPSHOT", "schema v7 and snapshot provenance required")
+    files = _index(snapshot.files, lambda f: (f.repo_id, f.rfilename))
+    _index(snapshot.copies, lambda c: (c.repo_id, c.rfilename, c.drive_label))
+    drives = _index(snapshot.drives, lambda d: d.drive_label)
+    anchors = _index(snapshot.anchors, lambda a: (a.drive_label, a.identity_epoch, a.generation))
+    copies = {}
+    for copy in snapshot.copies:
+        copies.setdefault((copy.repo_id, copy.rfilename), []).append(copy)
+    gaps = [g for g in snapshot.issues if g.repo_id in spec.repo_ids]
+    closure = []
+    selected = [f for f in files.values() if f.repo_id in spec.repo_ids]
+    for repo in spec.repo_ids:
+        if not any(f.repo_id == repo for f in selected) and not any(g.repo_id == repo for g in gaps):
+            gaps.append(Gap(repo, None, "MANIFEST_UNAVAILABLE", detail="repository has no archive manifest"))
+    output_paths = {f"{f.repo_id}/{f.rfilename}" for f in selected if _path(f.rfilename)}
+    for file in sorted(selected, key=lambda f: (f.repo_id, f.rfilename)):
+        def gap(code, detail=""):
+            gaps.append(Gap(file.repo_id, file.rfilename, code, detail=detail))
+
+        if not _path(file.rfilename):
+            gap("ARTIFACT_PATH_UNSAFE", str(file.rfilename))
+            continue
+        output = PurePosixPath(file.repo_id) / file.rfilename
+        if any(str(parent) in output_paths for parent in output.parents):
+            gap("OUTPUT_COLLISION", str(output))
+            continue
+        if not _integer(file.size_bytes):
+            gap("ARTIFACT_SIZE_UNKNOWN")
+            continue
+        if file.sha256 is not None and not _digest(file.sha256):
+            gap("ARTIFACT_DIGEST_INVALID")
+            continue
+        available, rejected = [], []
+        for copy in copies.get((file.repo_id, file.rfilename), ()):
+            evidence = _source(file, copy, drives.get(copy.drive_label), anchors)
+            if isinstance(evidence, Gap):
+                rejected.append(evidence)
+            else:
+                available.append(evidence)
+        if not available:
+            gaps.extend(rejected or (Gap(file.repo_id, file.rfilename, "ARCHIVE_MISSING"),))
+            continue
+        if len({digest for digest, _ in available}) != 1:
+            gap("SOURCE_DIGEST_AMBIGUOUS", "qualifying archived originals disagree")
+            continue
+        sources = tuple(sorted((src for _, src in available), key=lambda src: src.drive.drive_label))
+        closure.append(Artifact(file.repo_id, file.rfilename, file.size_bytes, available[0][0],
+                                file.format, file.quant, sources))
+    p = SlicePreview(spec, snapshot.snapshot_id, tuple(closure),
+                     tuple(sorted(gaps, key=lambda g: _json(asdict(g)))), "")
+    return replace(p, seal=hashlib.sha256(p.canonical_bytes()).hexdigest())
+
+
+def _verify(preview: SlicePreview) -> None:
+    if (preview.version != DOMAIN_VERSION
+            or preview.seal != hashlib.sha256(preview.canonical_bytes()).hexdigest()):
+        raise SliceRefusal("PREVIEW_TAMPERED")
+
+
+def approve(proposal: SlicePreview, *, expected_seal: str,
+            current_snapshot: CatalogSnapshot) -> SliceApproval:
+    """Pure approval of reviewed domain intent; caller supplies a fresh trusted snapshot.
+
+    No persistence, CAS, live preflight, or Start is performed. The later state store must
+    authenticate the caller and persist the approved artifact before any execution is possible.
+    """
+    _verify(proposal)
+    if expected_seal != proposal.seal:
+        raise SliceRefusal("PREVIEW_STALE", "reviewed seal differs")
+    if not proposal.source_ready:
+        raise SliceRefusal("PREVIEW_BLOCKED")
+    if preview(proposal.spec, current_snapshot).seal != proposal.seal:
+        raise SliceRefusal("PREVIEW_STALE", "catalog evidence changed since preview")
+    return SliceApproval(proposal.seal)
+
+
+def validate_approval(proposal: SlicePreview, approval: SliceApproval) -> None:
+    """Validate the stored domain pair, not current source availability or hardware readiness."""
+    _verify(proposal)
+    if (approval.stage != "domain" or approval.version != DOMAIN_VERSION
+            or approval.preview_seal != proposal.seal or not proposal.source_ready):
+        raise SliceRefusal("APPROVAL_MISMATCH")

--- a/modelark/slice/domain.py
+++ b/modelark/slice/domain.py
@@ -290,11 +290,12 @@ def _source(file, copy, drive, anchors):
         return fail("SOURCE_RECONCILIATION_REQUIRED", "anchor does not bind current identity/generation")
     if not _path(copy.stored_relpath):
         return fail("SOURCE_PATH_UNSAFE", str(copy.stored_relpath))
+    if copy.annex_key is not None and not isinstance(copy.annex_key, str):
+        return fail("SOURCE_IDENTITY_UNPROVEN", "malformed recorded annex identity")
     key = _ANNEX.fullmatch(copy.annex_key or "")
-    if key is None:
-        return fail("SOURCE_IDENTITY_UNPROVEN", "canonical SHA256 annex identity required")
     if (not _integer(copy.orig_bytes) or copy.orig_bytes != file.size_bytes
-            or not _integer(copy.stored_bytes) or int(key[1]) != copy.stored_bytes
+            or not _integer(copy.stored_bytes)
+            or (key is not None and int(key[1]) != copy.stored_bytes)
             or (copy.compressed is False and copy.orig_bytes != copy.stored_bytes)):
         return fail("SOURCE_SIZE_MISMATCH")
     if type(copy.compressed) is not bool:
@@ -308,11 +309,10 @@ def _source(file, copy, drive, anchors):
     except archive_hash.DigestEvidenceError as exc:
         return fail("SOURCE_DIGEST_CONFLICT", str(exc))
     provenance = copy.provenance
-    if (copy.orig_sha256 is not None and provenance in {"ingestion_computed", "hub_confirmed", "archive-head-blob"}
-            and (provenance != "hub_confirmed" or file.sha256 is not None)
-            and (provenance != "archive-head-blob" or not copy.compressed)):
+    if (copy.orig_sha256 is not None and provenance in {
+            "ingestion_computed", "hub_confirmed", "archive-head-blob", "annex_key"}):
         proof = provenance
-    elif not copy.compressed:
+    elif not copy.compressed and key is not None:
         proof = "annex_key"  # Independent raw original-byte identity, not a database backfill.
     else:
         return fail("SOURCE_PROVENANCE_UNPROVEN", "no independently established original-byte digest")

--- a/tests/test_slice_catalog.py
+++ b/tests/test_slice_catalog.py
@@ -148,12 +148,15 @@ def test_read_snapshot_is_consistent_across_concurrent_catalog_commit(api, tmp_p
 
 
 # 2026-09-07: "other" is not positive weight evidence; cover it as blocked below.
-@pytest.mark.parametrize("format", ["onnx", "mlx"])
-def test_foreign_archives_are_recoverable_without_hiding_declared_gaps(api, tmp_path, format):
+@pytest.mark.parametrize("name,format", [
+    ("model.onnx", "onnx"), ("model.npz", "mlx"),
+    ("model.onnx", "other"), ("model.onnx", None),
+    ("model.npz", "other"), ("model.npy", None),
+])
+def test_foreign_archives_are_recoverable_without_hiding_declared_gaps(api, tmp_path, name, format):
     d, catalog = api
     path = tmp_path / "catalog.sqlite"
     con = seed(path, d)
-    name = f"model.{format}"
     con.execute("UPDATE files SET rfilename=?,format=?", (name, format))
     con.execute("UPDATE archived SET rfilename=?,stored_relpath=?", (name, name))
     p = d.preview(spec(d), catalog.read_catalog(path, spec(d)))
@@ -176,6 +179,8 @@ def test_foreign_archives_are_recoverable_without_hiding_declared_gaps(api, tmp_
     ("model.safetensors.index.json", "aux"),
     ("model.other", "other"),
     ("unknown.dat", None),
+    ("mlx/config.json", "other"),
+    ("model.onnx.json", "other"),
 ])
 def test_manifest_failure_without_recognized_weights_stays_blocked(api, tmp_path, name, format):
     d, catalog = api

--- a/tests/test_slice_catalog.py
+++ b/tests/test_slice_catalog.py
@@ -1,0 +1,102 @@
+"""Read-only catalog boundary for the internal Slice 1 domain API."""
+import importlib
+import sqlite3
+from unittest import mock
+
+import pytest
+
+from modelark.core import db
+from test_slice_domain import SHA, facts, spec
+
+
+@pytest.fixture
+def api():
+    try:
+        return (importlib.import_module("modelark.slice.domain"),
+                importlib.import_module("modelark.slice.catalog"))
+    except ModuleNotFoundError as exc:
+        if not exc.name.startswith("modelark.slice"):
+            raise
+        pytest.fail("Slice 1 read-only catalog adapter is not implemented yet")
+
+
+def seed(path, d):
+    s = facts(d)
+    con = sqlite3.connect(path, isolation_level=None)
+    con.executescript(db.SCHEMA_PATH.read_text())
+    con.execute("PRAGMA user_version=7")
+    con.execute("INSERT INTO models(repo_id) VALUES('org/model')")
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,sha256,format,quant) VALUES(?,?,?,?,?,?)",
+                ("org/model", "model.safetensors", 12, SHA, "safetensors", "bf16"))
+    drive = s.drives[0]
+    con.execute("INSERT INTO drives(drive_label,fs_uuid,annex_uuid,serial,identity_epoch,write_generation,"
+                "identity_fingerprint,filesystem_capacity_bytes,write_authority) VALUES(?,?,?,?,?,?,?,?,?)",
+                (drive.drive_label, drive.fs_uuid, drive.annex_uuid, drive.serial, 1, 2,
+                 drive.identity_fingerprint, 1000, "dedicated_local"))
+    con.execute("INSERT INTO drive_dirty_generations(drive_label,identity_epoch,generation,operation_code) "
+                "VALUES('drive-a',1,2,'fixture')")
+    con.execute("INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,identity_fingerprint,"
+                "filesystem_capacity_bytes,anchor_free_bytes,write_authority,identity_proof,fence_proof,observed_at) "
+                "VALUES('drive-a',1,2,?,1000,900,'dedicated_local','fixture','fixture','2026-09-07')",
+                (drive.identity_fingerprint,))
+    con.execute("INSERT INTO archived(repo_id,rfilename,drive_label,stored_relpath,orig_bytes,stored_bytes,"
+                "orig_sha256,orig_sha256_provenance,annex_key,compressed) VALUES(?,?,?,?,?,?,?,?,?,?)",
+                ("org/model", "model.safetensors", "drive-a", "model.safetensors", 12, 12,
+                 SHA, "ingestion_computed", f"SHA256E-s12--{SHA}", 0))
+    return con
+
+
+def test_adapter_uses_explicit_read_only_snapshot_without_global_state(api, tmp_path):
+    d, catalog = api
+    path = tmp_path / "catalog ? #.sqlite"
+    con = seed(path, d)
+    before = tuple(con.iterdump())
+    configured = db.DB_PATH
+    with mock.patch.object(db, "connect", side_effect=AssertionError("no global catalog")), \
+         mock.patch("subprocess.run", side_effect=AssertionError("no annex")), \
+         mock.patch("socket.socket", side_effect=AssertionError("no network")):
+        snapshot = catalog.read_catalog(path, spec(d))
+        p = d.preview(spec(d), snapshot)
+    assert p.source_ready and p.required_drives == ("drive-a",)
+    assert db.DB_PATH == configured and tuple(con.iterdump()) == before
+    con.close()
+
+
+def test_missing_and_legacy_catalogs_are_not_created_or_migrated(api, tmp_path):
+    d, catalog = api
+    path = tmp_path / "absent.sqlite"
+    with pytest.raises(d.SliceRefusal, match="CATALOG_UNAVAILABLE"):
+        catalog.read_catalog(path, spec(d))
+    assert not path.exists()
+    con = sqlite3.connect(path)
+    con.execute("PRAGMA user_version=6")
+    con.close()
+    before = path.read_bytes()
+    with pytest.raises(d.SliceRefusal, match="CATALOG_VERSION_UNSUPPORTED"):
+        catalog.read_catalog(path, spec(d))
+    assert path.read_bytes() == before
+
+
+def test_replica_metadata_alone_never_becomes_archive_provenance(api, tmp_path):
+    d, catalog = api
+    path = tmp_path / "catalog.sqlite"
+    con = seed(path, d)
+    con.execute("DELETE FROM archived")
+    con.execute("INSERT INTO replicas(repo_id,rfilename,drive_label,annex_key) VALUES(?,?,?,?)",
+                ("org/model", "model.safetensors", "drive-a", f"SHA256E-s12--{SHA}"))
+    p = d.preview(spec(d), catalog.read_catalog(path, spec(d)))
+    assert not p.source_ready and p.gaps[0].code == "ARCHIVE_MISSING"
+    con.close()
+
+
+def test_manifest_selection_uses_recovery_policy_but_preserves_unknown_sizes(api, tmp_path):
+    d, catalog = api
+    path = tmp_path / "catalog.sqlite"
+    con = seed(path, d)
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) VALUES('org/model','other.gguf',99,'gguf')")
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) VALUES('org/model','config.json',NULL,'aux')")
+    snapshot = catalog.read_catalog(path, spec(d))
+    assert {f.rfilename for f in snapshot.files} == {"model.safetensors", "config.json"}
+    assert next(f for f in snapshot.files if f.rfilename == "config.json").size_bytes is None
+    assert "ARTIFACT_SIZE_UNKNOWN" in {g.code for g in d.preview(spec(d), snapshot).gaps}
+    con.close()

--- a/tests/test_slice_catalog.py
+++ b/tests/test_slice_catalog.py
@@ -100,3 +100,48 @@ def test_manifest_selection_uses_recovery_policy_but_preserves_unknown_sizes(api
     assert next(f for f in snapshot.files if f.rfilename == "config.json").size_bytes is None
     assert "ARTIFACT_SIZE_UNKNOWN" in {g.code for g in d.preview(spec(d), snapshot).gaps}
     con.close()
+
+
+def test_read_snapshot_is_consistent_across_concurrent_catalog_commit(api, tmp_path):
+    d, catalog = api
+    path = tmp_path / "catalog.sqlite"
+    writer = seed(path, d)
+    writer.execute("PRAGMA journal_mode=WAL")
+    connect = sqlite3.connect
+    connections = []
+    mutated = False
+
+    class Reader:
+        def __init__(self, con):
+            self.con = con
+
+        def execute(self, sql, *args):
+            nonlocal mutated
+            if "FROM files " in sql and not mutated:
+                mutated = True
+                # The read transaction is already pinned by user_version. A later writer commits
+                # successfully, but the reader must not combine its old copies with a new manifest.
+                writer.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                               "VALUES('org/model','new-config.json',5,'aux')")
+                with pytest.raises(sqlite3.OperationalError, match="readonly"):
+                    self.con.execute("DELETE FROM archived")
+            return self.con.execute(sql, *args)
+
+        def close(self):
+            self.con.close()
+
+    def reader_connect(database_uri, **kwargs):
+        assert database_uri.endswith("?mode=ro") and kwargs["uri"] is True
+        con = connect(database_uri, **kwargs)
+        connections.append(con)
+        return Reader(con)
+
+    with mock.patch.object(catalog.sqlite3, "connect", side_effect=reader_connect):
+        snapshot = catalog.read_catalog(path, spec(d))
+    assert mutated and d.preview(spec(d), snapshot).source_ready
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        connections[0].execute("SELECT 1")
+    fresh = catalog.read_catalog(path, spec(d))
+    assert fresh.snapshot_id != snapshot.snapshot_id
+    assert d.preview(spec(d), fresh).gaps[0].rfilename == "new-config.json"
+    writer.close()

--- a/tests/test_slice_catalog.py
+++ b/tests/test_slice_catalog.py
@@ -147,7 +147,8 @@ def test_read_snapshot_is_consistent_across_concurrent_catalog_commit(api, tmp_p
     writer.close()
 
 
-@pytest.mark.parametrize("format", ["onnx", "mlx", "other"])
+# 2026-09-07: "other" is not positive weight evidence; cover it as blocked below.
+@pytest.mark.parametrize("format", ["onnx", "mlx"])
 def test_foreign_archives_are_recoverable_without_hiding_declared_gaps(api, tmp_path, format):
     d, catalog = api
     path = tmp_path / "catalog.sqlite"
@@ -167,4 +168,24 @@ def test_foreign_archives_are_recoverable_without_hiding_declared_gaps(api, tmp_
     con.execute("DELETE FROM archived")
     p = d.preview(spec(d), catalog.read_catalog(path, spec(d)))
     assert {g.rfilename for g in p.gaps} == {name, "config.json"}
+    con.close()
+
+
+@pytest.mark.parametrize("name,format", [
+    ("config.json", "aux"),
+    ("model.safetensors.index.json", "aux"),
+    ("model.other", "other"),
+    ("unknown.dat", None),
+])
+def test_manifest_failure_without_recognized_weights_stays_blocked(api, tmp_path, name, format):
+    d, catalog = api
+    path = tmp_path / "catalog.sqlite"
+    con = seed(path, d)
+    con.execute("UPDATE files SET rfilename=?,format=?", (name, format))
+    con.execute("UPDATE archived SET rfilename=?,stored_relpath=?", (name, name))
+    p = d.preview(spec(d), catalog.read_catalog(path, spec(d)))
+    assert not p.source_ready
+    assert "MANIFEST_UNAVAILABLE" in {g.code for g in p.gaps}
+    with pytest.raises(d.SliceRefusal):
+        d.approve(p, expected_seal=p.seal, current_snapshot=catalog.read_catalog(path, spec(d)))
     con.close()

--- a/tests/test_slice_catalog.py
+++ b/tests/test_slice_catalog.py
@@ -145,3 +145,26 @@ def test_read_snapshot_is_consistent_across_concurrent_catalog_commit(api, tmp_p
     assert fresh.snapshot_id != snapshot.snapshot_id
     assert d.preview(spec(d), fresh).gaps[0].rfilename == "new-config.json"
     writer.close()
+
+
+@pytest.mark.parametrize("format", ["onnx", "mlx", "other"])
+def test_foreign_archives_are_recoverable_without_hiding_declared_gaps(api, tmp_path, format):
+    d, catalog = api
+    path = tmp_path / "catalog.sqlite"
+    con = seed(path, d)
+    name = f"model.{format}"
+    con.execute("UPDATE files SET rfilename=?,format=?", (name, format))
+    con.execute("UPDATE archived SET rfilename=?,stored_relpath=?", (name, name))
+    p = d.preview(spec(d), catalog.read_catalog(path, spec(d)))
+    assert p.source_ready and p.closure[0].rfilename == name
+    # The legacy restore fallback lists only archived rows. A slice must also expose any declared
+    # but unarchived artifact in this requested repository instead of silently narrowing its scope.
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,format) "
+                "VALUES('org/model','config.json',5,'aux')")
+    p = d.preview(spec(d), catalog.read_catalog(path, spec(d)))
+    assert not p.source_ready
+    assert [(g.rfilename, g.code) for g in p.gaps] == [("config.json", "ARCHIVE_MISSING")]
+    con.execute("DELETE FROM archived")
+    p = d.preview(spec(d), catalog.read_catalog(path, spec(d)))
+    assert {g.rfilename for g in p.gaps} == {name, "config.json"}
+    con.close()

--- a/tests/test_slice_domain.py
+++ b/tests/test_slice_domain.py
@@ -247,3 +247,40 @@ def test_duplicate_conflicting_evidence_is_not_order_dependent(domain):
     s = facts(domain)
     with pytest.raises(domain.SliceRefusal, match="INVALID_SNAPSHOT"):
         domain.preview(spec(domain), replace(s, drives=(*s.drives, replace(s.drives[0], lifecycle="lost"))))
+
+
+def test_snapshot_rejects_mutable_scalar_fields(domain):
+    s = facts(domain)
+    with pytest.raises(domain.SliceRefusal, match="INVALID_SNAPSHOT"):
+        replace(s, files=(replace(s.files[0], quant=[]),))
+    with pytest.raises(domain.SliceRefusal, match="INVALID_SPEC"):
+        replace(spec(domain), repo_ids=iter(("org/model",)))
+
+
+def test_zero_bytes_are_known_and_malformed_hashes_are_not_proof(domain):
+    s = facts(domain)
+    zero = replace(s, files=(replace(s.files[0], size_bytes=0),),
+                   copies=(replace(s.copies[0], orig_bytes=0, stored_bytes=0,
+                                   annex_key=f"SHA256E-s0--{SHA}"),))
+    assert domain.preview(spec(domain), zero).source_ready
+    bad = replace(s, files=(replace(s.files[0], sha256="not-a-digest"),))
+    assert domain.preview(spec(domain), bad).gaps[0].code == "ARTIFACT_DIGEST_INVALID"
+
+
+def test_catalog_identity_and_source_evidence_are_bound_to_approval(domain):
+    s = facts(domain)
+    p = domain.preview(spec(domain), s)
+    for changed in (replace(s, catalog_id="other-catalog"),
+                    replace(s, copies=(replace(s.copies[0], stored_relpath="different"),)),
+                    replace(s, anchors=())):
+        with pytest.raises(domain.SliceRefusal, match="PREVIEW_STALE"):
+            domain.approve(p, expected_seal=p.seal, current_snapshot=changed)
+
+
+def test_approval_validation_does_not_replan_for_later_source_changes(domain):
+    s = facts(domain)
+    p = domain.preview(spec(domain), s)
+    a = domain.approve(p, expected_seal=p.seal, current_snapshot=s)
+    changed = replace(s, drives=(replace(s.drives[0], lifecycle="lost"),))
+    assert not domain.preview(spec(domain), changed).source_ready
+    assert domain.validate_approval(p, a) is None  # Later execution must apply source-use gates.

--- a/tests/test_slice_domain.py
+++ b/tests/test_slice_domain.py
@@ -284,3 +284,49 @@ def test_approval_validation_does_not_replan_for_later_source_changes(domain):
     changed = replace(s, drives=(replace(s.drives[0], lifecycle="lost"),))
     assert not domain.preview(spec(domain), changed).source_ready
     assert domain.validate_approval(p, a) is None  # Later execution must apply source-use gates.
+
+
+def test_unrelated_fleet_activity_does_not_stale_slice_approval(domain):
+    s = alternatives(domain)
+    # drive-b has no copy of this slice. Its ongoing Fill generation is not slice evidence.
+    s = replace(s, copies=(s.copies[0],))
+    p = domain.preview(spec(domain), s)
+    changed = replace(s, drives=(s.drives[0], replace(s.drives[1], write_generation=99)),
+                      anchors=(s.anchors[0],))
+    assert domain.preview(spec(domain), changed).seal == p.seal
+    assert domain.approve(p, expected_seal=p.seal, current_snapshot=changed).preview_seal == p.seal
+
+
+def test_placement_exclusion_alone_does_not_stale_read_approval(domain):
+    s = facts(domain)
+    p = domain.preview(spec(domain), s)
+    changed = replace(s, drives=(replace(s.drives[0], eligibility="excluded"),))
+    assert domain.preview(spec(domain), changed).seal == p.seal
+    assert domain.approve(p, expected_seal=p.seal, current_snapshot=changed).preview_seal == p.seal
+
+
+def test_real_candidate_evidence_change_still_stales_approval(domain):
+    s = alternatives(domain)
+    p = domain.preview(spec(domain), s)
+    changed = replace(s, drives=(s.drives[0], replace(s.drives[1], write_generation=99)))
+    with pytest.raises(domain.SliceRefusal, match="PREVIEW_STALE"):
+        domain.approve(p, expected_seal=p.seal, current_snapshot=changed)
+
+
+@pytest.mark.parametrize("fs_uuid,annex_uuid", [("fs-a", None), (None, "annex-a")])
+def test_either_proven_uuid_can_bind_a_clean_source(domain, fs_uuid, annex_uuid):
+    from modelark.capacity_evidence import identity_fingerprint_v1
+
+    s = facts(domain)
+    fingerprint = identity_fingerprint_v1(fs_uuid=fs_uuid, annex_uuid=annex_uuid,
+                                          serial="serial-a", filesystem_capacity_bytes=1000)
+    s = replace(s, drives=(replace(s.drives[0], fs_uuid=fs_uuid, annex_uuid=annex_uuid,
+                                   identity_fingerprint=fingerprint),),
+                anchors=(replace(s.anchors[0], identity_fingerprint=fingerprint),))
+    assert domain.preview(spec(domain), s).source_ready
+
+
+def test_serial_alone_never_proves_source_identity(domain):
+    s = facts(domain)
+    s = replace(s, drives=(replace(s.drives[0], fs_uuid=None, annex_uuid=None),))
+    assert domain.preview(spec(domain), s).gaps[0].code == "SOURCE_IDENTITY_UNPROVEN"

--- a/tests/test_slice_domain.py
+++ b/tests/test_slice_domain.py
@@ -104,7 +104,6 @@ def test_catalog_only_and_partial_archives_report_exact_files(domain):
 @pytest.mark.parametrize("field,value,code", [
     ("orig_bytes", 13, "SOURCE_SIZE_MISMATCH"),
     ("orig_sha256", OTHER, "SOURCE_DIGEST_CONFLICT"),
-    ("annex_key", None, "SOURCE_IDENTITY_UNPROVEN"),
     ("present", False, "SOURCE_COPY_ABSENT"),
     ("stored_relpath", "../escape", "SOURCE_PATH_UNSAFE"),
 ])
@@ -330,3 +329,31 @@ def test_serial_alone_never_proves_source_identity(domain):
     s = facts(domain)
     s = replace(s, drives=(replace(s.drives[0], fs_uuid=None, annex_uuid=None),))
     assert domain.preview(spec(domain), s).gaps[0].code == "SOURCE_IDENTITY_UNPROVEN"
+
+
+# 2026-09-07 review correction: absence of an annex key alone is not missing identity.
+# A confined stored path on a proven drive may carry independent durable digest provenance.
+@pytest.mark.parametrize("key", [None, "WORM-s12-m1--model.safetensors", "URL--recorded-object"])
+@pytest.mark.parametrize("provenance", ["ingestion_computed", "hub_confirmed", "annex_key", "archive-head-blob"])
+def test_durable_original_proof_does_not_require_sha256_annex_backend(domain, key, provenance):
+    s = facts(domain)
+    s = replace(s, copies=(replace(s.copies[0], annex_key=key, provenance=provenance),))
+    p = domain.preview(spec(domain), s)
+    assert p.source_ready and p.closure[0].sha256 == SHA
+    assert p.closure[0].sources[0].digest_provenance == provenance
+
+
+def test_keyless_copy_without_durable_original_proof_is_still_blocked(domain):
+    s = facts(domain)
+    s = replace(s, copies=(replace(s.copies[0], annex_key=None, provenance="legacy_unknown"),))
+    assert domain.preview(spec(domain), s).gaps[0].code == "SOURCE_PROVENANCE_UNPROVEN"
+
+
+def test_compressed_hub_provenance_survives_missing_catalog_digest(domain):
+    s = facts(domain)
+    s = replace(s, files=(replace(s.files[0], sha256=None),),
+                copies=(replace(s.copies[0], provenance="hub_confirmed", compressed=True,
+                                stored_bytes=8, annex_key=f"SHA256E-s8--{OTHER}"),))
+    p = domain.preview(spec(domain), s)
+    assert p.source_ready and p.closure[0].sha256 == SHA
+    assert p.closure[0].sources[0].digest_provenance == "hub_confirmed"

--- a/tests/test_slice_domain.py
+++ b/tests/test_slice_domain.py
@@ -1,0 +1,249 @@
+"""Slice 1 contract: archive evidence -> immutable domain preview -> explicit approval.
+
+These contracts intentionally precede implementation. Hardware preflight and execution are later
+slices; a domain approval must never claim that a destination is ready for writes.
+"""
+from dataclasses import FrozenInstanceError, replace
+import importlib
+import random
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def domain():
+    try:
+        return importlib.import_module("modelark.slice.domain")
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"modelark.slice", "modelark.slice.domain"}:
+            raise
+        pytest.fail("Slice 1 domain preview/approval behavior is not implemented yet")
+
+
+SHA = "a" * 64
+OTHER = "b" * 64
+
+
+def facts(d):
+    from modelark.capacity_evidence import identity_fingerprint_v1
+
+    fingerprint = identity_fingerprint_v1(
+        fs_uuid="fs-a", annex_uuid="annex-a", serial="serial-a", filesystem_capacity_bytes=1000)
+    drive = d.DriveFact("drive-a", "fs-a", "annex-a", "serial-a", 1, 2,
+                        fingerprint, 1000, "dedicated_local", "active", "enabled")
+    anchor = d.AnchorFact("drive-a", 1, 2, fingerprint, 1000, "dedicated_local", "anchor-2")
+    file = d.FileFact("org/model", "model.safetensors", 12, SHA, "safetensors", "bf16")
+    copy = d.CopyFact("org/model", file.rfilename, "drive-a", file.rfilename,
+                      12, 12, SHA, "ingestion_computed", f"SHA256E-s12--{SHA}", False)
+    return d.CatalogSnapshot("fixture", (file,), (copy,), (drive,), (anchor,))
+
+
+def spec(d, **kwargs):
+    return d.SliceSpec(repo_ids=("org/model",), destination_id="usb-destination",
+                       destination_root="models", **kwargs)
+
+
+def test_offline_archive_is_source_ready_without_io(domain):
+    snapshot = facts(domain)
+    with mock.patch("pathlib.Path.resolve", side_effect=AssertionError("no source resolution")), \
+         mock.patch("subprocess.run", side_effect=AssertionError("no annex or mount")), \
+         mock.patch("socket.socket", side_effect=AssertionError("no acquisition")):
+        p = domain.preview(spec(domain), snapshot)
+        assert p.source_ready and not p.execution_ready
+        assert p.total_bytes == 12 and p.required_drives == ("drive-a",)
+        assert p.closure[0].sha256 == SHA
+        assert p.closure[0].sources[0].copy.annex_key == f"SHA256E-s12--{SHA}"
+        assert p.closure[0].sources[0].anchor.anchor_id == "anchor-2"
+
+
+@pytest.mark.parametrize("lifecycle,eligibility,ready", [
+    ("active", "enabled", True), ("active", "excluded", True),
+    ("lost", "enabled", False), ("retired", "excluded", False),
+])
+def test_lifecycle_and_placement_eligibility_are_orthogonal(domain, lifecycle, eligibility, ready):
+    s = facts(domain)
+    s = replace(s, drives=(replace(s.drives[0], lifecycle=lifecycle, eligibility=eligibility),))
+    p = domain.preview(spec(domain), s)
+    assert p.source_ready is ready
+    if not ready:
+        assert p.gaps[0].code == "SOURCE_INACTIVE"
+        assert p.gaps[0].drive_label == "drive-a"
+
+
+@pytest.mark.parametrize("change", ["missing", "old_generation", "old_epoch", "fingerprint", "authority"])
+def test_clean_anchor_must_bind_current_drive(domain, change):
+    s = facts(domain)
+    anchors = s.anchors
+    if change == "missing":
+        anchors = ()
+    else:
+        field, value = {
+            "old_generation": ("generation", 1), "old_epoch": ("identity_epoch", 2),
+            "fingerprint": ("identity_fingerprint", OTHER),
+            "authority": ("write_authority", "unknown"),
+        }[change]
+        anchors = (replace(anchors[0], **{field: value}),)
+    p = domain.preview(spec(domain), replace(s, anchors=anchors))
+    assert not p.source_ready
+    assert p.gaps[0].code == "SOURCE_RECONCILIATION_REQUIRED"
+    assert (p.gaps[0].repo_id, p.gaps[0].rfilename) == ("org/model", "model.safetensors")
+
+
+def test_catalog_only_and_partial_archives_report_exact_files(domain):
+    s = facts(domain)
+    config = domain.FileFact("org/model", "nested/config.json", 4, OTHER, "aux", None)
+    p = domain.preview(spec(domain), replace(s, files=(*s.files, config)))
+    assert not p.source_ready
+    assert [(g.rfilename, g.code) for g in p.gaps] == [(config.rfilename, "ARCHIVE_MISSING")]
+    assert p.closure[0].rfilename == "model.safetensors"
+    p = domain.preview(spec(domain), replace(s, copies=()))
+    assert p.gaps[0].code == "ARCHIVE_MISSING"
+
+
+@pytest.mark.parametrize("field,value,code", [
+    ("orig_bytes", 13, "SOURCE_SIZE_MISMATCH"),
+    ("orig_sha256", OTHER, "SOURCE_DIGEST_CONFLICT"),
+    ("annex_key", None, "SOURCE_IDENTITY_UNPROVEN"),
+    ("present", False, "SOURCE_COPY_ABSENT"),
+    ("stored_relpath", "../escape", "SOURCE_PATH_UNSAFE"),
+])
+def test_unproven_copy_cannot_satisfy_archive_evidence(domain, field, value, code):
+    s = facts(domain)
+    p = domain.preview(spec(domain), replace(s, copies=(replace(s.copies[0], **{field: value}),)))
+    assert not p.source_ready and p.gaps[0].code == code
+
+
+def test_legacy_digest_without_independent_proof_is_blocked(domain):
+    s = facts(domain)
+    copy = replace(s.copies[0], provenance="legacy_unknown", compressed=True,
+                   annex_key=f"SHA256E-s8--{OTHER}", stored_bytes=8)
+    p = domain.preview(spec(domain), replace(s, copies=(copy,)))
+    assert p.gaps[0].code == "SOURCE_PROVENANCE_UNPROVEN"
+
+
+def test_raw_annex_digest_is_independent_proof_not_a_catalog_mutation(domain):
+    s = facts(domain)
+    copy = replace(s.copies[0], provenance=None, orig_sha256=None)
+    p = domain.preview(spec(domain), replace(s, copies=(copy,)))
+    assert p.source_ready
+    assert p.closure[0].sources[0].digest_provenance == "annex_key"
+    assert copy.orig_sha256 is None and copy.provenance is None
+
+
+def test_compressed_annex_hash_is_not_original_byte_evidence(domain):
+    s = facts(domain)
+    copy = replace(s.copies[0], orig_sha256=None, provenance=None, compressed=True)
+    p = domain.preview(spec(domain), replace(s, copies=(copy,)))
+    assert not p.source_ready
+
+
+def alternatives(d):
+    from modelark.capacity_evidence import identity_fingerprint_v1
+
+    s = facts(d)
+    fingerprint = identity_fingerprint_v1(
+        fs_uuid="fs-b", annex_uuid="annex-b", serial="serial-b", filesystem_capacity_bytes=1000)
+    drive = replace(s.drives[0], drive_label="drive-b", fs_uuid="fs-b", annex_uuid="annex-b",
+                    serial="serial-b", identity_fingerprint=fingerprint)
+    anchor = replace(s.anchors[0], drive_label="drive-b", identity_fingerprint=fingerprint,
+                     anchor_id="anchor-b")
+    return replace(s, drives=(*s.drives, drive), anchors=(*s.anchors, anchor),
+                   copies=(*s.copies, replace(s.copies[0], drive_label="drive-b")))
+
+
+def test_valid_alternatives_survive_bad_preferred_source(domain):
+    s = alternatives(domain)
+    p = domain.preview(spec(domain), replace(s, drives=(replace(s.drives[0], lifecycle="lost"), s.drives[1])))
+    assert p.source_ready and p.required_drives == ("drive-b",)
+
+
+def test_missing_catalog_hash_requires_unambiguous_archived_content(domain):
+    s = alternatives(domain)
+    s = replace(s, files=(replace(s.files[0], sha256=None),),
+                copies=(s.copies[0], replace(s.copies[1], orig_sha256=OTHER,
+                                           annex_key=f"SHA256E-s12--{OTHER}")))
+    p = domain.preview(spec(domain), s)
+    assert not p.source_ready and p.gaps[0].code == "SOURCE_DIGEST_AMBIGUOUS"
+
+
+def test_preview_seal_is_order_independent_and_facts_are_immutable(domain):
+    s = alternatives(domain)
+    p = domain.preview(spec(domain), s)
+    for seed in range(10):
+        rng = random.Random(seed)
+        shuffled = {name: tuple(rng.sample(getattr(s, name), len(getattr(s, name))))
+                    for name in ("files", "copies", "drives", "anchors")}
+        assert domain.preview(spec(domain), replace(s, **shuffled)) == p
+    assert tuple(src.drive.drive_label for src in p.closure[0].sources) == ("drive-a", "drive-b")
+    with pytest.raises(FrozenInstanceError):
+        p.closure[0].sources[0].drive.lifecycle = "lost"
+    file_list = list(s.files)
+    copied = replace(s, files=file_list)
+    file_list.clear()
+    assert copied.files == s.files
+
+
+@pytest.mark.parametrize("path", ["/absolute", "../escape", "a/../b", "a\\b", "a//b", "a/./b", "x\0y"])
+def test_unsafe_artifact_paths_block_domain_preview(domain, path):
+    s = facts(domain)
+    p = domain.preview(spec(domain), replace(s, files=(replace(s.files[0], rfilename=path),)))
+    assert not p.source_ready and p.gaps[0].code == "ARTIFACT_PATH_UNSAFE"
+
+
+def test_file_directory_collisions_are_rejected(domain):
+    s = facts(domain)
+    nested = replace(s.files[0], rfilename="model.safetensors/config.json")
+    p = domain.preview(spec(domain), replace(s, files=(*s.files, nested)))
+    assert not p.source_ready and "OUTPUT_COLLISION" in {g.code for g in p.gaps}
+
+
+def test_missing_sizes_and_repositories_are_not_silently_omitted(domain):
+    s = facts(domain)
+    p = domain.preview(spec(domain), replace(s, files=(replace(s.files[0], size_bytes=None),)))
+    assert p.gaps[0].code == "ARTIFACT_SIZE_UNKNOWN"
+    p = domain.preview(replace(spec(domain), repo_ids=("missing/model",)), s)
+    assert not p.source_ready and p.gaps[0].repo_id == "missing/model"
+
+
+def test_explicit_approval_binds_reviewed_seal_and_never_starts_execution(domain):
+    s = facts(domain)
+    p = domain.preview(spec(domain), s)
+    a = domain.approve(p, expected_seal=p.seal, current_snapshot=s)
+    assert a.preview_seal == p.seal and a.stage == "domain"
+    assert domain.validate_approval(p, a) is None
+    assert not p.execution_ready
+    with pytest.raises(domain.SliceRefusal, match="PREVIEW_STALE"):
+        domain.approve(p, expected_seal=OTHER, current_snapshot=s)
+    with pytest.raises(domain.SliceRefusal, match="PREVIEW_STALE"):
+        domain.approve(p, expected_seal=p.seal, current_snapshot=replace(s, copies=()))
+
+
+def test_tampered_preview_and_approval_are_refused(domain):
+    s = facts(domain)
+    p = domain.preview(spec(domain), s)
+    a = domain.approve(p, expected_seal=p.seal, current_snapshot=s)
+    tampered = replace(p, spec=replace(p.spec, destination_id="other-usb"))
+    with pytest.raises(domain.SliceRefusal, match="PREVIEW_TAMPERED"):
+        domain.approve(tampered, expected_seal=p.seal, current_snapshot=s)
+    with pytest.raises(domain.SliceRefusal, match="APPROVAL_MISMATCH"):
+        domain.validate_approval(p, replace(a, preview_seal=OTHER))
+    with pytest.raises(domain.SliceRefusal, match="PREVIEW_BLOCKED"):
+        blocked = domain.preview(spec(domain), replace(s, copies=()))
+        domain.approve(blocked, expected_seal=blocked.seal, current_snapshot=replace(s, copies=()))
+
+
+def test_profile_and_destination_intent_are_part_of_seal(domain):
+    s = facts(domain)
+    p = domain.preview(spec(domain), s)
+    assert domain.preview(replace(p.spec, destination_root="different"), s).seal != p.seal
+    with pytest.raises(domain.SliceRefusal, match="UNSUPPORTED_PROFILE"):
+        domain.preview(spec(domain, consumer_profile="unknown"), s)
+    with pytest.raises(domain.SliceRefusal, match="INVALID_SPEC"):
+        domain.preview(replace(p.spec, destination_root="../outside"), s)
+
+
+def test_duplicate_conflicting_evidence_is_not_order_dependent(domain):
+    s = facts(domain)
+    with pytest.raises(domain.SliceRefusal, match="INVALID_SNAPSHOT"):
+        domain.preview(spec(domain), replace(s, drives=(*s.drives, replace(s.drives[0], lifecycle="lost"))))


### PR DESCRIPTION
Implements Slice 1 of the merged Usable Slice charter: derive an immutable archive-only closure, report exact per-file gaps, retain deterministic source alternatives, and bind explicit domain approval to the reviewed canonical seal. A clean offline source is schedulable; dirty/inactive/unproven copies block, while active drives excluded from placement remain readable.

The catalog adapter reads an explicitly supplied schema-v7 SQLite database in one read-only transaction. It preserves original-byte provenance and clean-drive evidence separately, uses the established recovery manifest, and retains all declared files when falling back for foreign/legacy formats so missing artifacts remain explicit gaps. It never configures the global catalog, migrates a schema, resolves archive paths, or retrieves annex content. Proven stored-path copies do not require a particular annex backend, and durable original-digest provenance survives missing current catalog metadata.

The API is internal. Domain approval has no execution authority: hardware preflight, durable ownership/CAS, CLI/portal wiring, and byte transfer remain later slices. No production Fill path or live archive is changed. DEC-104 through DEC-107 and `docs/usable-slice-domain.md` record this boundary. Foreign fallback requires positive ONNX/MLX weight evidence: catalog classification or exact `.onnx`/`.npz`/`.npy` extensions for legacy `other`/NULL rows. Auxiliary-only, index-only, and unknown repositories without that evidence retain a blocking manifest gap. This intentionally does not copy restore's unrestricted archived-row fallback, which cannot prove repository scope or preserve declared missing-file gaps.

Validation:

- Separate tests-first commit `1f3018f`; 39 expected missing-API failures before implementation.
- 75 focused contracts pass in the checkout and against the installed wheel, including stale/tampered approval, immutable facts, lifecycle/evidence matrices, concurrent-WAL snapshot consistency, unrelated-fleet freshness, either-UUID identity proof, complete/partial foreign-format recovery, legacy ONNX-as-other compatibility, and blocking incomplete/unknown manifests.
- Wheel build, Ruff across the repository, and `git diff --check` pass.
- Local regression: 1,052 passed, one intentional skip, across the full run and a successful rerun of 18 failures (17 sandbox-blocked HTTP cases and one already-corrected test-fixture argument name). Temporary HTTP servers use disposable catalogs and loopback ports.

Review corrections scope approval freshness to requested manifests and their recorded source candidates, exclude placement eligibility from read authority, follow the existing either-UUID reconciliation rule, and preserve proven legacy/non-annex sources without treating any policy error as a complete repository.

At current head `4420c4c`, CI Python 3.10/3.12, browser E2E, and static checks pass (3.10: 1,083 passed, one skipped). Greptile is 5/5 with no new findings; all review threads are resolved. The final Codex review completed at 2026-09-07 17:36 UTC with no new findings. The preceding browser job failed an unchanged Fill-graph assertion at `tests/test_e2e_portal.py:1281` and passed its isolated retry without code changes; the current head's fresh browser job also passed. Ready for operator merge; no merge or deployment performed.
