### PR TITLE
feat: durable Usable Slice transaction core

### DIFF
--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2618,3 +2618,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Refines only the internal Slice 2 authority, publication and source interfaces, with concurrency/crash/stop and bounded-replay contracts. The historical-temporary reproduction was already refused by the later allocation scan; explicit final authentication preserves that refusal after removing per-chunk scans. No catalog, live Fill or real-device changes.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-102, DEC-103, DEC-108, DEC-109
+
+### DEC-111: Upgrade early private slice state without losing durable authority
+- `id`: DEC-111
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: PR #69 second Greptile review at `c0a52d2` and a failing version-1 database regression reproducing missing `stop_serial` on Start.
+- `decision`: Advance private transaction state to schema version 2. In the existing initialization write transaction, add the stop serial only when an accepted version-1 database lacks it, then commit the version update with all existing plans, reservations, stop flags and journal heads preserved. Accept both development version-1 layouts and make reopening idempotent.
+- `rationale`: Even an internal API must not silently accept an earlier durable schema and fail later on reachable Start/Stop operations. An additive transactional migration preserves ownership rather than requiring state deletion or adoption.
+- `impact`: Private Slice 2 SQLite initialization and compatibility tests only; no catalog migration, live-state access or real-device execution.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2673,3 +2673,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Internal state-transition and receipt protocols, compatibility regressions and documentation only. Legacy receipts remain explicitly non-self-contained; no real archive, catalog, device or service is accessed.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110, DEC-111, DEC-113, DEC-114
+
+### DEC-116: Seal metadata capacity and resume retained attended sessions
+- `id`: DEC-116
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: Codex review of PR #69 at `8faebc1` and five failed regressions for retained waits and missing metadata capacity reservation.
+- `decision`: New transaction protocol v3 requires an explicit sealed metadata reserve above original artifact bytes. Check that reserve against the control/receipt payload upper bound over sealed source alternatives and actual private-state root, and pass the full required capacity to every destination gate. The trusted preflight adapter must account for filesystem allocation rounding, directories and temporary/control/receipt metadata within that reserve. Preserve v1/v2 seals and receipt formats for recovery only, with known payload-capacity checks. Return retained attended-wait sessions to transferring after their gates pass so run continues to completion.
+- `rationale`: Artifact bytes alone understate required destination space, especially with self-contained receipts. An adapter needs the remaining total reservation, not only historical allocation. A resolved attended wait must not terminate run on its stale status after successfully publishing a file.
+- `impact`: Internal plan/port capacity contract, receipt compatibility, session state and disposable tests; real filesystem charge proof is still an explicit Slice 3 prerequisite. No real device, archive, catalog or service mutation.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110, DEC-114, DEC-115

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2706,3 +2706,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Private state migration, transaction Start/completion and drive-loss synchronization with disposable regressions. No deployment, live Fill, real-device execution or catalog-schema change. Broader architectural changes remain proposals for the operator after at most three fix/review rounds.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110, DEC-111, DEC-115, DEC-117
+
+### DEC-119: Serialize startup outcomes with committed terminal authority
+- `id`: DEC-119
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Round 1 Greptile finding 3953694180 and Codex finding 3953703340 on PR #69, independently identifying the completion handoff race introduced by DEC-118's release ordering.
+- `decision`: Inside activation's write transaction, recognize committed completion before checking removed ownership and return observation-only status. Publish startup refusals only while the transaction remains resumable and owns the device, in the same write transaction as those checks; preserve already-terminal outcomes.
+- `rationale`: Closing the lease and committing SQLite are separate authority boundaries. A pre-activation read can see the prior committed state during handoff, and even a destination check can finish late. Rechecking only successful activation leaves refusal publication able to overwrite the terminal winner. Terminal authority must be checked at both durable mutation points.
+- `impact`: Round 2 of at most three correction/re-review rounds. Two deterministic threaded regressions reproduced completion downgrades to failed and invalidated before correction. No adapter implementation, real-device execution, catalog-schema change or deployment.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-115, DEC-118

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2596,3 +2596,25 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Adds internal state, transaction and source-gate modules plus tests and API documentation. Slice 3 must prove confinement, system/archive exclusion, capability accounting and recoverable owned-object certificates inside actual adapter calls before exposing execution. Catalog schemas, archive evidence and live Fill remain unchanged.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md, docs/plans/usable-slice-implementation-charter.md
 - `related`: DEC-101, DEC-102, DEC-103, DEC-104, DEF-041
+
+### DEC-109: Admit only the slice source gate to the neutral drive-fence import boundary
+- `id`: DEC-109
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: PR #69 CI at `7dbbe4e`: 1,152 tests passed and the reviewed-import guard rejected the new `slice/sources.py` fence import.
+- `decision`: Extend the neutral `drive_fence` import allowlist to the exact `slice/sources.py` path required by DEC-108. Match repo-relative paths rather than basenames; leave `drive_mutation` limited to its existing reviewed writer modules.
+- `rationale`: Slice reads must share the writer's exclusion primitive without gaining authority to dirty or anchor a drive. An explicit path exception preserves the architectural guard instead of bypassing it through dynamic imports or broadening mutation authority.
+- `impact`: Updates the import-policy contract and source-gate documentation; no production writer or catalog changes.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-103, DEC-108, tests/test_drive_mutation_envelope.py
+
+### DEC-110: Make initializing ownership observable and control publication restartable
+- `id`: DEC-110
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: PR #69 reviews at `7dbbe4e` and reproductions of read contention, overlapping first Starts, missing/changed controls and incomplete control creation.
+- `decision`: Commit an initializing device reservation before acquiring process exclusion, then activate only the fenced owner without erasing a newer stop request. Use deferred private-state reader transactions and bounded writer contention, retaining SQLite crash rollback capability. Publish control records through the same restartable prepared/no-replace protocol as receipts. Verify control contents and extant temporary certificates at final verification; check stop/ownership during hashing. Cache validated operation/allocation state under a durable-head guard and append CAS rather than replaying the journal per chunk. Limit source error translation to source setup, preserving downstream destination failures.
+- `rationale`: Repeated Start must observe an initializing owner, not depend on timing. An interrupted control write cannot strand durable ownership. Prepared evidence and current object certificates, not historical names, establish recovery authority. Cached execution state must retain a checkable link to its durable journal while avoiding work proportional to journal size for every content chunk.
+- `impact`: Refines only the internal Slice 2 authority, publication and source interfaces, with concurrency/crash/stop and bounded-replay contracts. The historical-temporary reproduction was already refused by the later allocation scan; explicit final authentication preserves that refusal after removing per-chunk scans. No catalog, live Fill or real-device changes.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-102, DEC-103, DEC-108, DEC-109

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2740,3 +2740,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `supersedes`: DEC-120
 - `related`: DEC-108, DEC-110, DEC-115, DEC-118, DEC-119
+
+### DEC-122: Release stopped delivery attempts before returning their outcome
+- `id`: DEC-122
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Operator-authorized correction of Codex P2 3954091840 on PR #69 at c5ec843; retained stopped-session and stop-persistence regressions reproduced writable capability after Stop.
+- `decision`: Treat Stop as ending the current Session attempt while retaining the transaction's durable reservation. Revoke the local Session before acknowledgment persistence, release its descriptors in the existing finally path, and return the captured stopped outcome rather than rereading successor state. Apply the same release when Stop wins over an attended-wait outcome; ordinary attended waits remain resumable on their retained attempt.
+- `rationale`: A stopped attempt cannot legally resume under DEC-121, so retaining its capability blocks the required fresh claim. Failure to persist acknowledgment must not preserve that local capability or be reported as durable success.
+- `impact`: Slice Session outcome handling and six disposable stop/restart regressions only; no Fill, schema, hardware-adapter, deployment or live-service change.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-113, DEC-121

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2684,3 +2684,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Internal plan/port capacity contract, receipt compatibility, session state and disposable tests; real filesystem charge proof is still an explicit Slice 3 prerequisite. No real device, archive, catalog or service mutation.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110, DEC-114, DEC-115
+
+### DEC-117: Check the final publication boundary and classify lazy source reads
+- `id`: DEC-117
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: Codex review of PR #69 at `44989bc` and seven failed regressions covering stops at verification EOF and source failures during lazy reads.
+- `decision`: Recheck the execution boundary after verification EOF/stream close and immediately before no-replace publication. Wrap only the yielded source stream's read operation to translate missing-source and other IO failures into typed source gaps, preserving destination exceptions outside that scope and keeping the reader/fence context alive through consumption.
+- `rationale`: A last-chunk check does not cover the subsequent EOF interval. Source availability can change after successful open; classifying only setup errors bypasses sealed fallback and actionable source blocking. Catching transaction-consumer exceptions would reintroduce incorrect destination attribution.
+- `impact`: Internal source-read and publication boundaries with control/file/receipt stop regressions, partial-read source failure/fallback tests and existing destination-error isolation coverage. No live device, archive, catalog or service access.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110, DEC-112, DEC-114

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2695,3 +2695,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Internal source-read and publication boundaries with control/file/receipt stop regressions, partial-read source failure/fallback tests and existing destination-error isolation coverage. No live device, archive, catalog or service access.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110, DEC-112, DEC-114
+
+### DEC-118: Serialize initialization stops, completion release and source revocation
+- `id`: DEC-118
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: PR #69 Codex findings 3953499094, 3953499106 and 3953499111; operator-authorized three-round correction/review limit.
+- `decision`: Persist the first reservation's activation stop serial in private schema v3 and reuse it for overlapping initializing callers. Migrate older pending initializations conservatively. Release the completing Session's process descriptor before durable ownership becomes available, and report a newly reserved transaction's bind failure as busy. Serialize operator lifecycle loss with the same nonblocking identity/epoch fence held by source reads, retaining it through graph commit.
+- `rationale`: A refreshed snapshot of a stop counter is not the original activation authority; a durable reservation is not proof of process ownership; and a source fence only prevents revocation if the revoker participates. The three corrections establish ordering at those actual authority boundaries.
+- `impact`: Private state migration, transaction Start/completion and drive-loss synchronization with disposable regressions. No deployment, live Fill, real-device execution or catalog-schema change. Broader architectural changes remain proposals for the operator after at most three fix/review rounds.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110, DEC-111, DEC-115, DEC-117

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2721,10 +2721,22 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 ### DEC-120: Require process-acquisition evidence for duplicate observation
 - `id`: DEC-120
 - `date`: 2026-09-08
-- `status`: accepted
+- `status`: superseded by DEC-121
 - `triggered_by`: Local round 2 boundary review extended the new-reservation busy regression to a second retry and reproduced a false initializing-writer observation despite no process for that transaction. Both external reviewers were clear on 46744c1.
 - `decision`: Record process acquisition on the durable owner only while holding device exclusion. Combine a failed bind with that same reservation's acquisition evidence before returning duplicate observation; otherwise report busy on every retry. Private schema v4 conservatively initializes older reservations without inventing acquisition evidence.
 - `rationale`: A reservation's existence, including a repeated reservation, does not identify the incumbent process. A retained child of a completed previous transaction may still own the socket. Once a reservation actually acquires exclusion, no other transaction can become the incumbent while that durable owner remains, because all Starts reserve before binding and there is no takeover/expiry path.
 - `impact`: Final correction round (3 of 3). Strengthened retry regression, inherited-child completion regression and v3 migration coverage. An initializing duplicate in the short pre-record interval conservatively receives busy. No new IPC/listener, hardware adapter, deployment, catalog-schema change or real-device execution. Stop after fresh reviews and report residual findings/common architectural causes.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110, DEC-118, DEC-119
+
+### DEC-121: Centralize delivery execution around current attempt capabilities
+- `id`: DEC-121
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Operator approval after the three-round PR #69 review stop; residual findings 3953777477, 3953814659 and 3953814662 exposed historical-acquisition, terminal-snapshot and stop-acknowledgment assumptions.
+- `decision`: Route Slice delivery claims, execution boundaries, legal transitions, journal mutation and completion through one attempt authority. Pair device exclusion with a unique kernel-held datagram marker, queried without messages or a listener, and publish its token only while both descriptors are held. Close marker before device exclusion. Require exact attempt identity within each durable mutation. Record requested and acknowledged stop serials separately in private schema v5; a Start can resume only a stop already acknowledged in its own snapshot. Recognize completion in reservation and claim before destination access.
+- `rationale`: Durable history is not proof of current process ownership, a preflight snapshot cannot authorize a later mutation, and observing a stop request is distinct from acknowledging it. Transitional uncertainty must refuse busy rather than invent a worker. Marker retention proves exclusion, not progress or worker responsiveness; a child retaining both descriptors is deliberately included.
+- `impact`: Existing Fill session-write/recovery guards adopt the same neutral attempt identity/state contract while retaining their catalog storage, expiry/CAS rules and current stop Event semantics. Slice retains its private delivery state, and actual Slice reads, Fill writers and drive-loss revocation share the existing archive identity/epoch fence. No catalog schema migration, scheduler rewrite, hardware adapter, public Start/Stop, live service change or deployment. The implementation/design skills guided the common contract and the ledger records the operator-authorized scope.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `supersedes`: DEC-120
+- `related`: DEC-108, DEC-110, DEC-115, DEC-118, DEC-119

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2585,3 +2585,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Slice 1 reader and positive/negative fallback contracts only; no catalog mutation, acquisition change, or live archive access.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-domain.md
 - `related`: DEC-105, DEC-106, tests/test_def033_gate1_contracts.py
+
+### DEC-108: Separate durable slice transaction authority from catalog and hardware adapters
+- `id`: DEC-108
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: Operator authorization of Slice 2 after PR #68 merged at `8408abe`.
+- `decision`: Persist transaction plans, explicit approval, unfinished device reservations and append-only journals in a private, fixed operator-host SQLite namespace outside the catalog. Combine atomic claims with Linux abstract Unix-socket process exclusion keyed solely by canonical destination device identity. Keep inherited descriptors excluding successor writers; do not support alternate namespaces, cross-host takeover or cleanup. Compose the existing nonblocking archive mutation fence with a fresh read-only catalog snapshot and an injected local source reader. Orchestrate recoverable publication over explicit trusted destination ports; ship no real hardware adapter or public Start entry point in Slice 2.
+- `rationale`: Process death must release only live exclusion, not durable ownership. A fixed host authority prevents catalog/root aliases from creating independent reservations, and abstract socket binds avoid replaceable lock-file identities. Keeping device proof and confined IO behind explicit ports permits disposable fault/concurrency tests without claiming that simulated devices satisfy real USB safety gates.
+- `impact`: Adds internal state, transaction and source-gate modules plus tests and API documentation. Slice 3 must prove confinement, system/archive exclusion, capability accounting and recoverable owned-object certificates inside actual adapter calls before exposing execution. Catalog schemas, archive evidence and live Fill remain unchanged.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md, docs/plans/usable-slice-implementation-charter.md
+- `related`: DEC-101, DEC-102, DEC-103, DEC-104, DEF-041

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2640,3 +2640,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Internal transaction orchestration, regression tests and API documentation only; no hardware adapter, public Start, catalog change or live Fill action.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110, DEC-111
+
+### DEC-113: Revoke a terminal session independently of status persistence
+- `id`: DEC-113
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: PR #69 Greptile review of `3f1af34` and two failed regressions injecting `STATE_BUSY` during terminal status persistence.
+- `decision`: Remember terminal refusal in the Session before attempting its durable status write, and release its process descriptor in a finally block for both typed refusals and no-replace collision exceptions. Keep the persistence error visible and reject reuse of that Session even when the durable status did not advance.
+- `rationale`: Failure to record a terminal transition must not preserve or restore the same in-process writer capability. The durable reservation remains intact; an unsuccessful status write must not be claimed as persisted.
+- `impact`: Internal session error handling, fault regressions and documentation only. No live database, archive or device access.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110, DEC-112

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2662,3 +2662,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Internal transaction pre-use gates and disposable regressions only; inside-call descriptor confinement remains a future adapter obligation, and no real destination or archive is accessed.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110, DEC-112, DEC-113
+
+### DEC-115: Preserve retry authority and make new delivery receipts self-contained
+- `id`: DEC-115
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: Codex review of PR #69 at `81bc4e0` and six failing regressions for transient state contention, terminal activation races and missing portable receipt context.
+- `decision`: Release process exclusion on `STATE_BUSY` without persisting a terminal failure, retaining approved retry authority. Check resumable state after process binding and inside activation's write transaction so delayed starters cannot overwrite terminal outcomes. Default new plans to transaction protocol v2 and embed the full sealed plan, direct topology, terminal delivery status and content/layout verification result in receipts. Preserve protocol-v1 seals and receipt bytes for legacy recovery instead of rewriting prepared publications.
+- `rationale`: Shared-state contention is transient, unlike a revoked approval. Activation must check authority at its actual state transition, not only before waiting for exclusion. A portable delivery receipt must retain its approved context without relying on the host database, while no-replace recovery forbids retroactively changing legacy receipt bytes.
+- `impact`: Internal state-transition and receipt protocols, compatibility regressions and documentation only. Legacy receipts remain explicitly non-self-contained; no real archive, catalog, device or service is accessed.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110, DEC-111, DEC-113, DEC-114

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2629,3 +2629,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Private Slice 2 SQLite initialization and compatibility tests only; no catalog migration, live-state access or real-device execution.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110
+
+### DEC-112: Retain session verification and revoke terminal writer capabilities
+- `id`: DEC-112
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: Final Codex review of PR #69 at `4342578`, reproduced by six failing performance, terminal-session and parent-certificate regressions.
+- `decision`: Authenticate completed directory checkpoints without re-flushing or re-journaling unchanged state. Rehash recovered files once per session and retain successful publication verification, with a mandatory final full digest pass. Refuse failed/invalidated Session reuse and release its process descriptor on terminal refusal without discarding durable ownership. Authenticate all journaled ancestors before child mutations, with inside-call confinement remaining a trusted adapter obligation.
+- `rationale`: Repeated work must not grow quadratically with shard count. A retained Session cannot bypass the same terminal-state gate applied by Start. Discovering lost parent authority only after child creation is too late to preserve unknown content.
+- `impact`: Internal transaction orchestration, regression tests and API documentation only; no hardware adapter, public Start, catalog change or live Fill action.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110, DEC-111

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2651,3 +2651,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Internal session error handling, fault regressions and documentation only. No live database, archive or device access.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-110, DEC-112
+
+### DEC-114: Audit destination layout before initial and resumed mutation
+- `id`: DEC-114
+- `date`: 2026-09-07
+- `status`: accepted
+- `triggered_by`: Codex review of PR #69 at `42ed3c3` and three failed regressions for zero-byte foreign descendants and unknown initial consumer roots.
+- `decision`: Authenticate the current consumer tree and its ancestor prefixes against journal-owned paths before Start/resume performs destination mutation, at artifact-step boundaries and during final verification. Refuse unknown roots or descendants even if their allocation is zero. Reuse cached operation certificates, without per-chunk scans, journal replay or redundant content hashing.
+- `rationale`: Final-only layout verification can discover a collision after additional files have already been published. Capacity checks do not prove absence of unknown metadata entries. Resume must re-establish the layout prerequisite before control recovery or artifact transfer.
+- `impact`: Internal transaction pre-use gates and disposable regressions only; inside-call descriptor confinement remains a future adapter obligation, and no real destination or archive is accessed.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110, DEC-112, DEC-113

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2717,3 +2717,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Round 2 of at most three correction/re-review rounds. Two deterministic threaded regressions reproduced completion downgrades to failed and invalidated before correction. No adapter implementation, real-device execution, catalog-schema change or deployment.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-108, DEC-115, DEC-118
+
+### DEC-120: Require process-acquisition evidence for duplicate observation
+- `id`: DEC-120
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Local round 2 boundary review extended the new-reservation busy regression to a second retry and reproduced a false initializing-writer observation despite no process for that transaction. Both external reviewers were clear on 46744c1.
+- `decision`: Record process acquisition on the durable owner only while holding device exclusion. Combine a failed bind with that same reservation's acquisition evidence before returning duplicate observation; otherwise report busy on every retry. Private schema v4 conservatively initializes older reservations without inventing acquisition evidence.
+- `rationale`: A reservation's existence, including a repeated reservation, does not identify the incumbent process. A retained child of a completed previous transaction may still own the socket. Once a reservation actually acquires exclusion, no other transaction can become the incumbent while that durable owner remains, because all Starts reserve before binding and there is no takeover/expiry path.
+- `impact`: Final correction round (3 of 3). Strengthened retry regression, inherited-child completion regression and v3 migration coverage. An initializing duplicate in the short pre-record interval conservatively receives busy. No new IPC/listener, hardware adapter, deployment, catalog-schema change or real-device execution. Stop after fresh reviews and report residual findings/common architectural causes.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-110, DEC-118, DEC-119

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -1,6 +1,6 @@
 # Usable Slice implementation charter
 
-Status: architecture locked; Slice 1 domain implementation under review
+Status: Slice 1 merged; Slice 2 transaction implementation in progress
 
 Updated: 2026-09-07
 
@@ -369,6 +369,10 @@ for eligibility, exact gap reporting, and the sealed direct-USB transaction.
 Slice 1's internal API and limits are documented in [Usable Slice domain](../usable-slice-domain.md).
 Its domain approval binds intent and archive evidence; execution readiness stays false until the
 later hardware preflight and durable ownership contracts are implemented.
+
+Slice 2's private state, process fencing, journal, and trusted adapter boundary are documented in
+[Usable Slice transaction](../usable-slice-transaction.md). Hardware adapters and real-device
+proof remain Slice 3 work; temporary-fixture success does not grant real-device execution authority.
 
 Finish PR #67's renewed bounded review (up to three iterations) at its exact pushed head and let the
 operator merge it. Then branch from that merged charter for implementation. The first test commit

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -16,6 +16,8 @@ the approved transaction and durable reservation. The initializing reservation i
 process exclusion becomes visible, so overlapping first Starts can identify the same owner. Final
 activation preserves any stop request arriving during initialization. It returns a `Session` to the sole writer, or a
 non-writing `Status` for a repeated Start while that same transaction holds the device.
+Both the post-bind check and activation's SQLite write transaction reject terminal state; a delayed
+starter cannot reactivate a transaction that another starter invalidated while it was paused.
 
 The private SQLite store is separate from every catalog, under the fixed operator-host namespace
 `~/.local/state/modelark/slice`. This is not a catalog/state-directory option: local workers for
@@ -31,6 +33,9 @@ journal from a dead writer is recovered rather than exposed as a read-only-datab
 Private schema version 2 transactionally upgrades development version-1 databases, adding the
 stop serial when absent while preserving plans, pending stops, reservations and journal heads.
 This migration never opens or changes a catalog database.
+Transient `STATE_BUSY` during Start or execution releases the process handle without turning the
+durable transaction into a terminal failure. A fresh Start can retry its existing approved authority.
+This differs from a terminal refusal whose subsequent status write fails: that old Session is revoked.
 
 A Linux abstract Unix socket bind provides process exclusion keyed only by the destination's
 canonical physical-device identity. No listener, remote connection, or replaceable lock file is
@@ -100,6 +105,14 @@ Final verification rehashes every artifact, verifies the control record's presen
 and authenticates every extant descendant, including historical temporary names. The receipt records
 the sealed transaction, destination, exact delivered bytes and actual per-file source evidence.
 It is delivery history, never an archive replica or placement claim.
+New plans use transaction protocol v2. Their destination receipts embed the entire sealed plan,
+including the evidence snapshot ID, slice specification/profile, approved closure and ordered source
+evidence, alongside actual delivered-file sources, direct topology, terminal delivery status and
+explicit content/layout verification results. The plan seal can be reconstructed without the host
+database. These fields describe the verified delivery, not continuing physical verification or archive
+replica evidence. Existing protocol-v1 plans retain their legacy receipt format and seals so an
+already-prepared receipt can recover without replacement; legacy receipts are not self-contained.
+Creation of new protocol-v1 transactions is refused; legacy support is recovery-only.
 
 ## Adapter boundary and remaining work
 

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -19,6 +19,9 @@ activation preserves any stop request arriving during initialization. It returns
 non-writing `Status` for a repeated Start while that same transaction holds the device.
 Both the post-bind check and activation's SQLite write transaction reject terminal state; a delayed
 starter cannot reactivate a transaction that another starter invalidated while it was paused.
+Initializing duplicates reuse the activation stop serial persisted with the first reservation.
+A new reservation that loses process exclusion reports `DESTINATION_BUSY`, rather than claiming
+that the unrelated incumbent is an active writer for the newly reserved transaction.
 
 The private SQLite store is separate from every catalog, under the fixed operator-host namespace
 `~/.local/state/modelark/slice`. This is not a catalog/state-directory option: local workers for
@@ -31,8 +34,10 @@ Reader operations use deferred transactions rather than requesting the writer re
 writers have a bounded SQLite busy wait and return typed `STATE_BUSY` on exhaustion. The private
 database handle retains SQLite rollback-recovery capability even for reader operations, so a hot
 journal from a dead writer is recovered rather than exposed as a read-only-database error.
-Private schema version 2 transactionally upgrades development version-1 databases, adding the
-stop serial when absent while preserving plans, pending stops, reservations and journal heads.
+Private schema version 3 transactionally upgrades development version-1/2 databases, adding the
+stop serial when absent and the reservation's activation serial while preserving plans, pending
+stops, reservations and journal heads. An old initializing reservation with no saved activation
+serial conservatively preserves a pending stop until an explicit stopped-state resume.
 This migration never opens or changes a catalog database.
 Transient `STATE_BUSY` during Start or execution releases the process handle without turning the
 durable transaction into a terminal failure. A fresh Start can retry its existing approved authority.
@@ -53,6 +58,8 @@ is checked between streaming and verification chunks and before publication. Clo
 and closes its process descriptor, but retains the durable reservation. A new seal cannot acquire
 that unfinished device. Completion releases the reservation only after verification and receipt
 publication; existing output/control records are not automatically deleted or adopted.
+Completion closes the Session's process descriptor inside the final state transaction before
+releasing durable ownership, including when the caller retains the completed Session object.
 When a retained Session retries a resolved source/destination wait, it returns to transferring
 before more work, so `run()` continues through receipt publication.
 Terminal refusals release the process descriptor while retaining durable ownership. A failed or
@@ -137,6 +144,10 @@ keeps it through the injected local reader's stream lifetime. The engine revalid
 sealed candidate before reading. Only approved alternatives can be used. Placement exclusion alone
 does not revoke reads; changed lifecycle, identity, generation, copy or digest evidence does.
 Busy, offline and locally missing sources remain distinct reasons; none triggers retrieval.
+Operator `declare_lost` acquires that same identity/epoch fence nonblocking and holds it through
+its graph commit. An active source read yields `DRIVE_BUSY` on revocation, leaving its preview
+and lifecycle unchanged for an explicit retry. Identities without a proven fingerprint cannot
+qualify as slice sources and do not require this source-read exclusion.
 Source waits/blocks identify the exact repository, filename and candidate drive reasons. Source
 open-error translation does not encompass destination exceptions from the consuming transaction.
 The yielded source-read wrapper converts missing-source and other source IO errors raised during

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -77,6 +77,13 @@ resume permission from another caller's later acknowledgment. Closing a live ses
 and closes its process descriptor, but retains the durable reservation. A new seal cannot acquire
 that unfinished device. Completion releases the reservation only after verification and receipt
 publication; existing output/control records are not automatically deleted or adopted.
+An observed Stop ends the current Session attempt: it returns its stopped outcome and releases
+the attempt/device descriptors before returning, without requiring caller cleanup. The old object
+reports `can_write=False` and cannot resume; a fresh Start can claim the still-reserved transaction.
+Stop also revokes the local attempt if acknowledgment persistence fails, while leaving that error
+visible and the durable request unacknowledged. An attended wait retains its attempt unless a
+pending Stop wins during outcome publication. A concurrent fresh Start cannot change the stopped
+result returned by the ending attempt.
 Completion closes the Session's process descriptor inside the final state transaction before
 releasing durable ownership, including when the caller retains the completed Session object.
 If a same-transaction starter acquires exclusion during that final commit window, its claim

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -1,0 +1,94 @@
+# Usable Slice transaction core
+
+Slice 2 adds private durable approval, device ownership, source-use gates, and recoverable
+publication orchestration. It remains an **internal API with no hardware adapter or CLI/portal
+entry point**. Do not use the test destination as a real USB adapter. Slice 1's domain approval
+still has no execution authority; a separately reviewed transaction seal binds destination
+evidence, and the destination port must validate that evidence before any writes.
+
+## Authority and lifetime
+
+`TransferPlan(proposal, destination_binding)` freezes the domain proposal and destination binding
+into a versioned seal. `Store.create(plan, domain_approval)` persists a ready transaction;
+`Store.approve(id, expected_seal=...)` durably approves that exact plan but starts nothing.
+`start(store, id, destination_port, source_port)` acquires device exclusion and atomically claims
+the approved transaction and durable reservation. It returns a `Session` to the sole writer, or a
+non-writing `Status` for a repeated Start while that same transaction holds the device.
+
+The private SQLite store is separate from every catalog, under the fixed operator-host namespace
+`~/.local/state/modelark/slice`. This is not a catalog/state-directory option: local workers for
+different catalogs must share this authority. Tests replace the module's `HOST_STATE_DIR` before
+construction, using a single temporary namespace shared by their child processes. Parent/child
+directory entries and initial database creation are flushed; SQLite transactions use FULL
+synchronous durability. Symlinked or non-private state locations are refused. There is no journal
+import, alternate-authority adoption, ownership takeover, expiry, or abandoned-output cleanup.
+
+A Linux abstract Unix socket bind provides process exclusion keyed only by the destination's
+canonical physical-device identity. No listener, remote connection, or replaceable lock file is
+used. The fence is shared across catalog paths, transaction IDs, and consumer roots in the same
+host/network namespace. Durable reservations survive loss of this process fence. An inherited
+descriptor retains exclusion after its parent closes or dies; an exec child capable of writing
+must explicitly inherit it. The engine itself spawns no writer children, and a forked child cannot
+reuse the parent's `Session` methods. Container/network-namespace isolation and cross-host ownership
+are not supported execution topologies.
+
+`Session.step()` transfers one remaining file, or verifies and completes a fully transferred
+transaction. `run()` continues until complete, a stop, or an attended wait/block. `request_stop`
+is checked between chunks and before publication. Closing a live session records stopped state
+and closes its process descriptor, but retains the durable reservation. A new seal cannot acquire
+that unfinished device. Completion releases the reservation only after verification and receipt
+publication; existing output/control records are not automatically deleted or adopted.
+
+## Journal and recovery
+
+The append-only journal binds transaction, seal, physical destination, operation order, path,
+creation token, expected digest/size, temporary identity, and actual prepared source evidence.
+Hash chaining plus a transactionally updated durable head detects altered or truncated records;
+the private store—not a hash or an imported filename—is the authority. Replay rejects operations
+outside the approved layout, changed bindings, or unsealed prepared source records.
+
+Every creation has a durable intent. Every directory's own metadata and parent entry are flushed
+before its completion record and before children. Files are streamed into exclusively created,
+owned temporaries, checked for exact original size/SHA-256, flushed, and durably prepared with the
+actual source record. Publication is atomic no-replace; the parent is flushed before completion.
+Receipt publication uses the same prepared/no-replace/parent-flush protocol. Temporary cleanup is
+restricted to authenticated transaction-owned objects.
+
+On recovery, an authenticated prepared temporary or published file is rehashed before finishing
+its publication. It does not need a still-online source: its original prepared source evidence is
+retained. An unprepared temporary, even with matching bytes, must be restarted from a currently
+qualifying sealed source. A completed checkpoint whose output disappeared is likewise restored
+or blocked. Before rewriting a missing completed file, old prepared source proof is durably
+cleared so interrupted new bytes cannot inherit it. Unrelated or replaced objects—even matching
+bytes—are collisions. In-flight allocation is derived only from journal-owned object certificates,
+including partial temporaries, and passed to the capacity gate; external consumption is not
+subtracted as transaction work.
+
+Final verification rehashes every artifact and rejects unexpected descendants. The receipt records
+the sealed transaction, destination, exact delivered bytes and actual per-file source evidence.
+It is delivery history, never an archive replica or placement claim.
+
+## Adapter boundary and remaining work
+
+`FencedSources` uses the **existing archive drive mutation fence**, nonblocking, with the same
+fingerprint/epoch key as Fill. It refreshes the explicit read-only catalog under that fence and
+keeps it through the injected local reader's stream lifetime. The engine revalidates the exact
+sealed candidate before reading. Only approved alternatives can be used. Placement exclusion alone
+does not revoke reads; changed lifecycle, identity, generation, copy or digest evidence does.
+Busy, offline and locally missing sources remain distinct reasons; none triggers retrieval.
+
+The source reader and destination interfaces are trusted adapter contracts, not security checks
+implemented by arbitrary callbacks. Slice 3 must supply and test:
+
+- Real attachment and physical identity checks; source/destination/system/archive-role disjointness.
+- Descriptor confinement, symlink/nested-mount rejection, local annex content resolution without
+  retrieval, and original-byte decompression.
+- Sealed filesystem capabilities, metadata/allocation accounting, and per-use identity/capacity gates.
+- Exclusive recoverable creation with authenticated object certificates, including crashes *inside*
+  adapter calls; device-bound reads/writes and atomic no-replace publication.
+- Actual device disappearance/replacement handling and the operator entry point.
+
+The test adapter uses temporary files and simulated device/ownership evidence (test-only xattrs).
+It proves the orchestration's protocol ordering and recovery across port boundaries, not a real
+USB filesystem's identity, ownership-certificate or durability guarantees. Real mounts, live
+catalogs, archive paths, network acquisition, and Fill service actions are not part of this work.

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -12,7 +12,9 @@ evidence, and the destination port must validate that evidence before any writes
 into a versioned seal. `Store.create(plan, domain_approval)` persists a ready transaction;
 `Store.approve(id, expected_seal=...)` durably approves that exact plan but starts nothing.
 `start(store, id, destination_port, source_port)` acquires device exclusion and atomically claims
-the approved transaction and durable reservation. It returns a `Session` to the sole writer, or a
+the approved transaction and durable reservation. The initializing reservation is committed before
+process exclusion becomes visible, so overlapping first Starts can identify the same owner. Final
+activation preserves any stop request arriving during initialization. It returns a `Session` to the sole writer, or a
 non-writing `Status` for a repeated Start while that same transaction holds the device.
 
 The private SQLite store is separate from every catalog, under the fixed operator-host namespace
@@ -22,6 +24,10 @@ construction, using a single temporary namespace shared by their child processes
 directory entries and initial database creation are flushed; SQLite transactions use FULL
 synchronous durability. Symlinked or non-private state locations are refused. There is no journal
 import, alternate-authority adoption, ownership takeover, expiry, or abandoned-output cleanup.
+Reader operations use deferred transactions rather than requesting the writer reservation;
+writers have a bounded SQLite busy wait and return typed `STATE_BUSY` on exhaustion. The private
+database handle retains SQLite rollback-recovery capability even for reader operations, so a hot
+journal from a dead writer is recovered rather than exposed as a read-only-database error.
 
 A Linux abstract Unix socket bind provides process exclusion keyed only by the destination's
 canonical physical-device identity. No listener, remote connection, or replaceable lock file is
@@ -34,7 +40,7 @@ are not supported execution topologies.
 
 `Session.step()` transfers one remaining file, or verifies and completes a fully transferred
 transaction. `run()` continues until complete, a stop, or an attended wait/block. `request_stop`
-is checked between chunks and before publication. Closing a live session records stopped state
+is checked between streaming and verification chunks and before publication. Closing a live session records stopped state
 and closes its process descriptor, but retains the durable reservation. A new seal cannot acquire
 that unfinished device. Completion releases the reservation only after verification and receipt
 publication; existing output/control records are not automatically deleted or adopted.
@@ -53,6 +59,8 @@ owned temporaries, checked for exact original size/SHA-256, flushed, and durably
 actual source record. Publication is atomic no-replace; the parent is flushed before completion.
 Receipt publication uses the same prepared/no-replace/parent-flush protocol. Temporary cleanup is
 restricted to authenticated transaction-owned objects.
+The destination control record also uses restartable temporary/prepared/no-replace publication;
+a crash between its exclusive creation and content flush does not strand an empty final control.
 
 On recovery, an authenticated prepared temporary or published file is rehashed before finishing
 its publication. It does not need a still-online source: its original prepared source evidence is
@@ -64,7 +72,13 @@ bytes—are collisions. In-flight allocation is derived only from journal-owned 
 including partial temporaries, and passed to the capacity gate; external consumption is not
 subtracted as transaction work.
 
-Final verification rehashes every artifact and rejects unexpected descendants. The receipt records
+The fenced session caches a validated operation set and incrementally tracks owned allocation,
+including hard-link aliases. Per-chunk checks do not replay the plan/journal or rescan completed
+objects. A durable-head comparison and append CAS reject unexpected journal changes while using
+the cache. Resume performs a new full replay and owned-object allocation scan.
+
+Final verification rehashes every artifact, verifies the control record's presence/token/digest,
+and authenticates every extant descendant, including historical temporary names. The receipt records
 the sealed transaction, destination, exact delivered bytes and actual per-file source evidence.
 It is delivery history, never an archive replica or placement claim.
 
@@ -76,6 +90,10 @@ keeps it through the injected local reader's stream lifetime. The engine revalid
 sealed candidate before reading. Only approved alternatives can be used. Placement exclusion alone
 does not revoke reads; changed lifecycle, identity, generation, copy or digest evidence does.
 Busy, offline and locally missing sources remain distinct reasons; none triggers retrieval.
+Source waits/blocks identify the exact repository, filename and candidate drive reasons. Source
+open-error translation does not encompass destination exceptions from the consuming transaction.
+The repository's import-policy guard permits this exact source-gate path to import the neutral
+fence only. It still forbids the slice package from importing the drive mutation envelope.
 
 The source reader and destination interfaces are trusted adapter contracts, not security checks
 implemented by arbitrary callbacks. Slice 3 must supply and test:

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -91,6 +91,10 @@ Already-complete directories are authenticated without repeating their flush/che
 Before child creation, append, publication or temporary cleanup, all journaled parent directories
 must retain completed ownership certificates. The hardware adapter must still prevent replacement
 inside an individual port call; these pre-use checks do not replace descriptor confinement.
+Layout authentication runs before Start/resume touches the destination, at each artifact step,
+and during final verification. Existing consumer roots, ancestor prefixes and descendants must
+be journal-owned, including zero-byte entries that capacity checks cannot detect. These metadata
+scans do not rehash completed artifacts or replay the journal, and do not run for every chunk.
 
 Final verification rehashes every artifact, verifies the control record's presence/token/digest,
 and authenticates every extant descendant, including historical temporary names. The receipt records

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -47,6 +47,9 @@ is checked between streaming and verification chunks and before publication. Clo
 and closes its process descriptor, but retains the durable reservation. A new seal cannot acquire
 that unfinished device. Completion releases the reservation only after verification and receipt
 publication; existing output/control records are not automatically deleted or adopted.
+Terminal refusals release the process descriptor while retaining durable ownership. A failed or
+invalidated transaction cannot resume through the old Session object after an adapter condition
+is restored; `step()` refuses it just as a new Start does.
 
 ## Journal and recovery
 
@@ -79,6 +82,12 @@ The fenced session caches a validated operation set and incrementally tracks own
 including hard-link aliases. Per-chunk checks do not replay the plan/journal or rescan completed
 objects. A durable-head comparison and append CAS reject unexpected journal changes while using
 the cache. Resume performs a new full replay and owned-object allocation scan.
+Recovered completed files are rehashed once per session, and newly published files retain their
+successful verification within that session. The final full digest pass is still mandatory.
+Already-complete directories are authenticated without repeating their flush/checkpoint sequence.
+Before child creation, append, publication or temporary cleanup, all journaled parent directories
+must retain completed ownership certificates. The hardware adapter must still prevent replacement
+inside an individual port call; these pre-use checks do not replace descriptor confinement.
 
 Final verification rehashes every artifact, verifies the control record's presence/token/digest,
 and authenticates every extant descendant, including historical temporary names. The receipt records

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -60,6 +60,10 @@ that unfinished device. Completion releases the reservation only after verificat
 publication; existing output/control records are not automatically deleted or adopted.
 Completion closes the Session's process descriptor inside the final state transaction before
 releasing durable ownership, including when the caller retains the completed Session object.
+If a same-transaction starter acquires exclusion during that final commit window, activation
+observes completion inside its own write transaction and returns a nonwriting completed status.
+Startup refusal publication is also serialized with terminal state and device ownership, so
+an adapter error based on a stale pre-activation snapshot cannot downgrade a terminal winner.
 When a retained Session retries a resolved source/destination wait, it returns to transferring
 before more work, so `run()` continues through receipt publication.
 Terminal refusals release the process descriptor while retaining durable ownership. A failed or

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -8,7 +8,8 @@ evidence, and the destination port must validate that evidence before any writes
 
 ## Authority and lifetime
 
-`TransferPlan(proposal, destination_binding)` freezes the domain proposal and destination binding
+`TransferPlan(proposal, destination_binding, metadata_reserve_bytes=...)` freezes the domain
+proposal, destination binding and explicit metadata capacity reservation
 into a versioned seal. `Store.create(plan, domain_approval)` persists a ready transaction;
 `Store.approve(id, expected_seal=...)` durably approves that exact plan but starts nothing.
 `start(store, id, destination_port, source_port)` acquires device exclusion and atomically claims
@@ -52,6 +53,8 @@ is checked between streaming and verification chunks and before publication. Clo
 and closes its process descriptor, but retains the durable reservation. A new seal cannot acquire
 that unfinished device. Completion releases the reservation only after verification and receipt
 publication; existing output/control records are not automatically deleted or adopted.
+When a retained Session retries a resolved source/destination wait, it returns to transferring
+before more work, so `run()` continues through receipt publication.
 Terminal refusals release the process descriptor while retaining durable ownership. A failed or
 invalidated transaction cannot resume through the old Session object after an adapter condition
 is restored; `step()` refuses it just as a new Start does.
@@ -85,6 +88,14 @@ cleared so interrupted new bytes cannot inherit it. Unrelated or replaced object
 bytes—are collisions. In-flight allocation is derived only from journal-owned object certificates,
 including partial temporaries, and passed to the capacity gate; external consumption is not
 subtracted as transaction work.
+Protocol-v3 plans require an explicit metadata reserve in addition to original artifact bytes.
+The trusted preflight adapter must charge allocation rounding, directories, temporary names and
+control/receipt storage for the bound filesystem. The engine checks the reserve against a serialized
+control/receipt upper bound over all sealed source alternatives, using the actual private-state root
+before transaction creation and Start. Insufficient total capacity fails before destination writes.
+Every destination check receives the full required byte total and authenticated owned allocation,
+so the adapter can preserve the remaining reservation throughout the transfer. Tests supply a
+simulated charge; proving real filesystem charges remains Slice 3's adapter obligation.
 
 The fenced session caches a validated operation set and incrementally tracks owned allocation,
 including hard-link aliases. Per-chunk checks do not replay the plan/journal or rescan completed
@@ -105,14 +116,16 @@ Final verification rehashes every artifact, verifies the control record's presen
 and authenticates every extant descendant, including historical temporary names. The receipt records
 the sealed transaction, destination, exact delivered bytes and actual per-file source evidence.
 It is delivery history, never an archive replica or placement claim.
-New plans use transaction protocol v2. Their destination receipts embed the entire sealed plan,
+New plans use transaction protocol v3. Their destination receipts embed the entire sealed plan,
 including the evidence snapshot ID, slice specification/profile, approved closure and ordered source
 evidence, alongside actual delivered-file sources, direct topology, terminal delivery status and
 explicit content/layout verification results. The plan seal can be reconstructed without the host
 database. These fields describe the verified delivery, not continuing physical verification or archive
-replica evidence. Existing protocol-v1 plans retain their legacy receipt format and seals so an
-already-prepared receipt can recover without replacement; legacy receipts are not self-contained.
-Creation of new protocol-v1 transactions is refused; legacy support is recovery-only.
+replica evidence. Existing protocol-v1/v2 plans retain their receipt formats and seals so an
+already-prepared receipt can recover without replacement. Protocol-v1 receipts are not self-contained;
+v2 receipts carry context but their plans did not seal a filesystem metadata reserve. Legacy resume
+checks at least the known control/receipt byte requirement and still requires adapter capacity proof.
+Creation of new protocol-v1/v2 transactions is refused; legacy support is recovery-only.
 
 ## Adapter boundary and remaining work
 

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -28,6 +28,9 @@ Reader operations use deferred transactions rather than requesting the writer re
 writers have a bounded SQLite busy wait and return typed `STATE_BUSY` on exhaustion. The private
 database handle retains SQLite rollback-recovery capability even for reader operations, so a hot
 journal from a dead writer is recovered rather than exposed as a read-only-database error.
+Private schema version 2 transactionally upgrades development version-1 databases, adding the
+stop serial when absent while preserving plans, pending stops, reservations and journal heads.
+This migration never opens or changes a catalog database.
 
 A Linux abstract Unix socket bind provides process exclusion keyed only by the destination's
 canonical physical-device identity. No listener, remote connection, or replaceable lock file is

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -20,8 +20,11 @@ non-writing `Status` for a repeated Start while that same transaction holds the 
 Both the post-bind check and activation's SQLite write transaction reject terminal state; a delayed
 starter cannot reactivate a transaction that another starter invalidated while it was paused.
 Initializing duplicates reuse the activation stop serial persisted with the first reservation.
-A new reservation that loses process exclusion reports `DESTINATION_BUSY`, rather than claiming
-that the unrelated incumbent is an active writer for the newly reserved transaction.
+A reservation records process acquisition only while its caller actually holds device exclusion.
+A failed bind permits duplicate observation only if that still-current durable reservation has
+recorded process acquisition. Otherwise every retry reports `DESTINATION_BUSY`, including while
+a completed former owner's child retains an inherited descriptor. Before acquisition is recorded,
+an overlapping initializing caller conservatively reports busy rather than asserting writer identity.
 
 The private SQLite store is separate from every catalog, under the fixed operator-host namespace
 `~/.local/state/modelark/slice`. This is not a catalog/state-directory option: local workers for
@@ -34,10 +37,12 @@ Reader operations use deferred transactions rather than requesting the writer re
 writers have a bounded SQLite busy wait and return typed `STATE_BUSY` on exhaustion. The private
 database handle retains SQLite rollback-recovery capability even for reader operations, so a hot
 journal from a dead writer is recovered rather than exposed as a read-only-database error.
-Private schema version 3 transactionally upgrades development version-1/2 databases, adding the
+Private schema version 4 transactionally upgrades development version-1/2/3 databases, adding the
 stop serial when absent and the reservation's activation serial while preserving plans, pending
 stops, reservations and journal heads. An old initializing reservation with no saved activation
 serial conservatively preserves a pending stop until an explicit stopped-state resume.
+Older reservations do not infer process-acquisition evidence from ownership or state labels;
+they must successfully acquire exclusion before that evidence can be recorded.
 This migration never opens or changes a catalog database.
 Transient `STATE_BUSY` during Start or execution releases the process handle without turning the
 durable transaction into a terminal failure. A fresh Start can retry its existing approved authority.

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -50,6 +50,9 @@ publication; existing output/control records are not automatically deleted or ad
 Terminal refusals release the process descriptor while retaining durable ownership. A failed or
 invalidated transaction cannot resume through the old Session object after an adapter condition
 is restored; `step()` refuses it just as a new Start does.
+Revocation runs even if persisting that terminal status fails: the old Session remembers its
+terminal refusal independently of the database and cannot regain its writer capability. The
+persistence error remains visible; a failed status write is not reported as a durable transition.
 
 ## Journal and recovery
 

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -12,19 +12,26 @@ evidence, and the destination port must validate that evidence before any writes
 proposal, destination binding and explicit metadata capacity reservation
 into a versioned seal. `Store.create(plan, domain_approval)` persists a ready transaction;
 `Store.approve(id, expected_seal=...)` durably approves that exact plan but starts nothing.
-`start(store, id, destination_port, source_port)` acquires device exclusion and atomically claims
-the approved transaction and durable reservation. The initializing reservation is committed before
-process exclusion becomes visible, so overlapping first Starts can identify the same owner. Final
-activation preserves any stop request arriving during initialization. It returns a `Session` to the sole writer, or a
-non-writing `Status` for a repeated Start while that same transaction holds the device.
-Both the post-bind check and activation's SQLite write transaction reject terminal state; a delayed
-starter cannot reactivate a transaction that another starter invalidated while it was paused.
-Initializing duplicates reuse the activation stop serial persisted with the first reservation.
-A reservation records process acquisition only while its caller actually holds device exclusion.
-A failed bind permits duplicate observation only if that still-current durable reservation has
-recorded process acquisition. Otherwise every retry reports `DESTINATION_BUSY`, including while
-a completed former owner's child retains an inherited descriptor. Before acquisition is recorded,
-an overlapping initializing caller conservatively reports busy rather than asserting writer identity.
+`start(store, id, destination_port, source_port)` delegates execution to `DeliveryAuthority`:
+reserve the approved device, acquire kernel exclusion plus a unique attempt marker, and publish
+that attempt in a guarded SQLite claim before checking the destination or activating. It returns
+a `Session` to the sole writer, or non-writing `Status` when the same attempt's exclusion is retained.
+Completion is recognized both during reservation and inside the claim transaction; a delayed
+starter returns completed status without touching the destination after completion wins.
+
+Every execution transition and journal append checks the exact `(transaction, attempt token)`
+inside its state transaction. The lifecycle transition table permits attended-wait retries but
+requires a fresh claim to resume stopped execution; completion has a separate receipt-bound gate.
+The neutral `modelark.execution_authority` identity/state contract is also used by existing Fill
+session writes and recovery. These remain separate stores and workflow policies: Fill's existing
+portal stop Event, expiry rules and SQL fencing-token CAS are unchanged. Slice delivery receipts
+do not become archive evidence, and this is not a scheduler or public Start/Stop implementation.
+
+A busy bind permits observation only after finding a current durable attempt, querying that
+attempt's live kernel marker, and re-reading the same durable attempt. Historical acquisition
+flags are not authority. Otherwise every retry reports `DESTINATION_BUSY`, including when an
+unrelated former owner's child retains exclusion. Transitional uncertainty is also busy.
+Observation proves retained attempt exclusion, not progress, responsiveness, or a live worker.
 
 The private SQLite store is separate from every catalog, under the fixed operator-host namespace
 `~/.local/state/modelark/slice`. This is not a catalog/state-directory option: local workers for
@@ -37,35 +44,42 @@ Reader operations use deferred transactions rather than requesting the writer re
 writers have a bounded SQLite busy wait and return typed `STATE_BUSY` on exhaustion. The private
 database handle retains SQLite rollback-recovery capability even for reader operations, so a hot
 journal from a dead writer is recovered rather than exposed as a read-only-database error.
-Private schema version 4 transactionally upgrades development version-1/2/3 databases, adding the
-stop serial when absent and the reservation's activation serial while preserving plans, pending
-stops, reservations and journal heads. An old initializing reservation with no saved activation
-serial conservatively preserves a pending stop until an explicit stopped-state resume.
-Older reservations do not infer process-acquisition evidence from ownership or state labels;
-they must successfully acquire exclusion before that evidence can be recorded.
+Private schema version 5 transactionally upgrades development version-1/2/3/4 databases while
+preserving plans, pending stops, reservations and journal heads. It adds a nullable live-attempt
+token and an acknowledged-stop serial; every pending legacy request remains unacknowledged,
+including on stopped rows which may contain a newer request. Legacy `process_seen` and `activation_serial`
+columns are retained for compatibility but are never read as execution authority. Older owners
+must acquire a new lease before publishing an attempt; migration invents no live marker.
 This migration never opens or changes a catalog database.
 Transient `STATE_BUSY` during Start or execution releases the process handle without turning the
 durable transaction into a terminal failure. A fresh Start can retry its existing approved authority.
 This differs from a terminal refusal whose subsequent status write fails: that old Session is revoked.
 
-A Linux abstract Unix socket bind provides process exclusion keyed only by the destination's
-canonical physical-device identity. No listener, remote connection, or replaceable lock file is
-used. The fence is shared across catalog paths, transaction IDs, and consumer roots in the same
-host/network namespace. Durable reservations survive loss of this process fence. An inherited
-descriptor retains exclusion after its parent closes or dies; an exec child capable of writing
-must explicitly inherit it. The engine itself spawns no writer children, and a forked child cannot
+A Linux abstract Unix stream socket bind provides process exclusion keyed only by the destination's
+canonical physical-device identity. A second abstract datagram endpoint identifies the unique
+attempt; probes only connect, never send or queue messages. There is no listener, helper service,
+remote connection, or replaceable lock file. Bind exclusion before the marker, publish the token
+only while both are held, and close the marker before exclusion. The fence is shared across
+catalog paths, transaction IDs, and consumer roots in the same host/network namespace.
+Durable reservations survive loss of this process fence. Inherited descriptors retain exclusion
+and identity after their parent closes or dies; an exec child capable of writing must explicitly
+inherit both and follow the same release order. The engine itself spawns no writer children, and a forked child cannot
 reuse the parent's `Session` methods. Container/network-namespace isolation and cross-host ownership
 are not supported execution topologies.
 
 `Session.step()` transfers one remaining file, or verifies and completes a fully transferred
 transaction. `run()` continues until complete, a stop, or an attended wait/block. `request_stop`
-is checked between streaming and verification chunks and before publication. Closing a live session records stopped state
+is checked between streaming and verification chunks and before publication. Each Start snapshots
+both requested and acknowledged stop serials. A crashed writer's unacknowledged stop is recorded
+as stopped on recovery without destination mutation; only a subsequent explicit Start whose
+snapshot already contains that exact acknowledgment can clear it. A delayed Start cannot gain
+resume permission from another caller's later acknowledgment. Closing a live session records stopped state
 and closes its process descriptor, but retains the durable reservation. A new seal cannot acquire
 that unfinished device. Completion releases the reservation only after verification and receipt
 publication; existing output/control records are not automatically deleted or adopted.
 Completion closes the Session's process descriptor inside the final state transaction before
 releasing durable ownership, including when the caller retains the completed Session object.
-If a same-transaction starter acquires exclusion during that final commit window, activation
+If a same-transaction starter acquires exclusion during that final commit window, its claim
 observes completion inside its own write transaction and returns a nonwriting completed status.
 Startup refusal publication is also serialized with terminal state and device ownership, so
 an adapter error based on a stale pre-activation snapshot cannot downgrade a terminal winner.

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -76,6 +76,8 @@ owned temporaries, checked for exact original size/SHA-256, flushed, and durably
 actual source record. Publication is atomic no-replace; the parent is flushed before completion.
 Receipt publication uses the same prepared/no-replace/parent-flush protocol. Temporary cleanup is
 restricted to authenticated transaction-owned objects.
+The execution boundary is checked after verification EOF/stream close and again immediately before
+publication, so a stop arriving at the end of hashing cannot slip through the last chunk check.
 The destination control record also uses restartable temporary/prepared/no-replace publication;
 a crash between its exclusive creation and content flush does not strand an empty final control.
 
@@ -137,6 +139,9 @@ does not revoke reads; changed lifecycle, identity, generation, copy or digest e
 Busy, offline and locally missing sources remain distinct reasons; none triggers retrieval.
 Source waits/blocks identify the exact repository, filename and candidate drive reasons. Source
 open-error translation does not encompass destination exceptions from the consuming transaction.
+The yielded source-read wrapper converts missing-source and other source IO errors raised during
+lazy reads into typed source failures. It does not wrap destination operations; sealed fallback
+selection and source blocking work even when the source fails after partial bytes have been read.
 The repository's import-policy guard permits this exact source-gate path to import the neutral
 fence only. It still forbids the slice package from importing the drive mutation envelope.
 

--- a/modelark/drive_lifecycle.py
+++ b/modelark/drive_lifecycle.py
@@ -7,11 +7,12 @@ row so historical claims remain reviewable, while excluding the identity from ne
 """
 from __future__ import annotations
 
+from contextlib import ExitStack
 import re
 import shlex
 from typing import Any, Callable, Iterable, Mapping
 
-from modelark import plan, proposal
+from modelark import drive_fence, plan, proposal
 
 
 def planner_revision(con) -> int:
@@ -918,6 +919,16 @@ def declare_lost(
                 value={"changed": False, "approval_invalidated": False},
             )
 
+        # Source-use gates hold this identity fence through the read. Keep revocation
+        # serialized through the graph commit; never wait while holding SQLite's writer.
+        if drive["identity_fingerprint"]:
+            try:
+                fences.enter_context(drive_fence.hold_drives_sorted(
+                    [(drive["identity_fingerprint"], drive["identity_epoch"])], blocking=False))
+            except drive_fence.FenceUnavailable as exc:
+                raise proposal.Refusal("DRIVE_BUSY", {"drive_label": drive_label},
+                                       ("retry_after_source_read",)) from exc
+
         active_approval = c.execute(
             "SELECT active_approved_proposal_id FROM planner_state WHERE singleton_id=1"
         ).fetchone()[0]
@@ -943,7 +954,8 @@ def declare_lost(
             },
         )
 
-    result = proposal.graph_write(con, op)
+    with ExitStack() as fences:
+        result = proposal.graph_write(con, op)
     drive = _drive(con, drive_label)
     return {
         "drive_label": drive_label,

--- a/modelark/execution_authority.py
+++ b/modelark/execution_authority.py
@@ -1,0 +1,34 @@
+"""Workflow-neutral execution identity checks; neither persistence nor live exclusion.
+
+Adapters must obtain ``actual`` inside their own guarded transaction and retain the
+appropriate physical fence. A matching durable attempt is necessary authority evidence,
+not proof that its process is alive. Each workflow supplies its own writable states.
+"""
+from __future__ import annotations
+
+from collections.abc import Collection
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Attempt:
+    owner: str
+    token: str | int
+
+
+class AuthorityLost(ValueError):
+    """The expected execution attempt no longer owns an allowed transition."""
+
+
+def require_current(expected: Attempt, actual: Attempt, state: str,
+                    allowed_states: Collection[str]) -> None:
+    """Require the exact execution owner, attempt token, and workflow state.
+
+    Tokens are opaque: persistence adapters normalize them, if necessary, before
+    constructing attempts. This function does not acquire locks, renew leases, or
+    authorize a mutation outside the caller's transaction/fence lifetime.
+    """
+    if expected != actual:
+        raise AuthorityLost("execution attempt differs")
+    if state not in allowed_states:
+        raise AuthorityLost("execution state does not permit this operation")

--- a/modelark/execution_recovery.py
+++ b/modelark/execution_recovery.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from modelark import execution_authority as authority
 from modelark.proposal import Refusal
 
 # session_id -> list of open file handles holding drive/controller fences (OS-visible flock).
@@ -247,18 +248,27 @@ def recover_expired_session(con, *, session_id, services):
                 "WHERE session_id=?", [session_id]).fetchone()
             if not row2:
                 raise Refusal("SESSION_NOT_FOUND", {"session_id": session_id}, ())
-            if int(row2[1]) != token:
+            expected = authority.Attempt(session_id, token)
+            actual = authority.Attempt(session_id, int(row2[1]))
+            try:
+                # Preserve refusal precedence: changed identity precedes expiry, and
+                # the workflow-state check follows expiry revalidation below.
+                authority.require_current(expected, actual, row2[0], (row2[0],))
+            except authority.AuthorityLost as exc:
                 raise Refusal(
                     "SESSION_TOKEN_MISMATCH",
-                    {"session_id": session_id, "token": token}, ())
+                    {"session_id": session_id, "token": token}, ()) from exc
             now2 = _now(services)
             if not _expired(row2[2], now2):
                 raise Refusal(
                     "SESSION_NOT_EXPIRED",
                     {"expires_at": row2[2], "now": now2.isoformat()}, ())
-            if row2[0] not in ("starting", "running", "stopping"):
+            try:
+                authority.require_current(expected, actual, row2[0],
+                                          ("starting", "running", "stopping"))
+            except authority.AuthorityLost as exc:
                 raise Refusal(
-                    "SESSION_STATE_INVALID", {"state": row2[0]}, ())
+                    "SESSION_STATE_INVALID", {"state": row2[0]}, ()) from exc
             # Expiry re-validated above; CAS on token + live state + still-expired expires_at.
             exp_bound = row2[2]
             if exp_bound is None:

--- a/modelark/execution_session.py
+++ b/modelark/execution_session.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Mapping
 
 from modelark import execution_config as ecfg
+from modelark import execution_authority as authority
 from modelark import execution_projection as eproj
 from modelark.proposal import Refusal, bump_revision, current_draft_ids, load_proposal
 
@@ -646,8 +647,14 @@ def session_write(con, session_id, fencing_token, operation: Callable):
             row2 = con.execute(
                 "SELECT fencing_token, state FROM execution_sessions WHERE session_id=?",
                 [session_id]).fetchone()
-            if not row2 or int(row2[0]) != int(fencing_token) or row2[1] not in LIVE_STATES:
+            if not row2:
                 raise Refusal("SESSION_TOKEN_MISMATCH", {"session_id": session_id}, ())
+            try:
+                authority.require_current(
+                    authority.Attempt(session_id, int(fencing_token)),
+                    authority.Attempt(session_id, int(row2[0])), row2[1], LIVE_STATES)
+            except authority.AuthorityLost as exc:
+                raise Refusal("SESSION_TOKEN_MISMATCH", {"session_id": session_id}, ()) from exc
             result = operation(con)
             new_rev = bump_revision(con)
             con.execute(

--- a/modelark/slice/authority.py
+++ b/modelark/slice/authority.py
@@ -1,0 +1,167 @@
+"""Live delivery-attempt capabilities, separate from durable plans and archive authority."""
+import errno
+import hashlib
+import os
+import socket
+import uuid
+
+from modelark.execution_authority import Attempt
+
+
+RESUMABLE_STATES = frozenset({"approved", "starting", "transferring", "verifying", "stopped",
+                              "waiting_source", "blocked_source", "waiting_destination"})
+RUNNING_STATES = RESUMABLE_STATES - {"approved"}
+TERMINAL_STATES = frozenset({"complete", "failed", "invalidated"})
+_OUTCOMES = frozenset({"stopped", "waiting_source", "blocked_source", "waiting_destination",
+                       "failed", "invalidated"})
+TRANSITIONS = {
+    "starting": _OUTCOMES | {"transferring"},
+    "transferring": _OUTCOMES | {"transferring", "verifying"},
+    "verifying": _OUTCOMES | {"verifying"},
+    **{state: _OUTCOMES | {"transferring"}
+       for state in ("waiting_source", "blocked_source", "waiting_destination")},
+    "stopped": frozenset({"stopped"}),  # Resume requires a newly claimed attempt.
+}
+
+
+def refusal_state(code):
+    return {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
+            "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}.get(
+                code, "invalidated" if code.startswith("DESTINATION_") else "failed")
+
+
+def _marker_address(device, attempt):
+    key = hashlib.sha256(f"{device}\0{attempt.owner}\0{attempt.token}".encode()).hexdigest()
+    return "\0modelark-slice-attempt-" + key
+
+
+class Lease:
+    """Two kernel-held descriptors: device exclusion and unique live-attempt identity.
+
+    Markers are bound datagram endpoints, queried by connect only (no messages/listener/thread).
+    Always close marker before exclusion. Fork children inherit both; a writing exec child must
+    inherit both fds and follow this release order. The engine itself creates no writer children.
+    """
+    def __init__(self, device, owner=None):
+        from .transaction import TransferRefusal
+        self.device, self.pid = device, os.getpid()
+        self.attempt = Attempt(owner, uuid.uuid4().hex) if owner is not None else None
+        self.marker = None
+        self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            self.socket.bind("\0modelark-slice-device-" + hashlib.sha256(device.encode()).hexdigest())
+            if self.attempt is not None:
+                self.marker = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+                self.marker.bind(_marker_address(device, self.attempt))
+        except OSError as exc:
+            self.close()
+            if exc.errno == errno.EADDRINUSE:
+                raise TransferRefusal("DESTINATION_BUSY") from exc
+            raise
+
+    @staticmethod
+    def retained(device, attempt):
+        if attempt is None:
+            return False
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as query:
+            query.setblocking(False)
+            try:
+                query.connect(_marker_address(device, attempt))
+            except OSError:
+                return False  # No current proof, including an endpoint disappearing during query.
+        return True
+
+    def close(self):
+        if self.marker is not None:
+            self.marker.close()
+        self.socket.close()
+
+    def check(self):
+        from .transaction import TransferRefusal
+        if (os.getpid() != self.pid or self.socket.fileno() < 0
+                or (self.attempt is not None and self.marker.fileno() < 0)):
+            raise TransferRefusal("EXECUTION_FENCE_LOST")
+
+
+class DeliveryAuthority:
+    """The sole execution facade for activation, boundaries, outcomes and release."""
+    def __init__(self, store, tx, device, lease):
+        self.store, self.tx, self.device, self.lease = store, tx, device, lease
+        self.attempt = lease.attempt
+
+    @classmethod
+    def acquire(cls, store, tx, device, reservation):
+        from .transaction import TransferRefusal
+        try:
+            lease = Lease(device, tx)
+        except TransferRefusal:
+            current = store.status(tx)
+            if current.state == "complete":
+                return current
+            attempt = store.current_attempt(device)
+            if (attempt is not None and attempt.owner == tx and Lease.retained(device, attempt)
+                    and store.current_attempt(device) == attempt):
+                return store.status(tx)  # Retained attempt exclusion, not a progress/heartbeat claim.
+            raise
+        authority = cls(store, tx, device, lease)
+        try:
+            current = store.status(tx)
+            if current.state == "complete":
+                lease.close()
+                return current
+            outcome = store.claim(tx, device, lease.attempt, reservation)
+            if outcome.state in {"complete", "stopped"}:
+                lease.close()
+                if outcome.state == "stopped":
+                    raise TransferRefusal("STOPPED")
+                return outcome
+            return authority
+        except BaseException:
+            lease.close()
+            raise
+
+    def activate(self):
+        from .transaction import TransferRefusal
+        self.lease.check()
+        outcome = self.store.transition(self.attempt, self.device, "transferring")
+        if outcome.state == "stopped":
+            raise TransferRefusal("STOPPED")
+        return outcome
+
+    def boundary(self):
+        from .transaction import TransferRefusal
+        self.lease.check()
+        stopped, head = self.store.guard(self.attempt, self.device)
+        if stopped:
+            raise TransferRefusal("STOPPED")
+        return head
+
+    def transition(self, state, reason=""):
+        from .transaction import TransferRefusal
+        self.lease.check()
+        outcome = self.store.transition(self.attempt, self.device, state, reason)
+        if outcome.state == "stopped" and state != "stopped":
+            raise TransferRefusal("STOPPED")
+        return outcome
+
+    def append(self, event, payload, *, expected_head):
+        self.lease.check()
+        return self.store.append(self.tx, event, payload, expected_head=expected_head,
+                                 attempt=self.attempt, device=self.device)
+
+    def complete(self):
+        self.lease.check()
+        self.store.complete(self.attempt, self.device, self.lease.close)
+
+    def refuse(self, exc):
+        # A failed/closed capability may never publish a later failure over a new attempt.
+        return self.transition(refusal_state(exc.code), str(exc))
+
+    def close(self):
+        try:
+            if self.lease.socket.fileno() >= 0 and self.lease.pid == os.getpid():
+                current = self.store.status(self.tx)
+                if current.state in {"starting", "transferring", "verifying"}:
+                    self.transition("stopped")
+        finally:
+            self.lease.close()

--- a/modelark/slice/sources.py
+++ b/modelark/slice/sources.py
@@ -1,5 +1,5 @@
 """Read-only source-use gate sharing the archive writer's nonblocking drive fence."""
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 
 from modelark import drive_fence
 from .catalog import read_catalog
@@ -20,15 +20,17 @@ class FencedSources:
     @contextmanager
     def open(self, candidate):
         key = (candidate.drive.identity_fingerprint, candidate.drive.identity_epoch)
-        try:
-            with drive_fence.hold_drives_sorted([key], blocking=False):
+        with ExitStack() as stack:
+            try:
+                stack.enter_context(drive_fence.hold_drives_sorted([key], blocking=False))
                 spec = SliceSpec((candidate.copy.repo_id,), "source-evidence", "unused")
                 snapshot = read_catalog(self.catalog_path, spec)
-                with self.reader.open(candidate) as stream:
-                    yield snapshot, stream
-        except drive_fence.FenceUnavailable as exc:
-            raise TransferRefusal("SOURCE_BUSY", candidate.drive.drive_label) from exc
-        except SliceRefusal as exc:
-            raise TransferRefusal("SOURCE_EVIDENCE_UNAVAILABLE", str(exc)) from exc
-        except FileNotFoundError as exc:
-            raise TransferRefusal("SOURCE_MISSING", candidate.drive.drive_label) from exc
+                stream = stack.enter_context(self.reader.open(candidate))
+            except drive_fence.FenceUnavailable as exc:
+                raise TransferRefusal("SOURCE_BUSY", candidate.drive.drive_label) from exc
+            except SliceRefusal as exc:
+                raise TransferRefusal("SOURCE_EVIDENCE_UNAVAILABLE", str(exc)) from exc
+            except FileNotFoundError as exc:
+                raise TransferRefusal("SOURCE_MISSING", candidate.drive.drive_label) from exc
+            # Do not translate exceptions thrown by the destination/consumer inside this yield.
+            yield snapshot, stream

--- a/modelark/slice/sources.py
+++ b/modelark/slice/sources.py
@@ -7,6 +7,20 @@ from .domain import SliceRefusal, SliceSpec
 from .transaction import TransferRefusal
 
 
+class _SourceRead:
+    """Translate only IO performed by the source stream, never its consumer's IO."""
+    def __init__(self, stream, label):
+        self.stream, self.label = stream, label
+
+    def read(self, size=-1):
+        try:
+            return self.stream.read(size)
+        except FileNotFoundError as exc:
+            raise TransferRefusal("SOURCE_MISSING", self.label) from exc
+        except OSError as exc:
+            raise TransferRefusal("SOURCE_READ_FAILED", f"{self.label}: {exc}") from exc
+
+
 class FencedSources:
     """Compose fresh catalog evidence with an injected retrieval-disabled local reader.
 
@@ -33,4 +47,4 @@ class FencedSources:
             except FileNotFoundError as exc:
                 raise TransferRefusal("SOURCE_MISSING", candidate.drive.drive_label) from exc
             # Do not translate exceptions thrown by the destination/consumer inside this yield.
-            yield snapshot, stream
+            yield snapshot, _SourceRead(stream, candidate.drive.drive_label)

--- a/modelark/slice/sources.py
+++ b/modelark/slice/sources.py
@@ -1,0 +1,34 @@
+"""Read-only source-use gate sharing the archive writer's nonblocking drive fence."""
+from contextlib import contextmanager
+
+from modelark import drive_fence
+from .catalog import read_catalog
+from .domain import SliceRefusal, SliceSpec
+from .transaction import TransferRefusal
+
+
+class FencedSources:
+    """Compose fresh catalog evidence with an injected retrieval-disabled local reader.
+
+    reader.open(candidate) must prove attachment identity and descriptor confinement before
+    yielding original bytes. Slice 2 intentionally ships no real archive reader/decompressor.
+    No controller fence, mutation envelope, schema bootstrap or archive repair is acquired.
+    """
+    def __init__(self, catalog_path, reader):
+        self.catalog_path, self.reader = catalog_path, reader
+
+    @contextmanager
+    def open(self, candidate):
+        key = (candidate.drive.identity_fingerprint, candidate.drive.identity_epoch)
+        try:
+            with drive_fence.hold_drives_sorted([key], blocking=False):
+                spec = SliceSpec((candidate.copy.repo_id,), "source-evidence", "unused")
+                snapshot = read_catalog(self.catalog_path, spec)
+                with self.reader.open(candidate) as stream:
+                    yield snapshot, stream
+        except drive_fence.FenceUnavailable as exc:
+            raise TransferRefusal("SOURCE_BUSY", candidate.drive.drive_label) from exc
+        except SliceRefusal as exc:
+            raise TransferRefusal("SOURCE_EVIDENCE_UNAVAILABLE", str(exc)) from exc
+        except FileNotFoundError as exc:
+            raise TransferRefusal("SOURCE_MISSING", candidate.drive.drive_label) from exc

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -85,7 +85,7 @@ class Store:
             raise ValueError("unsafe slice state database")
         with self._connection() as con:
             version = con.execute("PRAGMA user_version").fetchone()[0]
-            if version not in (0, 1, 2, 3):
+            if version not in (0, 1, 2, 3, 4):
                 raise ValueError("unsupported slice state version")
             con.execute("CREATE TABLE IF NOT EXISTS transactions ("
                         "id TEXT PRIMARY KEY, plan TEXT NOT NULL, seal TEXT NOT NULL,"
@@ -100,7 +100,8 @@ class Store:
                     con.execute("ALTER TABLE transactions ADD COLUMN stop_serial INTEGER NOT NULL DEFAULT 0")
             con.execute("CREATE TABLE IF NOT EXISTS owners (device TEXT PRIMARY KEY,"
                         "tx TEXT UNIQUE NOT NULL REFERENCES transactions(id),"
-                        "activation_serial INTEGER NOT NULL DEFAULT 0)")
+                        "activation_serial INTEGER NOT NULL DEFAULT 0,"
+                        "process_seen INTEGER NOT NULL DEFAULT 0)")
             columns = {row[1] for row in con.execute("PRAGMA table_info(owners)")}
             if "activation_serial" not in columns:
                 con.execute("ALTER TABLE owners ADD COLUMN activation_serial INTEGER NOT NULL DEFAULT 0")
@@ -108,10 +109,13 @@ class Store:
                 # pending stop conservatively; an explicit stopped-state resume can clear it.
                 con.execute("UPDATE owners SET activation_serial=(SELECT stop_serial-stop "
                             "FROM transactions WHERE id=owners.tx)")
+            if "process_seen" not in columns:
+                # An old reservation alone cannot prove that its process ever held exclusion.
+                con.execute("ALTER TABLE owners ADD COLUMN process_seen INTEGER NOT NULL DEFAULT 0")
             con.execute("CREATE TABLE IF NOT EXISTS journal (tx TEXT NOT NULL REFERENCES transactions(id),"
                         "seq INTEGER NOT NULL, event TEXT NOT NULL, payload TEXT NOT NULL, digest TEXT NOT NULL,"
                         "PRIMARY KEY(tx,seq))")
-            con.execute("PRAGMA user_version=3")
+            con.execute("PRAGMA user_version=4")
 
     @contextmanager
     def _connection(self, *, write=True):
@@ -210,6 +214,19 @@ class Store:
             if not owner:
                 con.execute("UPDATE transactions SET state='starting',reason='' WHERE id=?", (tx,))
             return Reservation(serial, not owner)
+
+    def process_owner(self, device):
+        with self._connection(write=False) as con:
+            row = con.execute("SELECT tx FROM owners WHERE device=? AND process_seen=1", (device,)).fetchone()
+        return row[0] if row else None
+
+    def record_process(self, tx, device):
+        # Only call while holding device exclusion. The bit remains valid for this durable
+        # reservation: no other transaction can acquire the device until that owner is deleted.
+        if self.process_owner(device) == tx:
+            return
+        with self._connection() as con:
+            con.execute("UPDATE owners SET process_seen=1 WHERE device=? AND tx=?", (device, tx))
 
     def activate(self, tx, device, stop_serial):
         from .transaction import TransferRefusal, _RESUMABLE_STATES

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -84,7 +84,8 @@ class Store:
             con.execute("CREATE TABLE IF NOT EXISTS transactions ("
                         "id TEXT PRIMARY KEY, plan TEXT NOT NULL, seal TEXT NOT NULL,"
                         "state TEXT NOT NULL, stop INTEGER NOT NULL DEFAULT 0, reason TEXT NOT NULL DEFAULT '',"
-                        "journal_seq INTEGER NOT NULL DEFAULT 0, journal_digest TEXT NOT NULL DEFAULT '')")
+                        "journal_seq INTEGER NOT NULL DEFAULT 0, journal_digest TEXT NOT NULL DEFAULT '',"
+                        "stop_serial INTEGER NOT NULL DEFAULT 0)")
             con.execute("CREATE TABLE IF NOT EXISTS owners (device TEXT PRIMARY KEY,"
                         "tx TEXT UNIQUE NOT NULL REFERENCES transactions(id))")
             con.execute("CREATE TABLE IF NOT EXISTS journal (tx TEXT NOT NULL REFERENCES transactions(id),"
@@ -93,14 +94,23 @@ class Store:
             con.execute("PRAGMA user_version=1")
 
     @contextmanager
-    def _connection(self):
-        con = sqlite3.connect(self.path.as_uri() + "?mode=rw", uri=True, timeout=0, isolation_level=None)
+    def _connection(self, *, write=True):
+        # Reader operations use deferred read transactions, but the private DB handle retains
+        # SQLite's ability to recover a hot rollback journal left by a dead writer.
+        con = sqlite3.connect(self.path.as_uri() + "?mode=rw", uri=True, timeout=5, isolation_level=None)
         try:
             con.execute("PRAGMA foreign_keys=ON")
             con.execute("PRAGMA synchronous=FULL")
-            con.execute("BEGIN IMMEDIATE")
+            con.execute("BEGIN IMMEDIATE" if write else "BEGIN")
             yield con
             con.execute("COMMIT")
+        except sqlite3.OperationalError as exc:
+            if con.in_transaction:
+                con.execute("ROLLBACK")
+            from .transaction import TransferRefusal
+            if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                raise TransferRefusal("STATE_BUSY", "private state writer did not finish") from exc
+            raise
         except BaseException:
             if con.in_transaction:
                 con.execute("ROLLBACK")
@@ -118,7 +128,7 @@ class Store:
 
     def load(self, tx):
         from .transaction import TransferPlan, TransferRefusal
-        with self._connection() as con:
+        with self._connection(write=False) as con:
             row = con.execute("SELECT plan,seal FROM transactions WHERE id=?", (tx,)).fetchone()
         if row is None:
             raise TransferRefusal("TRANSACTION_MISSING", tx)
@@ -140,29 +150,50 @@ class Store:
 
     def status(self, tx):
         from .transaction import Status, TransferRefusal
-        with self._connection() as con:
+        with self._connection(write=False) as con:
             row = con.execute("SELECT state,reason FROM transactions WHERE id=?", (tx,)).fetchone()
         if row is None:
             raise TransferRefusal("TRANSACTION_MISSING", tx)
         return Status(tx, *row)
 
     def owner(self, device):
-        with self._connection() as con:
+        with self._connection(write=False) as con:
             row = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
         return row[0] if row else None
 
-    def claim(self, tx, device):
+    def reserve(self, tx, device):
         from .transaction import TransferRefusal
-        with self._connection() as con:
+        def inspect(con):
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
             if owner and owner[0] != tx:
                 raise TransferRefusal("DESTINATION_BUSY", owner[0])
-            state = con.execute("SELECT state FROM transactions WHERE id=?", (tx,)).fetchone()[0]
-            if state not in {"approved", "transferring", "verifying", "stopped", "waiting_source",
+            state, serial = con.execute("SELECT state,stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
+            if state not in {"approved", "starting", "transferring", "verifying", "stopped", "waiting_source",
                              "blocked_source", "waiting_destination"}:
                 raise TransferRefusal("APPROVAL_MISSING" if state == "ready" else "NOT_RESUMABLE", state)
+            return owner, serial
+        # Repeated Start is a reader while an owner is actively journaling. Only the first
+        # reservation needs the writer transaction; recheck inside it to close the CAS race.
+        with self._connection(write=False) as con:
+            owner, serial = inspect(con)
+            if owner:
+                return serial
+        with self._connection() as con:
+            owner, serial = inspect(con)
             con.execute("INSERT OR IGNORE INTO owners(device,tx) VALUES(?,?)", (device, tx))
-            con.execute("UPDATE transactions SET state='transferring',stop=0,reason='' WHERE id=?", (tx,))
+            if not owner:
+                con.execute("UPDATE transactions SET state='starting',reason='' WHERE id=?", (tx,))
+            return serial
+
+    def activate(self, tx, device, stop_serial):
+        from .transaction import TransferRefusal
+        with self._connection() as con:
+            owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
+            if not owner or owner[0] != tx:
+                raise TransferRefusal("EXECUTION_FENCE_LOST")
+            # A stop arriving during initialization must not be erased by activation.
+            con.execute("UPDATE transactions SET state='transferring',reason='',"
+                        "stop=CASE WHEN stop_serial=? THEN 0 ELSE stop END WHERE id=?", (stop_serial, tx))
 
     def set_state(self, tx, state, reason=""):
         with self._connection() as con:
@@ -170,25 +201,39 @@ class Store:
 
     def request_stop(self, tx):
         with self._connection() as con:
-            con.execute("UPDATE transactions SET stop=1 WHERE id=?", (tx,))
+            con.execute("UPDATE transactions SET stop=1,stop_serial=stop_serial+1 WHERE id=?", (tx,))
 
     def stop_requested(self, tx):
-        with self._connection() as con:
+        with self._connection(write=False) as con:
             return bool(con.execute("SELECT stop FROM transactions WHERE id=?", (tx,)).fetchone()[0])
 
-    def append(self, tx, event, payload):
+    def guard(self, tx, device):
+        with self._connection(write=False) as con:
+            row = con.execute("SELECT t.stop,t.journal_seq,t.journal_digest,o.tx FROM transactions t "
+                              "LEFT JOIN owners o ON o.device=? WHERE t.id=?", (device, tx)).fetchone()
+        return bool(row[0]), (row[1], row[2]), row[3]
+
+    def head(self, tx):
+        with self._connection(write=False) as con:
+            return con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (tx,)).fetchone()
+
+    def append(self, tx, event, payload, *, expected_head=None):
         encoded = _json(payload).decode()
         with self._connection() as con:
             last = con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (tx,)).fetchone()
+            if expected_head is not None and last != expected_head:
+                from .transaction import TransferRefusal
+                raise TransferRefusal("JOURNAL_CORRUPT", "journal changed outside its fenced writer")
             seq, previous = last[0] + 1, last[1]
             digest = hashlib.sha256(_json([tx, seq, previous, event, encoded])).hexdigest()
             con.execute("INSERT INTO journal VALUES(?,?,?,?,?)", (tx, seq, event, encoded, digest))
             con.execute("UPDATE transactions SET journal_seq=?,journal_digest=? WHERE id=?", (seq, digest, tx))
+        return seq, digest
 
     def events(self, tx):
         import json
         from .transaction import TransferRefusal
-        with self._connection() as con:
+        with self._connection(write=False) as con:
             rows = con.execute("SELECT seq,event,payload,digest FROM journal WHERE tx=? ORDER BY seq", (tx,)).fetchall()
             head = con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (tx,)).fetchone()
         previous, events = "", []

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -214,15 +214,30 @@ class Store:
     def activate(self, tx, device, stop_serial):
         from .transaction import TransferRefusal, _RESUMABLE_STATES
         with self._connection() as con:
+            state = con.execute("SELECT state FROM transactions WHERE id=?", (tx,)).fetchone()[0]
+            if state == "complete":
+                return False
+            if state not in _RESUMABLE_STATES:
+                raise TransferRefusal("NOT_RESUMABLE", state)
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
             if not owner or owner[0] != tx:
                 raise TransferRefusal("EXECUTION_FENCE_LOST")
-            state = con.execute("SELECT state FROM transactions WHERE id=?", (tx,)).fetchone()[0]
-            if state not in _RESUMABLE_STATES:
-                raise TransferRefusal("NOT_RESUMABLE", state)
             # A stop arriving during initialization must not be erased by activation.
             con.execute("UPDATE transactions SET state='transferring',reason='',"
                         "stop=CASE WHEN stop_serial=? THEN 0 ELSE stop END WHERE id=?", (stop_serial.stop_serial, tx))
+        return True
+
+    def refuse_start(self, tx, device, state, reason):
+        from .transaction import Status, _RESUMABLE_STATES
+        # A pre-activation adapter check may finish after another Session commits its
+        # terminal outcome. Serialize refusal publication with that outcome, not a snapshot.
+        with self._connection() as con:
+            current = con.execute("SELECT state,reason FROM transactions WHERE id=?", (tx,)).fetchone()
+            owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
+            if current[0] in _RESUMABLE_STATES and owner and owner[0] == tx:
+                con.execute("UPDATE transactions SET state=?,reason=? WHERE id=?", (state, reason, tx))
+                current = state, reason
+            return Status(tx, *current)
 
     def set_state(self, tx, state, reason=""):
         with self._connection() as con:

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -125,10 +125,11 @@ class Store:
             con.close()
 
     def create(self, plan, approval):
-        if plan.version != "modelark.slice.transaction.v2":
+        if plan.version != "modelark.slice.transaction.v3":
             from .transaction import TransferRefusal
-            raise TransferRefusal("LEGACY_PLAN", "new transactions require protocol v2")
+            raise TransferRefusal("LEGACY_PLAN", "new transactions require protocol v3")
         validate_approval(plan.proposal, approval)
+        plan.required_bytes(self.root)
         tx = uuid.uuid4().hex
         with self._connection() as con:
             con.execute("INSERT INTO transactions(id,plan,seal,state) VALUES(?,?,?,'ready')",

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -79,19 +79,25 @@ class Store:
             raise ValueError("unsafe slice state database")
         with self._connection() as con:
             version = con.execute("PRAGMA user_version").fetchone()[0]
-            if version not in (0, 1):
+            if version not in (0, 1, 2):
                 raise ValueError("unsupported slice state version")
             con.execute("CREATE TABLE IF NOT EXISTS transactions ("
                         "id TEXT PRIMARY KEY, plan TEXT NOT NULL, seal TEXT NOT NULL,"
                         "state TEXT NOT NULL, stop INTEGER NOT NULL DEFAULT 0, reason TEXT NOT NULL DEFAULT '',"
                         "journal_seq INTEGER NOT NULL DEFAULT 0, journal_digest TEXT NOT NULL DEFAULT '',"
                         "stop_serial INTEGER NOT NULL DEFAULT 0)")
+            # Both pre-review v1 and the corrected v1 appeared during Slice 2 development.
+            # Preserve plans, reservations, stops and journal heads in the same durable commit.
+            if version == 1:
+                columns = {row[1] for row in con.execute("PRAGMA table_info(transactions)")}
+                if "stop_serial" not in columns:
+                    con.execute("ALTER TABLE transactions ADD COLUMN stop_serial INTEGER NOT NULL DEFAULT 0")
             con.execute("CREATE TABLE IF NOT EXISTS owners (device TEXT PRIMARY KEY,"
                         "tx TEXT UNIQUE NOT NULL REFERENCES transactions(id))")
             con.execute("CREATE TABLE IF NOT EXISTS journal (tx TEXT NOT NULL REFERENCES transactions(id),"
                         "seq INTEGER NOT NULL, event TEXT NOT NULL, payload TEXT NOT NULL, digest TEXT NOT NULL,"
                         "PRIMARY KEY(tx,seq))")
-            con.execute("PRAGMA user_version=1")
+            con.execute("PRAGMA user_version=2")
 
     @contextmanager
     def _connection(self, *, write=True):

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -125,6 +125,9 @@ class Store:
             con.close()
 
     def create(self, plan, approval):
+        if plan.version != "modelark.slice.transaction.v2":
+            from .transaction import TransferRefusal
+            raise TransferRefusal("LEGACY_PLAN", "new transactions require protocol v2")
         validate_approval(plan.proposal, approval)
         tx = uuid.uuid4().hex
         with self._connection() as con:
@@ -168,14 +171,13 @@ class Store:
         return row[0] if row else None
 
     def reserve(self, tx, device):
-        from .transaction import TransferRefusal
+        from .transaction import TransferRefusal, _RESUMABLE_STATES
         def inspect(con):
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
             if owner and owner[0] != tx:
                 raise TransferRefusal("DESTINATION_BUSY", owner[0])
             state, serial = con.execute("SELECT state,stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
-            if state not in {"approved", "starting", "transferring", "verifying", "stopped", "waiting_source",
-                             "blocked_source", "waiting_destination"}:
+            if state not in _RESUMABLE_STATES:
                 raise TransferRefusal("APPROVAL_MISSING" if state == "ready" else "NOT_RESUMABLE", state)
             return owner, serial
         # Repeated Start is a reader while an owner is actively journaling. Only the first
@@ -192,11 +194,14 @@ class Store:
             return serial
 
     def activate(self, tx, device, stop_serial):
-        from .transaction import TransferRefusal
+        from .transaction import TransferRefusal, _RESUMABLE_STATES
         with self._connection() as con:
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
             if not owner or owner[0] != tx:
                 raise TransferRefusal("EXECUTION_FENCE_LOST")
+            state = con.execute("SELECT state FROM transactions WHERE id=?", (tx,)).fetchone()[0]
+            if state not in _RESUMABLE_STATES:
+                raise TransferRefusal("NOT_RESUMABLE", state)
             # A stop arriving during initialization must not be erased by activation.
             con.execute("UPDATE transactions SET state='transferring',reason='',"
                         "stop=CASE WHEN stop_serial=? THEN 0 ELSE stop END WHERE id=?", (stop_serial, tx))

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -13,6 +13,8 @@ import stat
 import uuid
 from typing import NamedTuple
 
+from modelark.execution_authority import Attempt, AuthorityLost, require_current
+from .authority import RESUMABLE_STATES, RUNNING_STATES, TERMINAL_STATES, TRANSITIONS
 from .domain import _json, validate_approval
 
 
@@ -20,8 +22,9 @@ HOST_STATE_DIR = Path.home() / ".local" / "state" / "modelark" / "slice"
 
 
 class Reservation(NamedTuple):
+    state: str
     stop_serial: int
-    created: bool
+    acknowledged_stop_serial: int
 
 
 def _private_directory(path):
@@ -85,7 +88,7 @@ class Store:
             raise ValueError("unsafe slice state database")
         with self._connection() as con:
             version = con.execute("PRAGMA user_version").fetchone()[0]
-            if version not in (0, 1, 2, 3, 4):
+            if version not in (0, 1, 2, 3, 4, 5):
                 raise ValueError("unsupported slice state version")
             con.execute("CREATE TABLE IF NOT EXISTS transactions ("
                         "id TEXT PRIMARY KEY, plan TEXT NOT NULL, seal TEXT NOT NULL,"
@@ -112,10 +115,20 @@ class Store:
             if "process_seen" not in columns:
                 # An old reservation alone cannot prove that its process ever held exclusion.
                 con.execute("ALTER TABLE owners ADD COLUMN process_seen INTEGER NOT NULL DEFAULT 0")
+            if "attempt" not in columns:
+                con.execute("ALTER TABLE owners ADD COLUMN attempt TEXT")
+            transaction_columns = {row[1] for row in con.execute("PRAGMA table_info(transactions)")}
+            if "acknowledged_stop_serial" not in transaction_columns:
+                con.execute("ALTER TABLE transactions ADD COLUMN acknowledged_stop_serial INTEGER NOT NULL DEFAULT 0")
+                # Legacy stopped rows can also contain a NEW, unacknowledged request.
+                # No old state label proves which request was actually acknowledged.
+                con.execute("UPDATE transactions SET acknowledged_stop_serial=stop_serial-stop")
+            # Legacy fields are retained for development-database compatibility only.
+            # Neither process_seen nor activation_serial is execution authority in v5.
             con.execute("CREATE TABLE IF NOT EXISTS journal (tx TEXT NOT NULL REFERENCES transactions(id),"
                         "seq INTEGER NOT NULL, event TEXT NOT NULL, payload TEXT NOT NULL, digest TEXT NOT NULL,"
                         "PRIMARY KEY(tx,seq))")
-            con.execute("PRAGMA user_version=4")
+            con.execute("PRAGMA user_version=5")
 
     @contextmanager
     def _connection(self, *, write=True):
@@ -190,75 +203,93 @@ class Store:
         return row[0] if row else None
 
     def reserve(self, tx, device):
-        from .transaction import TransferRefusal, _RESUMABLE_STATES
+        from .transaction import TransferRefusal, Status
         def inspect(con):
-            owner = con.execute("SELECT tx,activation_serial FROM owners WHERE device=?", (device,)).fetchone()
+            state, serial, acknowledged = con.execute(
+                "SELECT state,stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
+            if state == "complete":
+                return None, Status(tx, state)
+            owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
             if owner and owner[0] != tx:
                 raise TransferRefusal("DESTINATION_BUSY", owner[0])
-            state, serial = con.execute("SELECT state,stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
-            if state not in _RESUMABLE_STATES:
+            if state not in RESUMABLE_STATES:
                 raise TransferRefusal("APPROVAL_MISSING" if state == "ready" else "NOT_RESUMABLE", state)
-            if owner and state == "starting":
-                serial = owner[1]
-            return owner, serial
+            return owner, Reservation(state, serial, acknowledged)
         # Repeated Start is a reader while an owner is actively journaling. Only the first
         # reservation needs the writer transaction; recheck inside it to close the CAS race.
         with self._connection(write=False) as con:
-            owner, serial = inspect(con)
-            if owner:
-                return Reservation(serial, False)
+            owner, reservation = inspect(con)
+            if owner or isinstance(reservation, Status):
+                return reservation
         with self._connection() as con:
-            owner, serial = inspect(con)
-            con.execute("INSERT OR IGNORE INTO owners(device,tx,activation_serial) VALUES(?,?,?)",
-                        (device, tx, serial))
+            owner, current = inspect(con)
+            if isinstance(current, Status):
+                return current
+            con.execute("INSERT OR IGNORE INTO owners(device,tx) VALUES(?,?)", (device, tx))
             if not owner:
                 con.execute("UPDATE transactions SET state='starting',reason='' WHERE id=?", (tx,))
-            return Reservation(serial, not owner)
+            # Revalidate ownership/state, but never upgrade this caller's original
+            # resume permission using a stop acknowledgment that happened while waiting.
+            return reservation
 
-    def process_owner(self, device):
+    def current_attempt(self, device):
         with self._connection(write=False) as con:
-            row = con.execute("SELECT tx FROM owners WHERE device=? AND process_seen=1", (device,)).fetchone()
-        return row[0] if row else None
+            row = con.execute("SELECT tx,attempt FROM owners WHERE device=?", (device,)).fetchone()
+        return Attempt(*row) if row and row[1] is not None else None
 
-    def record_process(self, tx, device):
-        # Only call while holding device exclusion. The bit remains valid for this durable
-        # reservation: no other transaction can acquire the device until that owner is deleted.
-        if self.process_owner(device) == tx:
-            return
+    def claim(self, tx, device, attempt, reservation):
+        """Publish an attempt only while its caller holds exclusion and its live marker."""
+        from .transaction import TransferRefusal, Status
         with self._connection() as con:
-            con.execute("UPDATE owners SET process_seen=1 WHERE device=? AND tx=?", (device, tx))
-
-    def activate(self, tx, device, stop_serial):
-        from .transaction import TransferRefusal, _RESUMABLE_STATES
-        with self._connection() as con:
-            state = con.execute("SELECT state FROM transactions WHERE id=?", (tx,)).fetchone()[0]
+            state, stop, serial, acknowledged = con.execute(
+                "SELECT state,stop,stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
             if state == "complete":
-                return False
-            if state not in _RESUMABLE_STATES:
+                return Status(tx, state)
+            if state not in RESUMABLE_STATES:
                 raise TransferRefusal("NOT_RESUMABLE", state)
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
-            if not owner or owner[0] != tx:
+            if not owner or owner[0] != tx or attempt.owner != tx:
                 raise TransferRefusal("EXECUTION_FENCE_LOST")
-            # A stop arriving during initialization must not be erased by activation.
-            con.execute("UPDATE transactions SET state='transferring',reason='',"
-                        "stop=CASE WHEN stop_serial=? THEN 0 ELSE stop END WHERE id=?", (stop_serial.stop_serial, tx))
-        return True
+            con.execute("UPDATE owners SET attempt=? WHERE device=? AND tx=?", (attempt.token, device, tx))
+            # Only a Start issued AFTER this exact stop was acknowledged may clear it.
+            resume = (reservation.state == state == "stopped"
+                      and reservation.stop_serial == reservation.acknowledged_stop_serial == serial == acknowledged)
+            if stop and not resume:
+                con.execute("UPDATE transactions SET state='stopped',reason='STOPPED',"
+                            "acknowledged_stop_serial=stop_serial WHERE id=?", (tx,))
+                return Status(tx, "stopped", "STOPPED")
+            con.execute("UPDATE transactions SET state='starting',reason='',stop=0 WHERE id=?", (tx,))
+            return Status(tx, "starting")
 
-    def refuse_start(self, tx, device, state, reason):
-        from .transaction import Status, _RESUMABLE_STATES
-        # A pre-activation adapter check may finish after another Session commits its
-        # terminal outcome. Serialize refusal publication with that outcome, not a snapshot.
-        with self._connection() as con:
-            current = con.execute("SELECT state,reason FROM transactions WHERE id=?", (tx,)).fetchone()
-            owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
-            if current[0] in _RESUMABLE_STATES and owner and owner[0] == tx:
-                con.execute("UPDATE transactions SET state=?,reason=? WHERE id=?", (state, reason, tx))
-                current = state, reason
-            return Status(tx, *current)
+    def _require_attempt(self, con, attempt, device, *, allow_stop=False):
+        from .transaction import TransferRefusal
+        row = con.execute("SELECT t.state,t.stop,o.tx,o.attempt FROM transactions t "
+                          "LEFT JOIN owners o ON o.device=? WHERE t.id=?", (device, attempt.owner)).fetchone()
+        if row is None:
+            raise TransferRefusal("EXECUTION_FENCE_LOST")
+        try:
+            require_current(attempt, Attempt(row[2], row[3]), row[0], RUNNING_STATES)
+        except AuthorityLost as exc:
+            code = "NOT_RESUMABLE" if row[0] in TERMINAL_STATES else "EXECUTION_FENCE_LOST"
+            raise TransferRefusal(code, str(exc)) from exc
+        if row[1] and not allow_stop:
+            raise TransferRefusal("STOPPED")
+        return row[0], bool(row[1])
 
-    def set_state(self, tx, state, reason=""):
+    def transition(self, attempt, device, state, reason=""):
+        from .transaction import Status, TransferRefusal
+        if state not in RUNNING_STATES | {"failed", "invalidated"}:
+            raise TransferRefusal("STATE_TRANSITION_INVALID", state)
         with self._connection() as con:
-            con.execute("UPDATE transactions SET state=?,reason=? WHERE id=?", (state, reason, tx))
+            current, stopped = self._require_attempt(con, attempt, device, allow_stop=True)
+            if stopped and state not in {"failed", "invalidated"}:
+                state, reason = "stopped", "STOPPED"
+            if state not in TRANSITIONS[current]:
+                raise TransferRefusal("STATE_TRANSITION_INVALID", f"{current} -> {state}")
+            con.execute("UPDATE transactions SET state=?,reason=?,acknowledged_stop_serial="
+                        "CASE WHEN ?='stopped' THEN stop_serial ELSE acknowledged_stop_serial END WHERE id=?",
+                        (state, reason, state, attempt.owner))
+            return Status(attempt.owner, state, reason)
 
     def request_stop(self, tx):
         with self._connection() as con:
@@ -268,19 +299,25 @@ class Store:
         with self._connection(write=False) as con:
             return bool(con.execute("SELECT stop FROM transactions WHERE id=?", (tx,)).fetchone()[0])
 
-    def guard(self, tx, device):
+    def guard(self, attempt, device):
         with self._connection(write=False) as con:
-            row = con.execute("SELECT t.stop,t.journal_seq,t.journal_digest,o.tx FROM transactions t "
-                              "LEFT JOIN owners o ON o.device=? WHERE t.id=?", (device, tx)).fetchone()
-        return bool(row[0]), (row[1], row[2]), row[3]
+            _, stopped = self._require_attempt(con, attempt, device, allow_stop=True)
+            head = con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (attempt.owner,)).fetchone()
+        return stopped, head
 
     def head(self, tx):
         with self._connection(write=False) as con:
             return con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (tx,)).fetchone()
 
-    def append(self, tx, event, payload, *, expected_head=None):
+    def append(self, tx, event, payload, *, expected_head=None, attempt, device):
+        from .transaction import TransferRefusal
         encoded = _json(payload).decode()
         with self._connection() as con:
+            state, _ = self._require_attempt(con, attempt, device)
+            if state not in {"transferring", "verifying"}:
+                raise TransferRefusal("STATE_TRANSITION_INVALID", f"journal append in {state}")
+            if attempt.owner != tx:
+                raise TransferRefusal("EXECUTION_FENCE_LOST")
             last = con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (tx,)).fetchone()
             if expected_head is not None and last != expected_head:
                 from .transaction import TransferRefusal
@@ -310,11 +347,15 @@ class Store:
     def receipt(self, tx):
         return next((payload for event, payload in reversed(self.events(tx)) if event == "receipt"), None)
 
-    def complete(self, tx, device, release_process):
+    def complete(self, attempt, device, release_process):
         from .transaction import TransferRefusal
+        tx = attempt.owner
         if self.receipt(tx) is None:
             raise TransferRefusal("RECEIPT_MISSING")
         with self._connection() as con:
+            state, _ = self._require_attempt(con, attempt, device)
+            if state != "verifying":
+                raise TransferRefusal("STATE_TRANSITION_INVALID", f"completion in {state}")
             con.execute("UPDATE transactions SET state='complete',reason='' WHERE id=?", (tx,))
             release_process()
             con.execute("DELETE FROM owners WHERE device=? AND tx=?", (device, tx))

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -11,11 +11,17 @@ from pathlib import Path
 import sqlite3
 import stat
 import uuid
+from typing import NamedTuple
 
 from .domain import _json, validate_approval
 
 
 HOST_STATE_DIR = Path.home() / ".local" / "state" / "modelark" / "slice"
+
+
+class Reservation(NamedTuple):
+    stop_serial: int
+    created: bool
 
 
 def _private_directory(path):
@@ -79,7 +85,7 @@ class Store:
             raise ValueError("unsafe slice state database")
         with self._connection() as con:
             version = con.execute("PRAGMA user_version").fetchone()[0]
-            if version not in (0, 1, 2):
+            if version not in (0, 1, 2, 3):
                 raise ValueError("unsupported slice state version")
             con.execute("CREATE TABLE IF NOT EXISTS transactions ("
                         "id TEXT PRIMARY KEY, plan TEXT NOT NULL, seal TEXT NOT NULL,"
@@ -93,11 +99,19 @@ class Store:
                 if "stop_serial" not in columns:
                     con.execute("ALTER TABLE transactions ADD COLUMN stop_serial INTEGER NOT NULL DEFAULT 0")
             con.execute("CREATE TABLE IF NOT EXISTS owners (device TEXT PRIMARY KEY,"
-                        "tx TEXT UNIQUE NOT NULL REFERENCES transactions(id))")
+                        "tx TEXT UNIQUE NOT NULL REFERENCES transactions(id),"
+                        "activation_serial INTEGER NOT NULL DEFAULT 0)")
+            columns = {row[1] for row in con.execute("PRAGMA table_info(owners)")}
+            if "activation_serial" not in columns:
+                con.execute("ALTER TABLE owners ADD COLUMN activation_serial INTEGER NOT NULL DEFAULT 0")
+                # Old initializations did not retain the activation token. Preserve any
+                # pending stop conservatively; an explicit stopped-state resume can clear it.
+                con.execute("UPDATE owners SET activation_serial=(SELECT stop_serial-stop "
+                            "FROM transactions WHERE id=owners.tx)")
             con.execute("CREATE TABLE IF NOT EXISTS journal (tx TEXT NOT NULL REFERENCES transactions(id),"
                         "seq INTEGER NOT NULL, event TEXT NOT NULL, payload TEXT NOT NULL, digest TEXT NOT NULL,"
                         "PRIMARY KEY(tx,seq))")
-            con.execute("PRAGMA user_version=2")
+            con.execute("PRAGMA user_version=3")
 
     @contextmanager
     def _connection(self, *, write=True):
@@ -174,25 +188,28 @@ class Store:
     def reserve(self, tx, device):
         from .transaction import TransferRefusal, _RESUMABLE_STATES
         def inspect(con):
-            owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
+            owner = con.execute("SELECT tx,activation_serial FROM owners WHERE device=?", (device,)).fetchone()
             if owner and owner[0] != tx:
                 raise TransferRefusal("DESTINATION_BUSY", owner[0])
             state, serial = con.execute("SELECT state,stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
             if state not in _RESUMABLE_STATES:
                 raise TransferRefusal("APPROVAL_MISSING" if state == "ready" else "NOT_RESUMABLE", state)
+            if owner and state == "starting":
+                serial = owner[1]
             return owner, serial
         # Repeated Start is a reader while an owner is actively journaling. Only the first
         # reservation needs the writer transaction; recheck inside it to close the CAS race.
         with self._connection(write=False) as con:
             owner, serial = inspect(con)
             if owner:
-                return serial
+                return Reservation(serial, False)
         with self._connection() as con:
             owner, serial = inspect(con)
-            con.execute("INSERT OR IGNORE INTO owners(device,tx) VALUES(?,?)", (device, tx))
+            con.execute("INSERT OR IGNORE INTO owners(device,tx,activation_serial) VALUES(?,?,?)",
+                        (device, tx, serial))
             if not owner:
                 con.execute("UPDATE transactions SET state='starting',reason='' WHERE id=?", (tx,))
-            return serial
+            return Reservation(serial, not owner)
 
     def activate(self, tx, device, stop_serial):
         from .transaction import TransferRefusal, _RESUMABLE_STATES
@@ -205,7 +222,7 @@ class Store:
                 raise TransferRefusal("NOT_RESUMABLE", state)
             # A stop arriving during initialization must not be erased by activation.
             con.execute("UPDATE transactions SET state='transferring',reason='',"
-                        "stop=CASE WHEN stop_serial=? THEN 0 ELSE stop END WHERE id=?", (stop_serial, tx))
+                        "stop=CASE WHEN stop_serial=? THEN 0 ELSE stop END WHERE id=?", (stop_serial.stop_serial, tx))
 
     def set_state(self, tx, state, reason=""):
         with self._connection() as con:
@@ -261,10 +278,11 @@ class Store:
     def receipt(self, tx):
         return next((payload for event, payload in reversed(self.events(tx)) if event == "receipt"), None)
 
-    def complete(self, tx, device):
+    def complete(self, tx, device, release_process):
         from .transaction import TransferRefusal
         if self.receipt(tx) is None:
             raise TransferRefusal("RECEIPT_MISSING")
         with self._connection() as con:
             con.execute("UPDATE transactions SET state='complete',reason='' WHERE id=?", (tx,))
+            release_process()
             con.execute("DELETE FROM owners WHERE device=? AND tx=?", (device, tx))

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -1,0 +1,213 @@
+"""Private, durable single-host slice authority. Never opens a ModelArk catalog.
+
+The host namespace is deliberately not a per-catalog/per-transaction option. Tests replace
+HOST_STATE_DIR with one disposable directory shared by all their child processes. Hardware
+adapters and a public entry point are not provided by Slice 2.
+"""
+from contextlib import contextmanager
+import hashlib
+import os
+from pathlib import Path
+import sqlite3
+import stat
+import uuid
+
+from .domain import _json, validate_approval
+
+
+HOST_STATE_DIR = Path.home() / ".local" / "state" / "modelark" / "slice"
+
+
+def _private_directory(path):
+    for ancestor in (path, *path.parents):
+        if ancestor.is_symlink():
+            raise ValueError("slice state path may not contain symlinks")
+    missing = []
+    current = path
+    while not current.exists():
+        missing.append(current)
+        current = current.parent
+    # The last existing directory may be the result of interrupted bootstrap. Make its
+    # parent entry durable before adding descendants, even when this retry creates nothing.
+    for target in (current, current.parent):
+        fd = os.open(target, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    for directory in reversed(missing):
+        try:
+            directory.mkdir(mode=0o700)
+        except FileExistsError:
+            pass
+        for target in (directory, directory.parent):
+            fd = os.open(target, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+    for ancestor in (path, *path.parents):
+        if ancestor.is_symlink():
+            raise ValueError("slice state path may not contain symlinks")
+    info = path.stat()
+    if info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) & 0o077:
+        raise ValueError("slice state directory must be private to its owner")
+
+
+class Store:
+    def __init__(self):
+        self.root = HOST_STATE_DIR.absolute()
+        _private_directory(self.root)
+        self.path = self.root / "transactions.sqlite"
+        try:
+            fd = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, 0o600)
+        except FileExistsError:
+            pass
+        else:
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            fd = os.open(self.root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        info = self.path.lstat()
+        if (not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid()
+                or stat.S_IMODE(info.st_mode) & 0o077 or info.st_nlink != 1):
+            raise ValueError("unsafe slice state database")
+        with self._connection() as con:
+            version = con.execute("PRAGMA user_version").fetchone()[0]
+            if version not in (0, 1):
+                raise ValueError("unsupported slice state version")
+            con.execute("CREATE TABLE IF NOT EXISTS transactions ("
+                        "id TEXT PRIMARY KEY, plan TEXT NOT NULL, seal TEXT NOT NULL,"
+                        "state TEXT NOT NULL, stop INTEGER NOT NULL DEFAULT 0, reason TEXT NOT NULL DEFAULT '',"
+                        "journal_seq INTEGER NOT NULL DEFAULT 0, journal_digest TEXT NOT NULL DEFAULT '')")
+            con.execute("CREATE TABLE IF NOT EXISTS owners (device TEXT PRIMARY KEY,"
+                        "tx TEXT UNIQUE NOT NULL REFERENCES transactions(id))")
+            con.execute("CREATE TABLE IF NOT EXISTS journal (tx TEXT NOT NULL REFERENCES transactions(id),"
+                        "seq INTEGER NOT NULL, event TEXT NOT NULL, payload TEXT NOT NULL, digest TEXT NOT NULL,"
+                        "PRIMARY KEY(tx,seq))")
+            con.execute("PRAGMA user_version=1")
+
+    @contextmanager
+    def _connection(self):
+        con = sqlite3.connect(self.path.as_uri() + "?mode=rw", uri=True, timeout=0, isolation_level=None)
+        try:
+            con.execute("PRAGMA foreign_keys=ON")
+            con.execute("PRAGMA synchronous=FULL")
+            con.execute("BEGIN IMMEDIATE")
+            yield con
+            con.execute("COMMIT")
+        except BaseException:
+            if con.in_transaction:
+                con.execute("ROLLBACK")
+            raise
+        finally:
+            con.close()
+
+    def create(self, plan, approval):
+        validate_approval(plan.proposal, approval)
+        tx = uuid.uuid4().hex
+        with self._connection() as con:
+            con.execute("INSERT INTO transactions(id,plan,seal,state) VALUES(?,?,?,'ready')",
+                        (tx, plan.to_json(), plan.seal))
+        return tx
+
+    def load(self, tx):
+        from .transaction import TransferPlan, TransferRefusal
+        with self._connection() as con:
+            row = con.execute("SELECT plan,seal FROM transactions WHERE id=?", (tx,)).fetchone()
+        if row is None:
+            raise TransferRefusal("TRANSACTION_MISSING", tx)
+        plan = TransferPlan.from_json(row[0])
+        if plan.seal != row[1]:
+            raise TransferRefusal("STATE_CORRUPT", "plan seal differs")
+        return plan
+
+    def approve(self, tx, *, expected_seal):
+        from .transaction import TransferRefusal
+        self.load(tx)
+        with self._connection() as con:
+            seal, state = con.execute("SELECT seal,state FROM transactions WHERE id=?", (tx,)).fetchone()
+            if seal != expected_seal:
+                raise TransferRefusal("PREVIEW_STALE")
+            if state not in {"ready", "approved"}:
+                raise TransferRefusal("APPROVAL_STATE", state)
+            con.execute("UPDATE transactions SET state='approved' WHERE id=? AND state='ready'", (tx,))
+
+    def status(self, tx):
+        from .transaction import Status, TransferRefusal
+        with self._connection() as con:
+            row = con.execute("SELECT state,reason FROM transactions WHERE id=?", (tx,)).fetchone()
+        if row is None:
+            raise TransferRefusal("TRANSACTION_MISSING", tx)
+        return Status(tx, *row)
+
+    def owner(self, device):
+        with self._connection() as con:
+            row = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
+        return row[0] if row else None
+
+    def claim(self, tx, device):
+        from .transaction import TransferRefusal
+        with self._connection() as con:
+            owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
+            if owner and owner[0] != tx:
+                raise TransferRefusal("DESTINATION_BUSY", owner[0])
+            state = con.execute("SELECT state FROM transactions WHERE id=?", (tx,)).fetchone()[0]
+            if state not in {"approved", "transferring", "verifying", "stopped", "waiting_source",
+                             "blocked_source", "waiting_destination"}:
+                raise TransferRefusal("APPROVAL_MISSING" if state == "ready" else "NOT_RESUMABLE", state)
+            con.execute("INSERT OR IGNORE INTO owners(device,tx) VALUES(?,?)", (device, tx))
+            con.execute("UPDATE transactions SET state='transferring',stop=0,reason='' WHERE id=?", (tx,))
+
+    def set_state(self, tx, state, reason=""):
+        with self._connection() as con:
+            con.execute("UPDATE transactions SET state=?,reason=? WHERE id=?", (state, reason, tx))
+
+    def request_stop(self, tx):
+        with self._connection() as con:
+            con.execute("UPDATE transactions SET stop=1 WHERE id=?", (tx,))
+
+    def stop_requested(self, tx):
+        with self._connection() as con:
+            return bool(con.execute("SELECT stop FROM transactions WHERE id=?", (tx,)).fetchone()[0])
+
+    def append(self, tx, event, payload):
+        encoded = _json(payload).decode()
+        with self._connection() as con:
+            last = con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (tx,)).fetchone()
+            seq, previous = last[0] + 1, last[1]
+            digest = hashlib.sha256(_json([tx, seq, previous, event, encoded])).hexdigest()
+            con.execute("INSERT INTO journal VALUES(?,?,?,?,?)", (tx, seq, event, encoded, digest))
+            con.execute("UPDATE transactions SET journal_seq=?,journal_digest=? WHERE id=?", (seq, digest, tx))
+
+    def events(self, tx):
+        import json
+        from .transaction import TransferRefusal
+        with self._connection() as con:
+            rows = con.execute("SELECT seq,event,payload,digest FROM journal WHERE tx=? ORDER BY seq", (tx,)).fetchall()
+            head = con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (tx,)).fetchone()
+        previous, events = "", []
+        for expected, (seq, event, payload, digest) in enumerate(rows, 1):
+            if seq != expected or digest != hashlib.sha256(_json([tx, seq, previous, event, payload])).hexdigest():
+                raise TransferRefusal("JOURNAL_CORRUPT")
+            previous = digest
+            events.append((event, json.loads(payload)))
+        if head != (len(rows), previous):
+            raise TransferRefusal("JOURNAL_CORRUPT", "journal tail differs from durable head")
+        return events
+
+    def receipt(self, tx):
+        return next((payload for event, payload in reversed(self.events(tx)) if event == "receipt"), None)
+
+    def complete(self, tx, device):
+        from .transaction import TransferRefusal
+        if self.receipt(tx) is None:
+            raise TransferRefusal("RECEIPT_MISSING")
+        with self._connection() as con:
+            con.execute("UPDATE transactions SET state='complete',reason='' WHERE id=?", (tx,))
+            con.execute("DELETE FROM owners WHERE device=? AND tx=?", (device, tx))

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -20,6 +20,10 @@ import uuid
 from . import domain as d
 
 
+_RESUMABLE_STATES = frozenset({"approved", "starting", "transferring", "verifying", "stopped",
+                              "waiting_source", "blocked_source", "waiting_destination"})
+
+
 class TransferRefusal(ValueError):
     def __init__(self, code, detail=""):
         self.code, self.detail = code, detail
@@ -44,11 +48,12 @@ class DestinationBinding:
 class TransferPlan:
     proposal: d.SlicePreview
     destination: DestinationBinding
-    version: str = "modelark.slice.transaction.v1"
+    version: str = "modelark.slice.transaction.v2"
 
     def __post_init__(self):
         d._verify(self.proposal)
-        if not self.proposal.source_ready or self.version != "modelark.slice.transaction.v1":
+        if not self.proposal.source_ready or self.version not in {
+                "modelark.slice.transaction.v1", "modelark.slice.transaction.v2"}:
             raise TransferRefusal("PREVIEW_BLOCKED")
         if self.proposal.spec.destination_id != self.destination.device_id:
             raise TransferRefusal("DESTINATION_CHANGED", "binding differs from reviewed destination intent")
@@ -199,6 +204,8 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         if current.state == "complete":
             lease.close()
             return current
+        if current.state not in _RESUMABLE_STATES:
+            raise TransferRefusal("NOT_RESUMABLE", current.state)
         destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination))
         store.activate(tx, plan.destination.device_id, serial)
         session = Session(store, tx, plan, destination, sources, lease, fault)
@@ -208,7 +215,7 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         return session
     except TransferRefusal as exc:
         try:
-            if exc.code != "DESTINATION_BUSY":
+            if exc.code not in {"DESTINATION_BUSY", "STATE_BUSY", "NOT_RESUMABLE"}:
                 store.set_state(tx, _refusal_state(exc.code), str(exc))
         finally:
             lease.close()
@@ -578,6 +585,10 @@ class Session:
         self._audit_layout()
         receipt = {"version": self.plan.version, "transaction": self.transaction_id, "seal": self.plan.seal,
                    "destination": asdict(self.plan.destination), "files": files}
+        if self.plan.version == "modelark.slice.transaction.v2":
+            receipt.update(plan=json.loads(self.plan.to_json()), topology="direct", status="complete",
+                           verification={"content": "sha256-original-bytes", "layout": "authenticated",
+                                         "result": "verified", "file_count": len(files)})
         path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / ".modelark-slice-receipt.json")
         data = d._json(receipt)
         op = self._op(path, "receipt", size=len(data), sha=hashlib.sha256(data).hexdigest())
@@ -591,7 +602,12 @@ class Session:
     def step(self):
         if self._terminal:
             raise TransferRefusal("NOT_RESUMABLE", "session encountered a terminal refusal")
-        current = self.store.status(self.transaction_id)
+        try:
+            current = self.store.status(self.transaction_id)
+        except TransferRefusal as exc:
+            if exc.code == "STATE_BUSY":
+                self.lease.close()
+            raise
         if current.state == "complete":
             return current
         if current.state in {"failed", "invalidated"}:
@@ -618,6 +634,11 @@ class Session:
                 return self.store.status(self.transaction_id)
             self._finish()
         except TransferRefusal as exc:
+            if exc.code == "STATE_BUSY":
+                # Transient shared-state contention does not revoke the approved transaction.
+                # Release this writer and let a fresh Start retry its still-durable authority.
+                self.lease.close()
+                raise
             states = {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
                       "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}
             state = _refusal_state(exc.code)

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -7,21 +7,18 @@ catalog and opens *local original bytes* under that fence. Real adapters belong 
 """
 from contextlib import AbstractContextManager
 from dataclasses import asdict, dataclass
-import errno
 import hashlib
 import io
 import json
-import os
 from pathlib import PurePosixPath
-import socket
 from typing import BinaryIO, Protocol
 import uuid
 
 from . import domain as d
+from .authority import DeliveryAuthority, Lease, refusal_state as _refusal_state
 
 
-_RESUMABLE_STATES = frozenset({"approved", "starting", "transferring", "verifying", "stopped",
-                              "waiting_source", "blocked_source", "waiting_destination"})
+_Lease = Lease  # Compatibility for the internal disposable exclusion tests.
 
 
 class TransferRefusal(ValueError):
@@ -176,32 +173,6 @@ class SourcePort(Protocol):
     def open(self, source: d.SourceEvidence) -> AbstractContextManager[tuple[d.CatalogSnapshot, BinaryIO]]: ...
 
 
-class _Lease:
-    """Linux host-wide process fence, independent of paths and immune to lock-file replacement.
-
-    Closing the parent's descriptor does not unlock an inherited child's descriptor. Workers
-    spawning an exec child capable of writing must pass fd explicitly; it is CLOEXEC by default.
-    """
-    def __init__(self, device):
-        self.pid = os.getpid()
-        self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        key = hashlib.sha256(device.encode()).hexdigest()
-        try:
-            self.socket.bind("\0modelark-slice-device-" + key)
-        except OSError as exc:
-            self.socket.close()
-            if exc.errno == errno.EADDRINUSE:
-                raise TransferRefusal("DESTINATION_BUSY") from exc
-            raise
-
-    def close(self):
-        self.socket.close()
-
-    def check(self):
-        if os.getpid() != self.pid or self.socket.fileno() < 0:
-            raise TransferRefusal("EXECUTION_FENCE_LOST")
-
-
 def _same_source(artifact, candidate, snapshot):
     files = [f for f in snapshot.files if (f.repo_id, f.rfilename) == (artifact.repo_id, artifact.rfilename)]
     copies = [c for c in snapshot.copies if (c.repo_id, c.rfilename, c.drive_label)
@@ -231,29 +202,16 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         return status
     required = plan.required_bytes(store.root)
     serial = store.reserve(tx, plan.destination.device_id)
+    if isinstance(serial, Status):
+        return serial
     (fault or (lambda point: None))("reservation_committed")
+    authority = DeliveryAuthority.acquire(store, tx, plan.destination.device_id, serial)
+    if isinstance(authority, Status):
+        return authority
     try:
-        lease = _Lease(plan.destination.device_id)
-    except TransferRefusal:
-        current = store.status(tx)
-        if current.state == "complete" or store.process_owner(plan.destination.device_id) == tx:
-            return current  # Observation only; never hands out a writer capability.
-        raise
-    try:
-        # Another first starter may have won, completed, and released exclusion while this
-        # caller was between durable reservation and process bind. Never downgrade completion.
-        current = store.status(tx)
-        if current.state == "complete":
-            lease.close()
-            return current
-        if current.state not in _RESUMABLE_STATES:
-            raise TransferRefusal("NOT_RESUMABLE", current.state)
-        store.record_process(tx, plan.destination.device_id)
         destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination), required)
-        if not store.activate(tx, plan.destination.device_id, serial):
-            lease.close()
-            return store.status(tx)
-        session = Session(store, tx, plan, destination, sources, lease, fault)
+        authority.activate()
+        session = Session(store, tx, plan, destination, sources, authority, fault)
         session._fault("reserved")
         session._audit_layout()
         session._control()
@@ -261,14 +219,12 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
     except TransferRefusal as exc:
         try:
             if exc.code not in {"DESTINATION_BUSY", "STATE_BUSY", "NOT_RESUMABLE"}:
-                current = store.refuse_start(tx, plan.destination.device_id, _refusal_state(exc.code), str(exc))
-                if current.state == "complete":
-                    return current
+                authority.refuse(exc)
         finally:
-            lease.close()
+            authority.lease.close()
         raise
     except BaseException:
-        lease.close()
+        authority.lease.close()
         raise
 
 
@@ -325,12 +281,6 @@ def _operations(store, tx):
     return result
 
 
-def _refusal_state(code):
-    return {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
-            "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}.get(
-                code, "invalidated" if code.startswith("DESTINATION_") else "failed")
-
-
 def _allocated(store, tx, destination):
     total, seen = 0, set()
     for op in _operations(store, tx).values():
@@ -352,11 +302,16 @@ def _allocated(store, tx, destination):
 class Session:
     @property
     def can_write(self):
-        return self.lease.socket.fileno() >= 0 and os.getpid() == self.lease.pid
+        try:
+            self.lease.check()
+        except TransferRefusal:
+            return False
+        return True
 
-    def __init__(self, store, tx, plan, destination, sources, lease, fault):
+    def __init__(self, store, tx, plan, destination, sources, authority, fault):
         self.store, self.transaction_id, self.plan = store, tx, plan
-        self.destination, self.sources, self.lease = destination, sources, lease
+        self.destination, self.sources, self.authority = destination, sources, authority
+        self.lease = authority.lease
         self._fault = fault or (lambda point: None)
         self.ops = _operations(store, tx)
         self.head = store.head(tx)
@@ -379,23 +334,12 @@ class Session:
         self.close()
 
     def close(self):
-        if self.lease.socket.fileno() < 0:
-            return
-        try:
-            if os.getpid() == self.lease.pid and self.store.status(self.transaction_id).state in {"transferring", "verifying"}:
-                self.store.set_state(self.transaction_id, "stopped")
-        finally:
-            self.lease.close()  # Never explicit unlock: inherited writer children retain exclusion.
+        self.authority.close()
 
     def _boundary(self):
-        self.lease.check()
-        stopped, head, owner = self.store.guard(self.transaction_id, self.plan.destination.device_id)
-        if owner != self.transaction_id:
-            raise TransferRefusal("EXECUTION_FENCE_LOST")
+        head = self.authority.boundary()
         if head != self.head:
             raise TransferRefusal("JOURNAL_CORRUPT", "journal changed outside its fenced writer")
-        if stopped:
-            raise TransferRefusal("STOPPED")
         self.destination.check(self.plan.destination, self._allocated_bytes, self._required_bytes)
 
     def _check(self):
@@ -413,7 +357,7 @@ class Session:
 
     def _record(self, op, state):
         op = dict(op, state=state)
-        self.head = self.store.append(self.transaction_id, "operation", op, expected_head=self.head)
+        self.head = self.authority.append("operation", op, expected_head=self.head)
         self.ops[op["path"]] = op
         for path in (op["path"], op.get("temporary")):
             if path:
@@ -623,7 +567,7 @@ class Session:
 
     def _finish(self):
         self._verify_control(required=True)
-        self.store.set_state(self.transaction_id, "verifying")
+        self.authority.transition("verifying")
         ops = self.ops
         files = []
         for artifact in self.plan.proposal.closure:
@@ -641,8 +585,8 @@ class Session:
             self._publish(op)
         else:
             self._write(op, io.BytesIO(data))
-        self.head = self.store.append(self.transaction_id, "receipt", receipt, expected_head=self.head)
-        self.store.complete(self.transaction_id, self.plan.destination.device_id, self.lease.close)
+        self.head = self.authority.append("receipt", receipt, expected_head=self.head)
+        self.authority.complete()
 
     def step(self):
         if self._terminal:
@@ -664,7 +608,7 @@ class Session:
             self._check()
             self._audit_layout()
             if current.state in {"waiting_source", "blocked_source", "waiting_destination"}:
-                self.store.set_state(self.transaction_id, "transferring")
+                self.authority.transition("transferring")
             ops = self.ops
             for artifact in self.plan.proposal.closure:
                 path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)
@@ -691,7 +635,7 @@ class Session:
             state = _refusal_state(exc.code)
             self._terminal = exc.code not in states
             try:
-                self.store.set_state(self.transaction_id, state, str(exc))
+                self.authority.transition(state, str(exc))
             finally:
                 if self._terminal:
                     self.lease.close()
@@ -700,7 +644,7 @@ class Session:
         except FileExistsError as exc:
             self._terminal = True
             try:
-                self.store.set_state(self.transaction_id, "failed", "OUTPUT_COLLISION")
+                self.authority.transition("failed", "OUTPUT_COLLISION")
             finally:
                 self.lease.close()
             raise TransferRefusal("OUTPUT_COLLISION", str(exc)) from exc

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -236,7 +236,7 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         lease = _Lease(plan.destination.device_id)
     except TransferRefusal:
         current = store.status(tx)
-        if current.state == "complete" or store.owner(plan.destination.device_id) == tx:
+        if current.state == "complete" or (not serial.created and store.owner(plan.destination.device_id) == tx):
             return current  # Observation only; never hands out a writer capability.
         raise
     try:
@@ -637,7 +637,7 @@ class Session:
         else:
             self._write(op, io.BytesIO(data))
         self.head = self.store.append(self.transaction_id, "receipt", receipt, expected_head=self.head)
-        self.store.complete(self.transaction_id, self.plan.destination.device_id)
+        self.store.complete(self.transaction_id, self.plan.destination.device_id, self.lease.close)
 
     def step(self):
         if self._terminal:

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -249,7 +249,9 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         if current.state not in _RESUMABLE_STATES:
             raise TransferRefusal("NOT_RESUMABLE", current.state)
         destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination), required)
-        store.activate(tx, plan.destination.device_id, serial)
+        if not store.activate(tx, plan.destination.device_id, serial):
+            lease.close()
+            return store.status(tx)
         session = Session(store, tx, plan, destination, sources, lease, fault)
         session._fault("reserved")
         session._audit_layout()
@@ -258,7 +260,9 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
     except TransferRefusal as exc:
         try:
             if exc.code not in {"DESTINATION_BUSY", "STATE_BUSY", "NOT_RESUMABLE"}:
-                store.set_state(tx, _refusal_state(exc.code), str(exc))
+                current = store.refuse_start(tx, plan.destination.device_id, _refusal_state(exc.code), str(exc))
+                if current.state == "complete":
+                    return current
         finally:
             lease.close()
         raise

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -203,6 +203,7 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         store.activate(tx, plan.destination.device_id, serial)
         session = Session(store, tx, plan, destination, sources, lease, fault)
         session._fault("reserved")
+        session._audit_layout()
         session._control()
         return session
     except TransferRefusal as exc:
@@ -411,6 +412,23 @@ class Session:
                     or self._owned(str(parent), op) is None):
                 raise TransferRefusal("OUTPUT_COLLISION", str(parent))
 
+    def _audit_layout(self):
+        # Capacity drift cannot detect foreign empty entries. Inspect the approved tree before
+        # resuming any destination mutation, and at each artifact boundary, not per byte chunk.
+        self._boundary()
+        root = PurePosixPath(self.plan.proposal.spec.destination_root)
+        for parent in reversed((root, *root.parents)):
+            path = str(parent)
+            if path != "." and self.destination.inspect(path) is not None:
+                op = self._paths.get(path)
+                if not op or self._owned(path, op) is None:
+                    raise TransferRefusal("OUTPUT_COLLISION", path)
+        for path in self.destination.list_paths(str(root)):
+            self._boundary()
+            op = self._paths.get(path)
+            if not op or self._owned(path, op) is None:
+                raise TransferRefusal("OUTPUT_COLLISION", path)
+
     def _control(self):
         path = ".modelark-slice-owner"
         data = d._json({"transaction": self.transaction_id, "seal": self.plan.seal,
@@ -557,11 +575,7 @@ class Session:
             if op["state"] != "complete" or not op["source"] or not self._owned(path, op) or not self._matches(path, op):
                 raise TransferRefusal("VERIFICATION_FAILED", path)
             files.append({"path": path, "size": op["size"], "sha256": op["sha"], "source": op["source"]})
-        expected = dict(ops)
-        expected.update((op["temporary"], op) for op in ops.values() if op.get("temporary"))
-        for path in self.destination.list_paths(self.plan.proposal.spec.destination_root):
-            if path not in expected or self._owned(path, expected[path]) is None:
-                raise TransferRefusal("OUTPUT_COLLISION", path)
+        self._audit_layout()
         receipt = {"version": self.plan.version, "transaction": self.transaction_id, "seal": self.plan.seal,
                    "destination": asdict(self.plan.destination), "files": files}
         path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / ".modelark-slice-receipt.json")
@@ -587,6 +601,7 @@ class Session:
         self.lease.check()
         try:
             self._check()
+            self._audit_layout()
             ops = self.ops
             for artifact in self.plan.proposal.closure:
                 path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -236,7 +236,7 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         lease = _Lease(plan.destination.device_id)
     except TransferRefusal:
         current = store.status(tx)
-        if current.state == "complete" or (not serial.created and store.owner(plan.destination.device_id) == tx):
+        if current.state == "complete" or store.process_owner(plan.destination.device_id) == tx:
             return current  # Observation only; never hands out a writer capability.
         raise
     try:
@@ -248,6 +248,7 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
             return current
         if current.state not in _RESUMABLE_STATES:
             raise TransferRefusal("NOT_RESUMABLE", current.state)
+        store.record_process(tx, plan.destination.device_id)
         destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination), required)
         if not store.activate(tx, plan.destination.device_id, serial):
             lease.close()

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -48,27 +48,64 @@ class DestinationBinding:
 class TransferPlan:
     proposal: d.SlicePreview
     destination: DestinationBinding
-    version: str = "modelark.slice.transaction.v2"
+    version: str = "modelark.slice.transaction.v3"
+    metadata_reserve_bytes: int | None = None
 
     def __post_init__(self):
         d._verify(self.proposal)
         if not self.proposal.source_ready or self.version not in {
-                "modelark.slice.transaction.v1", "modelark.slice.transaction.v2"}:
+                "modelark.slice.transaction.v1", "modelark.slice.transaction.v2", "modelark.slice.transaction.v3"}:
             raise TransferRefusal("PREVIEW_BLOCKED")
         if self.proposal.spec.destination_id != self.destination.device_id:
             raise TransferRefusal("DESTINATION_CHANGED", "binding differs from reviewed destination intent")
         if self.proposal.total_bytes > self.destination.available_bytes:
             raise TransferRefusal("DESTINATION_CAPACITY_INSUFFICIENT")
+        if self.version == "modelark.slice.transaction.v3":
+            if not d._integer(self.metadata_reserve_bytes):
+                raise TransferRefusal("DESTINATION_CAPACITY_UNPROVEN", "explicit metadata reserve required")
+        else:
+            object.__setattr__(self, "metadata_reserve_bytes", None)
         root = PurePosixPath(self.proposal.spec.destination_root)
         if root.parts[0] == ".modelark-slice-owner":
             raise TransferRefusal("OUTPUT_COLLISION", "reserved control path")
+        if self.version == "modelark.slice.transaction.v3":
+            self.required_bytes("")
 
     @property
     def seal(self):
         return hashlib.sha256(self.to_json().encode()).hexdigest()
 
     def to_json(self):
-        return d._json(asdict(self)).decode()
+        payload = asdict(self)
+        if self.version != "modelark.slice.transaction.v3":
+            payload.pop("metadata_reserve_bytes")
+        return d._json(payload).decode()
+
+    def receipt(self, tx, files):
+        receipt = {"version": self.version, "transaction": tx, "seal": self.seal,
+                   "destination": asdict(self.destination), "files": files}
+        if self.version != "modelark.slice.transaction.v1":
+            receipt.update(plan=json.loads(self.to_json()), topology="direct", status="complete",
+                           verification={"content": "sha256-original-bytes", "layout": "authenticated",
+                                         "result": "verified", "file_count": len(files)})
+        return receipt
+
+    def required_bytes(self, store_root):
+        # Exact upper bound on serialized control/receipt payloads: source choice can vary only
+        # within the sealed alternatives. Filesystem allocation padding/metadata is the trusted
+        # preflight adapter's responsibility and must also fit its explicit sealed reserve.
+        tx = "0" * 32
+        files = [{"path": str(PurePosixPath(self.proposal.spec.destination_root) / a.repo_id / a.rfilename),
+                  "size": a.size_bytes, "sha256": a.sha256,
+                  "source": asdict(max(a.sources, key=lambda source: len(d._json(asdict(source)))))}
+                 for a in self.proposal.closure]
+        control = d._json({"transaction": tx, "seal": self.seal, "store": str(store_root),
+                           "destination": asdict(self.destination)})
+        minimum = len(control) + len(d._json(self.receipt(tx, files)))
+        reserve = minimum if self.metadata_reserve_bytes is None else self.metadata_reserve_bytes
+        if reserve < minimum or self.proposal.total_bytes + reserve > self.destination.available_bytes:
+            raise TransferRefusal("DESTINATION_CAPACITY_INSUFFICIENT", "artifact and transaction metadata charge")
+        return self.proposal.total_bytes + reserve
 
     @classmethod
     def from_json(cls, payload):
@@ -83,7 +120,8 @@ class TransferPlan:
                 closure.append(d.Artifact(**item, sources=sources))
             proposal = d.SlicePreview(d.SliceSpec(**p["spec"]), p["snapshot_id"], tuple(closure),
                                       tuple(d.Gap(**g) for g in p["gaps"]), p["seal"], p["version"])
-            return cls(proposal, DestinationBinding(**obj["destination"]), obj["version"])
+            return cls(proposal, DestinationBinding(**obj["destination"]), obj["version"],
+                       obj.get("metadata_reserve_bytes"))
         except (KeyError, TypeError, ValueError) as exc:
             raise TransferRefusal("STATE_CORRUPT", str(exc)) from exc
 
@@ -107,14 +145,17 @@ class DestinationPort(Protocol):
     """Bound destination operations; never resolve a mountpoint again during writes.
 
     check must reject changed/system/archive/ambiguous devices, incompatible capabilities,
-    and unexplained capacity drift after subtracting the supplied owned allocations.
+    and unexplained capacity drift after subtracting the supplied owned allocations. It must
+    reserve required_bytes (artifacts plus transaction metadata), crediting only authenticated
+    already-owned allocations. The sealed metadata charge includes filesystem rounding, directory
+    and temporary-entry costs; the preflight adapter must prove that charge for the bound device.
     inspect must authenticate creation tokens (not filenames/hashes) against actual objects.
     create_* must be exclusive and recoverable after a crash inside the adapter. flush on a
     directory includes its metadata. publish is atomic no-replace and may retain the temp link.
     list_paths returns every descendant, including directories and unexpected objects.
     A concrete adapter must prove these obligations separately; the test port is not production.
     """
-    def check(self, binding: DestinationBinding, allocated: int) -> None: ...
+    def check(self, binding: DestinationBinding, allocated: int, required_bytes: int) -> None: ...
     def inspect(self, path: str) -> ObjectInfo | None: ...
     def create_directory(self, path: str, token: str) -> None: ...
     def create_file(self, path: str, token: str) -> None: ...
@@ -188,6 +229,7 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         raise TransferRefusal("APPROVAL_MISSING")
     if status.state == "complete":
         return status
+    required = plan.required_bytes(store.root)
     serial = store.reserve(tx, plan.destination.device_id)
     (fault or (lambda point: None))("reservation_committed")
     try:
@@ -206,7 +248,7 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
             return current
         if current.state not in _RESUMABLE_STATES:
             raise TransferRefusal("NOT_RESUMABLE", current.state)
-        destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination))
+        destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination), required)
         store.activate(tx, plan.destination.device_id, serial)
         session = Session(store, tx, plan, destination, sources, lease, fault)
         session._fault("reserved")
@@ -318,6 +360,7 @@ class Session:
         self._allocated_bytes = 0
         self._verified_files = set()
         self._terminal = False
+        self._required_bytes = plan.required_bytes(store.root)
         for op in self.ops.values():
             for path in (op["path"], op.get("temporary")):
                 if path:
@@ -348,7 +391,7 @@ class Session:
             raise TransferRefusal("JOURNAL_CORRUPT", "journal changed outside its fenced writer")
         if stopped:
             raise TransferRefusal("STOPPED")
-        self.destination.check(self.plan.destination, self._allocated_bytes)
+        self.destination.check(self.plan.destination, self._allocated_bytes, self._required_bytes)
 
     def _check(self):
         self._boundary()
@@ -583,12 +626,7 @@ class Session:
                 raise TransferRefusal("VERIFICATION_FAILED", path)
             files.append({"path": path, "size": op["size"], "sha256": op["sha"], "source": op["source"]})
         self._audit_layout()
-        receipt = {"version": self.plan.version, "transaction": self.transaction_id, "seal": self.plan.seal,
-                   "destination": asdict(self.plan.destination), "files": files}
-        if self.plan.version == "modelark.slice.transaction.v2":
-            receipt.update(plan=json.loads(self.plan.to_json()), topology="direct", status="complete",
-                           verification={"content": "sha256-original-bytes", "layout": "authenticated",
-                                         "result": "verified", "file_count": len(files)})
+        receipt = self.plan.receipt(self.transaction_id, files)
         path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / ".modelark-slice-receipt.json")
         data = d._json(receipt)
         op = self._op(path, "receipt", size=len(data), sha=hashlib.sha256(data).hexdigest())
@@ -618,6 +656,8 @@ class Session:
         try:
             self._check()
             self._audit_layout()
+            if current.state in {"waiting_source", "blocked_source", "waiting_destination"}:
+                self.store.set_state(self.transaction_id, "transferring")
             ops = self.ops
             for artifact in self.plan.proposal.closure:
                 path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -309,6 +309,7 @@ class Session:
         self._usage = {}
         self._allocated_bytes = 0
         self._verified_files = set()
+        self._terminal = False
         for op in self.ops.values():
             for path in (op["path"], op.get("temporary")):
                 if path:
@@ -574,10 +575,13 @@ class Session:
         self.store.complete(self.transaction_id, self.plan.destination.device_id)
 
     def step(self):
+        if self._terminal:
+            raise TransferRefusal("NOT_RESUMABLE", "session encountered a terminal refusal")
         current = self.store.status(self.transaction_id)
         if current.state == "complete":
             return current
         if current.state in {"failed", "invalidated"}:
+            self._terminal = True
             self.lease.close()
             raise TransferRefusal("NOT_RESUMABLE", current.state)
         self.lease.check()
@@ -602,13 +606,20 @@ class Session:
             states = {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
                       "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}
             state = _refusal_state(exc.code)
-            self.store.set_state(self.transaction_id, state, str(exc))
+            self._terminal = exc.code not in states
+            try:
+                self.store.set_state(self.transaction_id, state, str(exc))
+            finally:
+                if self._terminal:
+                    self.lease.close()
             if exc.code not in states:
-                self.lease.close()
                 raise
         except FileExistsError as exc:
-            self.store.set_state(self.transaction_id, "failed", "OUTPUT_COLLISION")
-            self.lease.close()
+            self._terminal = True
+            try:
+                self.store.set_state(self.transaction_id, "failed", "OUTPUT_COLLISION")
+            finally:
+                self.lease.close()
             raise TransferRefusal("OUTPUT_COLLISION", str(exc)) from exc
         return self.store.status(self.transaction_id)
 

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -183,15 +183,24 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
         raise TransferRefusal("APPROVAL_MISSING")
     if status.state == "complete":
         return status
+    serial = store.reserve(tx, plan.destination.device_id)
+    (fault or (lambda point: None))("reservation_committed")
     try:
         lease = _Lease(plan.destination.device_id)
     except TransferRefusal:
-        if store.owner(plan.destination.device_id) == tx:
-            return store.status(tx)  # Observation only; never hands out a writer capability.
+        current = store.status(tx)
+        if current.state == "complete" or store.owner(plan.destination.device_id) == tx:
+            return current  # Observation only; never hands out a writer capability.
         raise
     try:
+        # Another first starter may have won, completed, and released exclusion while this
+        # caller was between durable reservation and process bind. Never downgrade completion.
+        current = store.status(tx)
+        if current.state == "complete":
+            lease.close()
+            return current
         destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination))
-        store.claim(tx, plan.destination.device_id)
+        store.activate(tx, plan.destination.device_id, serial)
         session = Session(store, tx, plan, destination, sources, lease, fault)
         session._fault("reserved")
         session._control()
@@ -221,7 +230,8 @@ def _operations(store, tx):
             kind = payload.get("kind")
             if (payload.get("seal") != plan.seal or payload.get("device") != plan.destination.device_id
                     or not d._path(path) or payload.get("state") not in {"intent", "prepared", "complete"}
-                    or not isinstance(payload.get("token"), str) or len(payload["token"]) != 32):
+                    or not isinstance(payload.get("token"), str) or len(payload["token"]) != 32
+                    or any(c not in "0123456789abcdef" for c in payload["token"])):
                 raise TransferRefusal("JOURNAL_CORRUPT")
             if kind == "file":
                 artifact = files.get(path)
@@ -248,7 +258,7 @@ def _operations(store, tx):
                 raise TransferRefusal("JOURNAL_CORRUPT", path)
             temporary = payload.get("temporary")
             expected = str(PurePosixPath(path).parent / (".slice-" + payload["token"]))
-            if temporary != (expected if kind in {"file", "receipt"} else None):
+            if temporary != (expected if kind in {"file", "receipt", "control"} else None):
                 raise TransferRefusal("JOURNAL_CORRUPT", "temporary identity differs")
             previous = result.get(path)
             if previous and any(previous.get(key) != payload.get(key) for key in
@@ -293,6 +303,16 @@ class Session:
         self.store, self.transaction_id, self.plan = store, tx, plan
         self.destination, self.sources, self.lease = destination, sources, lease
         self._fault = fault or (lambda point: None)
+        self.ops = _operations(store, tx)
+        self.head = store.head(tx)
+        self._paths = {}
+        self._usage = {}
+        self._allocated_bytes = 0
+        for op in self.ops.values():
+            for path in (op["path"], op.get("temporary")):
+                if path:
+                    self._paths[path] = op
+                    self._owned(path, op)
 
     def __enter__(self):
         return self
@@ -309,21 +329,41 @@ class Session:
         finally:
             self.lease.close()  # Never explicit unlock: inherited writer children retain exclusion.
 
-    def _check(self):
+    def _boundary(self):
         self.lease.check()
-        if self.store.owner(self.plan.destination.device_id) != self.transaction_id:
+        stopped, head, owner = self.store.guard(self.transaction_id, self.plan.destination.device_id)
+        if owner != self.transaction_id:
             raise TransferRefusal("EXECUTION_FENCE_LOST")
-        if self.store.stop_requested(self.transaction_id):
+        if head != self.head:
+            raise TransferRefusal("JOURNAL_CORRUPT", "journal changed outside its fenced writer")
+        if stopped:
             raise TransferRefusal("STOPPED")
-        self.destination.check(self.plan.destination, _allocated(self.store, self.transaction_id, self.destination))
+        self.destination.check(self.plan.destination, self._allocated_bytes)
+
+    def _check(self):
+        self._boundary()
+        self._verify_control()
+
+    def _verify_control(self, *, required=False):
+        op = self.ops.get(".modelark-slice-owner")
+        if op is None or op["state"] != "complete":
+            if required:
+                raise TransferRefusal("CONTROL_CORRUPT", "ownership record is not complete")
+            return  # Initial control creation still has only its durable intent.
+        if not self._owned(op["path"], op) or not self._matches(op["path"], op):
+            raise TransferRefusal("CONTROL_CORRUPT", "ownership record disappeared or changed")
 
     def _record(self, op, state):
         op = dict(op, state=state)
-        self.store.append(self.transaction_id, "operation", op)
+        self.head = self.store.append(self.transaction_id, "operation", op, expected_head=self.head)
+        self.ops[op["path"]] = op
+        for path in (op["path"], op.get("temporary")):
+            if path:
+                self._paths[path] = op
         return op
 
     def _op(self, path, kind, *, size=0, sha="", source=None):
-        previous = _operations(self.store, self.transaction_id).get(path)
+        previous = self.ops.get(path)
         if previous:
             if (previous["kind"], previous["size"], previous["sha"]) != (kind, size, sha):
                 raise TransferRefusal("JOURNAL_CORRUPT", path)
@@ -331,7 +371,7 @@ class Session:
         if self.destination.inspect(path) is not None:
             raise TransferRefusal("OUTPUT_COLLISION", path)
         token = uuid.uuid4().hex
-        temporary = str(PurePosixPath(path).parent / (".slice-" + token)) if kind in {"file", "receipt"} else None
+        temporary = str(PurePosixPath(path).parent / (".slice-" + token)) if kind in {"file", "receipt", "control"} else None
         op = dict(path=path, kind=kind, size=size, sha=sha, token=token, temporary=temporary,
                   source=source, seal=self.plan.seal, device=self.plan.destination.device_id)
         op = self._record(op, "intent")
@@ -342,32 +382,39 @@ class Session:
         info = self.destination.inspect(path)
         if info and (info.token != op["token"] or info.kind != ("directory" if op["kind"] == "directory" else "file")):
             raise TransferRefusal("OUTPUT_COLLISION", path)
+        usage = self._usage.setdefault(op["token"], {})
+        before = max(usage.values(), default=0)
+        if info is None:
+            usage.pop(path, None)
+        else:
+            if not d._integer(info.allocated_bytes):
+                raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN", path)
+            usage[path] = info.allocated_bytes
+        self._allocated_bytes += max(usage.values(), default=0) - before
         return info
+
+    def _refresh_parent(self, path):
+        parent = str(PurePosixPath(path).parent)
+        if parent in self._paths:
+            self._owned(parent, self._paths[parent])
 
     def _control(self):
         path = ".modelark-slice-owner"
         data = d._json({"transaction": self.transaction_id, "seal": self.plan.seal,
                         "store": str(self.store.root), "destination": asdict(self.plan.destination)})
         op = self._op(path, "control", size=len(data), sha=hashlib.sha256(data).hexdigest())
-        info = self._owned(path, op)
-        self._check()
-        if info is None:
-            self.destination.create_file(path, op["token"])
-            self.destination.append(path, op["token"], data)
-            self._fault("control_created")
-        elif not self._matches(path, op):
-            raise TransferRefusal("CONTROL_CORRUPT")
-        self.destination.flush(path)
-        self.destination.flush(".")
-        self._fault("control_flushed")
-        self._record(op, "complete")
-        self._fault("control_complete")
+        if op["state"] in {"prepared", "complete"}:
+            self._publish(op)
+        else:
+            self._write(op, io.BytesIO(data))
 
     def _directory(self, path):
         op = self._op(path, "directory")
         self._check()
         if self._owned(path, op) is None:
             self.destination.create_directory(path, op["token"])
+            self._owned(path, op)
+            self._refresh_parent(path)
             self._fault("directory_created")
         self.destination.flush(path)
         self._fault("directory_flushed")
@@ -385,6 +432,7 @@ class Session:
         digest, size = hashlib.sha256(), 0
         with self.destination.read(path) as stream:
             while data := stream.read(1024 * 1024):
+                self._boundary()
                 digest.update(data)
                 size += len(data)
         return size == op["size"] and digest.hexdigest() == op["sha"]
@@ -395,7 +443,12 @@ class Session:
         if self._owned(path, op) is None:
             if self._owned(temp, op) is None or not self._matches(temp, op):
                 raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", temp)
-            self.destination.publish(temp, path, op["token"])
+            try:
+                self.destination.publish(temp, path, op["token"])
+            except FileExistsError as exc:
+                raise TransferRefusal("OUTPUT_COLLISION", path) from exc
+            self._owned(path, op)
+            self._refresh_parent(path)
             self._fault(kind + "_published")
         elif not self._matches(path, op):
             raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", path)
@@ -405,6 +458,8 @@ class Session:
         self._fault(kind + "_complete")
         if self._owned(temp, op) is not None:
             self.destination.discard_temporary(temp, op["token"])
+            self._owned(temp, op)
+            self._refresh_parent(temp)
             self.destination.flush(str(PurePosixPath(temp).parent))
         return op
 
@@ -418,20 +473,22 @@ class Session:
         op = self._record(dict(op, source=None), "intent")
         if self._owned(temp, op) is not None:
             self.destination.discard_temporary(temp, op["token"])
+            self._owned(temp, op)
         self.destination.create_file(temp, op["token"])
-        self._fault("temporary_created" if kind == "file" else "receipt_created")
+        self._owned(temp, op)
+        self._refresh_parent(temp)
+        self._fault("temporary_created" if kind == "file" else kind + "_created")
         digest, size = hashlib.sha256(), 0
         while data := stream.read(1024 * 1024):
-            self._check()
-            if self.store.stop_requested(self.transaction_id):
-                raise TransferRefusal("STOPPED")
+            self._boundary()
             size += len(data)
             if size > op["size"]:
                 raise TransferRefusal("SOURCE_DIGEST_MISMATCH")
             self.destination.append(temp, op["token"], data)
+            self._owned(temp, op)
             digest.update(data)
             # Intent and ownership certificate authenticate actual in-flight allocation on recovery.
-            self._fault("chunk_written")
+            self._fault("chunk_written" if kind == "file" else kind + "_chunk_written")
         if size != op["size"] or digest.hexdigest() != op["sha"]:
             raise TransferRefusal("SOURCE_DIGEST_MISMATCH")
         self.destination.flush(temp)
@@ -460,13 +517,15 @@ class Session:
             except TransferRefusal as exc:
                 if not (exc.code.startswith("SOURCE_") or exc.code == "WAITING_SOURCE"):
                     raise
-                errors.append((exc.code, source.drive.drive_label))
-        waiting = any(code == "WAITING_SOURCE" for code, _ in errors)
-        raise TransferRefusal("WAITING_SOURCE" if waiting else "SOURCE_BLOCKED", json.dumps(errors))
+                errors.append({"code": exc.code, "drive_label": source.drive.drive_label, "detail": exc.detail})
+        waiting = any(error["code"] == "WAITING_SOURCE" for error in errors)
+        detail = {"repo_id": artifact.repo_id, "rfilename": artifact.rfilename, "candidates": errors}
+        raise TransferRefusal("WAITING_SOURCE" if waiting else "SOURCE_BLOCKED", json.dumps(detail))
 
     def _finish(self):
+        self._verify_control(required=True)
         self.store.set_state(self.transaction_id, "verifying")
-        ops = _operations(self.store, self.transaction_id)
+        ops = self.ops
         files = []
         for artifact in self.plan.proposal.closure:
             path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)
@@ -474,11 +533,11 @@ class Session:
             if op["state"] != "complete" or not op["source"] or not self._owned(path, op) or not self._matches(path, op):
                 raise TransferRefusal("VERIFICATION_FAILED", path)
             files.append({"path": path, "size": op["size"], "sha256": op["sha"], "source": op["source"]})
-        expected = set(ops)
-        expected.update(op["temporary"] for op in ops.values() if op.get("temporary"))
-        unexpected = set(self.destination.list_paths(self.plan.proposal.spec.destination_root)) - expected
-        if unexpected:
-            raise TransferRefusal("OUTPUT_COLLISION", str(sorted(unexpected)))
+        expected = dict(ops)
+        expected.update((op["temporary"], op) for op in ops.values() if op.get("temporary"))
+        for path in self.destination.list_paths(self.plan.proposal.spec.destination_root):
+            if path not in expected or self._owned(path, expected[path]) is None:
+                raise TransferRefusal("OUTPUT_COLLISION", path)
         receipt = {"version": self.plan.version, "transaction": self.transaction_id, "seal": self.plan.seal,
                    "destination": asdict(self.plan.destination), "files": files}
         path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / ".modelark-slice-receipt.json")
@@ -488,7 +547,7 @@ class Session:
             self._publish(op)
         else:
             self._write(op, io.BytesIO(data))
-        self.store.append(self.transaction_id, "receipt", receipt)
+        self.head = self.store.append(self.transaction_id, "receipt", receipt, expected_head=self.head)
         self.store.complete(self.transaction_id, self.plan.destination.device_id)
 
     def step(self):
@@ -497,9 +556,7 @@ class Session:
             return self.store.status(self.transaction_id)
         try:
             self._check()
-            if self.store.stop_requested(self.transaction_id):
-                raise TransferRefusal("STOPPED")
-            ops = _operations(self.store, self.transaction_id)
+            ops = self.ops
             for artifact in self.plan.proposal.closure:
                 path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)
                 op = ops.get(path)

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -520,6 +520,7 @@ class Session:
                 self._boundary()
                 digest.update(data)
                 size += len(data)
+        self._boundary()  # Includes EOF/stream-close time, including zero-byte objects.
         return size == op["size"] and digest.hexdigest() == op["sha"]
 
     def _publish(self, op):
@@ -530,6 +531,7 @@ class Session:
             if self._owned(temp, op) is None or not self._matches(temp, op):
                 raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", temp)
             self._check_parents(path)
+            self._boundary()  # Parent authentication and recovery hashing may observe a stop.
             try:
                 self.destination.publish(temp, path, op["token"])
             except FileExistsError as exc:

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -633,12 +633,22 @@ class Session:
             states = {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
                       "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}
             state = _refusal_state(exc.code)
-            self._terminal = exc.code not in states
+            # Stop ends this attempt; attended source/destination waits may retain it.
+            self._terminal = exc.code == "STOPPED" or exc.code not in states
             try:
-                self.authority.transition(state, str(exc))
+                outcome = self.authority.transition(state, str(exc))
+            except TransferRefusal as transition_error:
+                if transition_error.code != "STOPPED":
+                    raise
+                # A pending stop can win while publishing an attended-wait outcome.
+                # The authority committed its acknowledgment before raising STOPPED.
+                self._terminal = True
+                outcome = Status(self.transaction_id, "stopped", "STOPPED")
             finally:
                 if self._terminal:
                     self.lease.close()
+            if outcome.state == "stopped":
+                return outcome  # Never replace this result with a successor attempt's state.
             if exc.code not in states:
                 raise
         except FileExistsError as exc:

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -308,6 +308,7 @@ class Session:
         self._paths = {}
         self._usage = {}
         self._allocated_bytes = 0
+        self._verified_files = set()
         for op in self.ops.values():
             for path in (op["path"], op.get("temporary")):
                 if path:
@@ -398,6 +399,17 @@ class Session:
         if parent in self._paths:
             self._owned(parent, self._paths[parent])
 
+    def _check_parents(self, path):
+        # The destination root itself is bound by the port. Every descendant ancestor must
+        # already be a completed, currently authenticated directory before any child mutation.
+        for parent in reversed(PurePosixPath(path).parents):
+            if str(parent) == ".":
+                continue
+            op = self.ops.get(str(parent))
+            if (not op or op["kind"] != "directory" or op["state"] != "complete"
+                    or self._owned(str(parent), op) is None):
+                raise TransferRefusal("OUTPUT_COLLISION", str(parent))
+
     def _control(self):
         path = ".modelark-slice-owner"
         data = d._json({"transaction": self.transaction_id, "seal": self.plan.seal,
@@ -411,7 +423,11 @@ class Session:
     def _directory(self, path):
         op = self._op(path, "directory")
         self._check()
-        if self._owned(path, op) is None:
+        self._check_parents(path)
+        existing = self._owned(path, op)
+        if existing is not None and op["state"] == "complete":
+            return
+        if existing is None:
             self.destination.create_directory(path, op["token"])
             self._owned(path, op)
             self._refresh_parent(path)
@@ -440,9 +456,11 @@ class Session:
     def _publish(self, op):
         self._check()
         path, temp, kind = op["path"], op["temporary"], op["kind"]
+        self._check_parents(path)
         if self._owned(path, op) is None:
             if self._owned(temp, op) is None or not self._matches(temp, op):
                 raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", temp)
+            self._check_parents(path)
             try:
                 self.destination.publish(temp, path, op["token"])
             except FileExistsError as exc:
@@ -457,15 +475,19 @@ class Session:
         op = self._record(op, "complete")
         self._fault(kind + "_complete")
         if self._owned(temp, op) is not None:
+            self._check_parents(temp)
             self.destination.discard_temporary(temp, op["token"])
             self._owned(temp, op)
             self._refresh_parent(temp)
             self.destination.flush(str(PurePosixPath(temp).parent))
+        if kind == "file":
+            self._verified_files.add(op["token"])
         return op
 
     def _write(self, op, stream, source=None):
         path, temp, kind = op["path"], op["temporary"], op["kind"]
         self._check()
+        self._check_parents(path)
         if self._owned(path, op) is not None:
             raise TransferRefusal("OUTPUT_COLLISION", path)
         # A missing completed output may be restarted. Clear its old prepared proof durably
@@ -481,6 +503,7 @@ class Session:
         digest, size = hashlib.sha256(), 0
         while data := stream.read(1024 * 1024):
             self._boundary()
+            self._check_parents(temp)
             size += len(data)
             if size > op["size"]:
                 raise TransferRefusal("SOURCE_DIGEST_MISMATCH")
@@ -551,9 +574,13 @@ class Session:
         self.store.complete(self.transaction_id, self.plan.destination.device_id)
 
     def step(self):
+        current = self.store.status(self.transaction_id)
+        if current.state == "complete":
+            return current
+        if current.state in {"failed", "invalidated"}:
+            self.lease.close()
+            raise TransferRefusal("NOT_RESUMABLE", current.state)
         self.lease.check()
-        if self.store.status(self.transaction_id).state == "complete":
-            return self.store.status(self.transaction_id)
         try:
             self._check()
             ops = self.ops
@@ -561,8 +588,10 @@ class Session:
                 path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)
                 op = ops.get(path)
                 if op and op["state"] == "complete" and self._owned(path, op):
-                    if not self._matches(path, op):
-                        raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", path)
+                    if op["token"] not in self._verified_files:
+                        if not self._matches(path, op):
+                            raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", path)
+                        self._verified_files.add(op["token"])
                     if self._owned(op["temporary"], op) is not None:
                         self._publish(op)
                     continue
@@ -575,9 +604,11 @@ class Session:
             state = _refusal_state(exc.code)
             self.store.set_state(self.transaction_id, state, str(exc))
             if exc.code not in states:
+                self.lease.close()
                 raise
         except FileExistsError as exc:
             self.store.set_state(self.transaction_id, "failed", "OUTPUT_COLLISION")
+            self.lease.close()
             raise TransferRefusal("OUTPUT_COLLISION", str(exc)) from exc
         return self.store.status(self.transaction_id)
 

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -1,0 +1,530 @@
+"""Internal Slice 2 orchestration over explicitly supplied, trusted adapter ports.
+
+No hardware adapter, catalog writer, remote retriever or public Start entry point lives here.
+An implementation of DestinationPort must prove confinement, device identity, allocation and
+recoverable owned-object creation. SourcePort holds the archive mutation fence, refreshes the
+catalog and opens *local original bytes* under that fence. Real adapters belong to Slice 3.
+"""
+from contextlib import AbstractContextManager
+from dataclasses import asdict, dataclass
+import errno
+import hashlib
+import io
+import json
+import os
+from pathlib import PurePosixPath
+import socket
+from typing import BinaryIO, Protocol
+import uuid
+
+from . import domain as d
+
+
+class TransferRefusal(ValueError):
+    def __init__(self, code, detail=""):
+        self.code, self.detail = code, detail
+        super().__init__(f"{code}: {detail}")
+
+
+@dataclass(frozen=True)
+class DestinationBinding:
+    device_id: str
+    filesystem_id: str
+    mount_id: str
+    available_bytes: int
+
+    def __post_init__(self):
+        if (not all(isinstance(v, str) and v.strip() for v in
+                    (self.device_id, self.filesystem_id, self.mount_id))
+                or not d._integer(self.available_bytes)):
+            raise TransferRefusal("DESTINATION_UNPROVEN")
+
+
+@dataclass(frozen=True)
+class TransferPlan:
+    proposal: d.SlicePreview
+    destination: DestinationBinding
+    version: str = "modelark.slice.transaction.v1"
+
+    def __post_init__(self):
+        d._verify(self.proposal)
+        if not self.proposal.source_ready or self.version != "modelark.slice.transaction.v1":
+            raise TransferRefusal("PREVIEW_BLOCKED")
+        if self.proposal.spec.destination_id != self.destination.device_id:
+            raise TransferRefusal("DESTINATION_CHANGED", "binding differs from reviewed destination intent")
+        if self.proposal.total_bytes > self.destination.available_bytes:
+            raise TransferRefusal("DESTINATION_CAPACITY_INSUFFICIENT")
+        root = PurePosixPath(self.proposal.spec.destination_root)
+        if root.parts[0] == ".modelark-slice-owner":
+            raise TransferRefusal("OUTPUT_COLLISION", "reserved control path")
+
+    @property
+    def seal(self):
+        return hashlib.sha256(self.to_json().encode()).hexdigest()
+
+    def to_json(self):
+        return d._json(asdict(self)).decode()
+
+    @classmethod
+    def from_json(cls, payload):
+        try:
+            obj = json.loads(payload)
+            p = obj["proposal"]
+            closure = []
+            for item in p["closure"]:
+                sources = tuple(d.SourceEvidence(d.CopyFact(**s["copy"]), d.DriveFact(**s["drive"]),
+                                                 d.AnchorFact(**s["anchor"]), s["digest_provenance"])
+                                for s in item.pop("sources"))
+                closure.append(d.Artifact(**item, sources=sources))
+            proposal = d.SlicePreview(d.SliceSpec(**p["spec"]), p["snapshot_id"], tuple(closure),
+                                      tuple(d.Gap(**g) for g in p["gaps"]), p["seal"], p["version"])
+            return cls(proposal, DestinationBinding(**obj["destination"]), obj["version"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise TransferRefusal("STATE_CORRUPT", str(exc)) from exc
+
+
+@dataclass(frozen=True)
+class Status:
+    transaction_id: str
+    state: str
+    reason: str = ""
+    can_write: bool = False
+
+
+@dataclass(frozen=True)
+class ObjectInfo:
+    kind: str
+    token: str | None
+    allocated_bytes: int
+
+
+class DestinationPort(Protocol):
+    """Bound destination operations; never resolve a mountpoint again during writes.
+
+    check must reject changed/system/archive/ambiguous devices, incompatible capabilities,
+    and unexplained capacity drift after subtracting the supplied owned allocations.
+    inspect must authenticate creation tokens (not filenames/hashes) against actual objects.
+    create_* must be exclusive and recoverable after a crash inside the adapter. flush on a
+    directory includes its metadata. publish is atomic no-replace and may retain the temp link.
+    list_paths returns every descendant, including directories and unexpected objects.
+    A concrete adapter must prove these obligations separately; the test port is not production.
+    """
+    def check(self, binding: DestinationBinding, allocated: int) -> None: ...
+    def inspect(self, path: str) -> ObjectInfo | None: ...
+    def create_directory(self, path: str, token: str) -> None: ...
+    def create_file(self, path: str, token: str) -> None: ...
+    def append(self, path: str, token: str, data: bytes) -> None: ...
+    def discard_temporary(self, path: str, token: str) -> None: ...
+    def read(self, path: str) -> AbstractContextManager[BinaryIO]: ...
+    def flush(self, path: str) -> None: ...
+    def publish(self, temporary: str, path: str, token: str) -> None: ...
+    def list_paths(self, root: str) -> tuple[str, ...]: ...
+
+
+class SourcePort(Protocol):
+    """Nonblocking archive fence through refresh, confined open, read, and stream close.
+
+    Yield a fresh CatalogSnapshot and original-byte stream; never retrieve absent content.
+    SOURCE_BUSY/SOURCE_MISSING/WAITING_SOURCE are distinct attended refusal codes.
+    """
+    def open(self, source: d.SourceEvidence) -> AbstractContextManager[tuple[d.CatalogSnapshot, BinaryIO]]: ...
+
+
+class _Lease:
+    """Linux host-wide process fence, independent of paths and immune to lock-file replacement.
+
+    Closing the parent's descriptor does not unlock an inherited child's descriptor. Workers
+    spawning an exec child capable of writing must pass fd explicitly; it is CLOEXEC by default.
+    """
+    def __init__(self, device):
+        self.pid = os.getpid()
+        self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        key = hashlib.sha256(device.encode()).hexdigest()
+        try:
+            self.socket.bind("\0modelark-slice-device-" + key)
+        except OSError as exc:
+            self.socket.close()
+            if exc.errno == errno.EADDRINUSE:
+                raise TransferRefusal("DESTINATION_BUSY") from exc
+            raise
+
+    def close(self):
+        self.socket.close()
+
+    def check(self):
+        if os.getpid() != self.pid or self.socket.fileno() < 0:
+            raise TransferRefusal("EXECUTION_FENCE_LOST")
+
+
+def _same_source(artifact, candidate, snapshot):
+    files = [f for f in snapshot.files if (f.repo_id, f.rfilename) == (artifact.repo_id, artifact.rfilename)]
+    copies = [c for c in snapshot.copies if (c.repo_id, c.rfilename, c.drive_label)
+              == (artifact.repo_id, artifact.rfilename, candidate.drive.drive_label)]
+    drives = [v for v in snapshot.drives if v.drive_label == candidate.drive.drive_label]
+    if len(files) != 1 or len(copies) != 1 or len(drives) != 1:
+        return False
+    file = files[0]
+    if (file.size_bytes, file.format, file.quant) != (artifact.size_bytes, artifact.format, artifact.quant):
+        return False
+    anchors = d._index(snapshot.anchors, lambda a: (a.drive_label, a.identity_epoch, a.generation))
+    result = d._source(file, copies[0], drives[0], anchors)
+    if isinstance(result, d.Gap) or result[0] != artifact.sha256:
+        return False
+    expected, actual = asdict(candidate), asdict(result[1])
+    expected["drive"].pop("eligibility")
+    actual["drive"].pop("eligibility")
+    return expected == actual
+
+
+def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault=None):
+    plan = store.load(tx)
+    status = store.status(tx)
+    if status.state == "ready":
+        raise TransferRefusal("APPROVAL_MISSING")
+    if status.state == "complete":
+        return status
+    try:
+        lease = _Lease(plan.destination.device_id)
+    except TransferRefusal:
+        if store.owner(plan.destination.device_id) == tx:
+            return store.status(tx)  # Observation only; never hands out a writer capability.
+        raise
+    try:
+        destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination))
+        store.claim(tx, plan.destination.device_id)
+        session = Session(store, tx, plan, destination, sources, lease, fault)
+        session._fault("reserved")
+        session._control()
+        return session
+    except TransferRefusal as exc:
+        try:
+            if exc.code != "DESTINATION_BUSY":
+                store.set_state(tx, _refusal_state(exc.code), str(exc))
+        finally:
+            lease.close()
+        raise
+    except BaseException:
+        lease.close()
+        raise
+
+
+def _operations(store, tx):
+    plan = store.load(tx)
+    root = PurePosixPath(plan.proposal.spec.destination_root)
+    files = {str(root / f.repo_id / f.rfilename): f for f in plan.proposal.closure}
+    directories = {str(p) for path in files for p in PurePosixPath(path).parents if str(p) != "."}
+    receipt_path = str(root / ".modelark-slice-receipt.json")
+    result = {}
+    for event, payload in store.events(tx):
+        if event == "operation":
+            path = payload.get("path")
+            kind = payload.get("kind")
+            if (payload.get("seal") != plan.seal or payload.get("device") != plan.destination.device_id
+                    or not d._path(path) or payload.get("state") not in {"intent", "prepared", "complete"}
+                    or not isinstance(payload.get("token"), str) or len(payload["token"]) != 32):
+                raise TransferRefusal("JOURNAL_CORRUPT")
+            if kind == "file":
+                artifact = files.get(path)
+                if artifact is None or (payload.get("size"), payload.get("sha")) != (artifact.size_bytes, artifact.sha256):
+                    raise TransferRefusal("JOURNAL_CORRUPT", path)
+                if payload.get("source"):
+                    recorded = json.loads(d._json(payload["source"]))
+                    try:
+                        recorded["drive"].pop("eligibility")
+                    except (KeyError, TypeError) as exc:
+                        raise TransferRefusal("JOURNAL_CORRUPT") from exc
+                    approved = []
+                    for source in artifact.sources:
+                        value = asdict(source)
+                        value["drive"].pop("eligibility")
+                        approved.append(value)
+                    if recorded not in approved:
+                        raise TransferRefusal("JOURNAL_CORRUPT", "unsealed source record")
+                elif payload["state"] != "intent":
+                    raise TransferRefusal("JOURNAL_CORRUPT", "prepared file lacks source proof")
+            elif not ((kind == "directory" and path in directories)
+                      or (kind == "control" and path == ".modelark-slice-owner")
+                      or (kind == "receipt" and path == receipt_path)):
+                raise TransferRefusal("JOURNAL_CORRUPT", path)
+            temporary = payload.get("temporary")
+            expected = str(PurePosixPath(path).parent / (".slice-" + payload["token"]))
+            if temporary != (expected if kind in {"file", "receipt"} else None):
+                raise TransferRefusal("JOURNAL_CORRUPT", "temporary identity differs")
+            previous = result.get(path)
+            if previous and any(previous.get(key) != payload.get(key) for key in
+                                ("kind", "token", "temporary", "size", "sha")):
+                raise TransferRefusal("JOURNAL_CORRUPT", "operation identity changed")
+            result[path] = payload
+        elif event != "receipt" or payload.get("seal") != plan.seal or payload.get("transaction") != tx:
+            raise TransferRefusal("JOURNAL_CORRUPT", "unexpected event")
+    return result
+
+
+def _refusal_state(code):
+    return {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
+            "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}.get(
+                code, "invalidated" if code.startswith("DESTINATION_") else "failed")
+
+
+def _allocated(store, tx, destination):
+    total, seen = 0, set()
+    for op in _operations(store, tx).values():
+        for path in (op["path"], op.get("temporary")):
+            if not path or path in seen:
+                continue
+            seen.add(path)
+            info = destination.inspect(path)
+            if info is not None:
+                if info.token != op["token"] or not d._integer(info.allocated_bytes):
+                    raise TransferRefusal("OUTPUT_COLLISION", path)
+                # A publication can temporarily have two names for one object; tokens identify it.
+                if info.token not in seen:
+                    total += info.allocated_bytes
+                    seen.add(info.token)
+    return total
+
+
+class Session:
+    @property
+    def can_write(self):
+        return self.lease.socket.fileno() >= 0 and os.getpid() == self.lease.pid
+
+    def __init__(self, store, tx, plan, destination, sources, lease, fault):
+        self.store, self.transaction_id, self.plan = store, tx, plan
+        self.destination, self.sources, self.lease = destination, sources, lease
+        self._fault = fault or (lambda point: None)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self):
+        if self.lease.socket.fileno() < 0:
+            return
+        try:
+            if os.getpid() == self.lease.pid and self.store.status(self.transaction_id).state in {"transferring", "verifying"}:
+                self.store.set_state(self.transaction_id, "stopped")
+        finally:
+            self.lease.close()  # Never explicit unlock: inherited writer children retain exclusion.
+
+    def _check(self):
+        self.lease.check()
+        if self.store.owner(self.plan.destination.device_id) != self.transaction_id:
+            raise TransferRefusal("EXECUTION_FENCE_LOST")
+        if self.store.stop_requested(self.transaction_id):
+            raise TransferRefusal("STOPPED")
+        self.destination.check(self.plan.destination, _allocated(self.store, self.transaction_id, self.destination))
+
+    def _record(self, op, state):
+        op = dict(op, state=state)
+        self.store.append(self.transaction_id, "operation", op)
+        return op
+
+    def _op(self, path, kind, *, size=0, sha="", source=None):
+        previous = _operations(self.store, self.transaction_id).get(path)
+        if previous:
+            if (previous["kind"], previous["size"], previous["sha"]) != (kind, size, sha):
+                raise TransferRefusal("JOURNAL_CORRUPT", path)
+            return previous
+        if self.destination.inspect(path) is not None:
+            raise TransferRefusal("OUTPUT_COLLISION", path)
+        token = uuid.uuid4().hex
+        temporary = str(PurePosixPath(path).parent / (".slice-" + token)) if kind in {"file", "receipt"} else None
+        op = dict(path=path, kind=kind, size=size, sha=sha, token=token, temporary=temporary,
+                  source=source, seal=self.plan.seal, device=self.plan.destination.device_id)
+        op = self._record(op, "intent")
+        self._fault(kind + "_intent")
+        return op
+
+    def _owned(self, path, op):
+        info = self.destination.inspect(path)
+        if info and (info.token != op["token"] or info.kind != ("directory" if op["kind"] == "directory" else "file")):
+            raise TransferRefusal("OUTPUT_COLLISION", path)
+        return info
+
+    def _control(self):
+        path = ".modelark-slice-owner"
+        data = d._json({"transaction": self.transaction_id, "seal": self.plan.seal,
+                        "store": str(self.store.root), "destination": asdict(self.plan.destination)})
+        op = self._op(path, "control", size=len(data), sha=hashlib.sha256(data).hexdigest())
+        info = self._owned(path, op)
+        self._check()
+        if info is None:
+            self.destination.create_file(path, op["token"])
+            self.destination.append(path, op["token"], data)
+            self._fault("control_created")
+        elif not self._matches(path, op):
+            raise TransferRefusal("CONTROL_CORRUPT")
+        self.destination.flush(path)
+        self.destination.flush(".")
+        self._fault("control_flushed")
+        self._record(op, "complete")
+        self._fault("control_complete")
+
+    def _directory(self, path):
+        op = self._op(path, "directory")
+        self._check()
+        if self._owned(path, op) is None:
+            self.destination.create_directory(path, op["token"])
+            self._fault("directory_created")
+        self.destination.flush(path)
+        self._fault("directory_flushed")
+        self.destination.flush(str(PurePosixPath(path).parent))
+        self._fault("directory_parent_flushed")
+        self._record(op, "complete")
+        self._fault("directory_complete")
+
+    def _parents(self, path):
+        for parent in reversed(PurePosixPath(path).parents):
+            if str(parent) != ".":
+                self._directory(str(parent))
+
+    def _matches(self, path, op):
+        digest, size = hashlib.sha256(), 0
+        with self.destination.read(path) as stream:
+            while data := stream.read(1024 * 1024):
+                digest.update(data)
+                size += len(data)
+        return size == op["size"] and digest.hexdigest() == op["sha"]
+
+    def _publish(self, op):
+        self._check()
+        path, temp, kind = op["path"], op["temporary"], op["kind"]
+        if self._owned(path, op) is None:
+            if self._owned(temp, op) is None or not self._matches(temp, op):
+                raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", temp)
+            self.destination.publish(temp, path, op["token"])
+            self._fault(kind + "_published")
+        elif not self._matches(path, op):
+            raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", path)
+        self.destination.flush(str(PurePosixPath(path).parent))
+        self._fault(kind + "_parent_flushed")
+        op = self._record(op, "complete")
+        self._fault(kind + "_complete")
+        if self._owned(temp, op) is not None:
+            self.destination.discard_temporary(temp, op["token"])
+            self.destination.flush(str(PurePosixPath(temp).parent))
+        return op
+
+    def _write(self, op, stream, source=None):
+        path, temp, kind = op["path"], op["temporary"], op["kind"]
+        self._check()
+        if self._owned(path, op) is not None:
+            raise TransferRefusal("OUTPUT_COLLISION", path)
+        # A missing completed output may be restarted. Clear its old prepared proof durably
+        # BEFORE touching temporary bytes, so a crash cannot attribute new bytes to an old read.
+        op = self._record(dict(op, source=None), "intent")
+        if self._owned(temp, op) is not None:
+            self.destination.discard_temporary(temp, op["token"])
+        self.destination.create_file(temp, op["token"])
+        self._fault("temporary_created" if kind == "file" else "receipt_created")
+        digest, size = hashlib.sha256(), 0
+        while data := stream.read(1024 * 1024):
+            self._check()
+            if self.store.stop_requested(self.transaction_id):
+                raise TransferRefusal("STOPPED")
+            size += len(data)
+            if size > op["size"]:
+                raise TransferRefusal("SOURCE_DIGEST_MISMATCH")
+            self.destination.append(temp, op["token"], data)
+            digest.update(data)
+            # Intent and ownership certificate authenticate actual in-flight allocation on recovery.
+            self._fault("chunk_written")
+        if size != op["size"] or digest.hexdigest() != op["sha"]:
+            raise TransferRefusal("SOURCE_DIGEST_MISMATCH")
+        self.destination.flush(temp)
+        self._fault(kind + "_flushed")
+        op = self._record(dict(op, source=source), "prepared")
+        self._fault(kind + "_prepared")
+        return self._publish(op)
+
+    def _file(self, artifact):
+        path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)
+        self._parents(path)
+        op = self._op(path, "file", size=artifact.size_bytes, sha=artifact.sha256)
+        final = self._owned(path, op)
+        if op["state"] in {"prepared", "complete"} and op["source"]:
+            if final is not None or self._owned(op["temporary"], op) is not None:
+                return self._publish(op)
+        elif final is not None:
+            raise TransferRefusal("UNPREPARED_PUBLICATION", path)
+        errors = []
+        for source in artifact.sources:
+            try:
+                with self.sources.open(source) as (snapshot, stream):
+                    if not _same_source(artifact, source, snapshot):
+                        raise TransferRefusal("SOURCE_CHANGED", source.drive.drive_label)
+                    return self._write(op, stream, asdict(source))
+            except TransferRefusal as exc:
+                if not (exc.code.startswith("SOURCE_") or exc.code == "WAITING_SOURCE"):
+                    raise
+                errors.append((exc.code, source.drive.drive_label))
+        waiting = any(code == "WAITING_SOURCE" for code, _ in errors)
+        raise TransferRefusal("WAITING_SOURCE" if waiting else "SOURCE_BLOCKED", json.dumps(errors))
+
+    def _finish(self):
+        self.store.set_state(self.transaction_id, "verifying")
+        ops = _operations(self.store, self.transaction_id)
+        files = []
+        for artifact in self.plan.proposal.closure:
+            path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)
+            op = ops[path]
+            if op["state"] != "complete" or not op["source"] or not self._owned(path, op) or not self._matches(path, op):
+                raise TransferRefusal("VERIFICATION_FAILED", path)
+            files.append({"path": path, "size": op["size"], "sha256": op["sha"], "source": op["source"]})
+        expected = set(ops)
+        expected.update(op["temporary"] for op in ops.values() if op.get("temporary"))
+        unexpected = set(self.destination.list_paths(self.plan.proposal.spec.destination_root)) - expected
+        if unexpected:
+            raise TransferRefusal("OUTPUT_COLLISION", str(sorted(unexpected)))
+        receipt = {"version": self.plan.version, "transaction": self.transaction_id, "seal": self.plan.seal,
+                   "destination": asdict(self.plan.destination), "files": files}
+        path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / ".modelark-slice-receipt.json")
+        data = d._json(receipt)
+        op = self._op(path, "receipt", size=len(data), sha=hashlib.sha256(data).hexdigest())
+        if op["state"] in {"prepared", "complete"}:
+            self._publish(op)
+        else:
+            self._write(op, io.BytesIO(data))
+        self.store.append(self.transaction_id, "receipt", receipt)
+        self.store.complete(self.transaction_id, self.plan.destination.device_id)
+
+    def step(self):
+        self.lease.check()
+        if self.store.status(self.transaction_id).state == "complete":
+            return self.store.status(self.transaction_id)
+        try:
+            self._check()
+            if self.store.stop_requested(self.transaction_id):
+                raise TransferRefusal("STOPPED")
+            ops = _operations(self.store, self.transaction_id)
+            for artifact in self.plan.proposal.closure:
+                path = str(PurePosixPath(self.plan.proposal.spec.destination_root) / artifact.repo_id / artifact.rfilename)
+                op = ops.get(path)
+                if op and op["state"] == "complete" and self._owned(path, op):
+                    if not self._matches(path, op):
+                        raise TransferRefusal("RECOVERY_DIGEST_MISMATCH", path)
+                    if self._owned(op["temporary"], op) is not None:
+                        self._publish(op)
+                    continue
+                self._file(artifact)
+                return self.store.status(self.transaction_id)
+            self._finish()
+        except TransferRefusal as exc:
+            states = {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
+                      "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}
+            state = _refusal_state(exc.code)
+            self.store.set_state(self.transaction_id, state, str(exc))
+            if exc.code not in states:
+                raise
+        except FileExistsError as exc:
+            self.store.set_state(self.transaction_id, "failed", "OUTPUT_COLLISION")
+            raise TransferRefusal("OUTPUT_COLLISION", str(exc)) from exc
+        return self.store.status(self.transaction_id)
+
+    def run(self):
+        while (result := self.step()).state in {"transferring", "verifying"}:
+            pass
+        return result

--- a/tests/test_drive_lifecycle.py
+++ b/tests/test_drive_lifecycle.py
@@ -199,6 +199,21 @@ def test_declare_lost_refuses_while_fill_is_live(tmp_path):
     con.close()
 
 
+def test_declare_lost_serializes_with_source_read_fence(tmp_path, monkeypatch):
+    from modelark import drive_fence
+    monkeypatch.setattr(drive_fence, "_LOCK_DIR", tmp_path / "locks")
+    con = _catalog(tmp_path)
+    preview = drive_lifecycle.loss_preview(con, "drive-02")
+    key = (preview["identity_fingerprint"], preview["identity_epoch"])
+    with drive_fence.hold_drives_sorted([key], blocking=False):
+        with pytest.raises(proposal.Refusal) as caught:
+            _declare(con, preview)
+        assert caught.value.code == "DRIVE_BUSY"
+        assert drive_lifecycle.loss_preview(con, "drive-02") == preview
+    assert _declare(con, preview)["lifecycle"] == "lost"
+    con.close()
+
+
 def test_portal_operation_returns_canonical_replan_without_targeting_lost_drive(tmp_path):
     con = _catalog(tmp_path)
     from modelark.web import data, drive_api

--- a/tests/test_drive_mutation_envelope.py
+++ b/tests/test_drive_mutation_envelope.py
@@ -626,7 +626,7 @@ def test_envelope_wired_only_into_reviewed_transport():
     # 2026-09-07 / DEC-109: Slice 2's read-only gate shares the neutral fence, not mutation authority.
     fence_allowed = mutation_allowed | {
         "admission.py", "proposal.py", "execution_service.py", "execution_recovery.py",
-        "slice/sources.py",
+        "slice/sources.py", "drive_lifecycle.py",
     }
     importers, offenders = set(), []
     for path in root.rglob("*.py"):

--- a/tests/test_drive_mutation_envelope.py
+++ b/tests/test_drive_mutation_envelope.py
@@ -623,12 +623,15 @@ def test_envelope_wired_only_into_reviewed_transport():
     mutation_allowed = {"fetch.py", "drive_bootstrap.py"}
     # #35-C admission preview + PR-08 proposal approval (A6) hold drive fences.
     # PR-09 execution session/recovery holds real controller+drive fences (B8/B9).
+    # 2026-09-07 / DEC-109: Slice 2's read-only gate shares the neutral fence, not mutation authority.
     fence_allowed = mutation_allowed | {
         "admission.py", "proposal.py", "execution_service.py", "execution_recovery.py",
+        "slice/sources.py",
     }
     importers, offenders = set(), []
     for path in root.rglob("*.py"):
-        if path.name in ("drive_fence.py", "drive_mutation.py"):
+        relative = path.relative_to(root).as_posix()
+        if relative in ("drive_fence.py", "drive_mutation.py"):
             continue
         tree = ast.parse(path.read_text(), filename=str(path))
         for node in ast.walk(tree):
@@ -639,9 +642,9 @@ def test_envelope_wired_only_into_reviewed_transport():
                 module = (node.module or "").split(".")
                 hits = (set(module) & envelope) | {a.name for a in node.names if a.name in envelope}
             for mod in hits:
-                importers.add(path.name)
+                importers.add(relative)
                 allowed = fence_allowed if mod == "drive_fence" else mutation_allowed
-                if path.name not in allowed:
+                if relative not in allowed:
                     offenders.append(f"{path.relative_to(root)}:{node.lineno} ({mod})")
     assert offenders == [], f"envelope import policy violated; found: {offenders}"
     assert "fetch.py" in importers, (

--- a/tests/test_execution_authority.py
+++ b/tests/test_execution_authority.py
@@ -1,0 +1,147 @@
+"""Shared attempt invariants and the existing Fill persistence adapter boundary."""
+from contextlib import contextmanager
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from modelark import execution_authority as authority
+from modelark import execution_recovery, execution_session
+from modelark.proposal import Refusal
+
+
+@pytest.mark.parametrize("token", [7, "attempt-7"])
+def test_exact_attempt_in_allowed_state_is_current(token):
+    authority.require_current(authority.Attempt("owner", token),
+                              authority.Attempt("owner", token), "running", {"running"})
+
+
+@pytest.mark.parametrize("actual", [authority.Attempt("other", 7),
+                                  authority.Attempt("owner", 8),
+                                  authority.Attempt("owner", "7")])
+def test_same_state_does_not_authorize_another_owner_or_attempt(actual):
+    with pytest.raises(authority.AuthorityLost):
+        authority.require_current(authority.Attempt("owner", 7), actual, "running", {"running"})
+
+
+def test_same_attempt_does_not_authorize_a_terminal_state():
+    with pytest.raises(authority.AuthorityLost):
+        authority.require_current(authority.Attempt("owner", 7),
+                                  authority.Attempt("owner", 7), "done", {"running"})
+
+
+def _connection():
+    con = sqlite3.connect(":memory:", isolation_level=None)
+    con.execute("CREATE TABLE execution_sessions(session_id TEXT PRIMARY KEY, state TEXT,"
+                "fencing_token INTEGER, bound_planner_revision INTEGER, expires_at TEXT,"
+                "approved_proposal_id TEXT, terminal_code TEXT, terminal_at TEXT)")
+    con.execute("INSERT INTO execution_sessions VALUES('fill','running',7,0,"
+                "'2000-01-01T00:00:00Z','proposal',NULL,NULL)")
+    return con
+
+
+def test_fill_graph_write_checks_shared_attempt_inside_transaction(monkeypatch):
+    con = _connection()
+    seen = []
+    original = authority.require_current
+
+    def check(expected, actual, state, allowed_states):
+        assert con.in_transaction
+        seen.append((expected, actual, state))
+        original(expected, actual, state, allowed_states)
+
+    monkeypatch.setattr(authority, "require_current", check)
+    monkeypatch.setattr(execution_session, "bump_revision", lambda connection: 1)
+    try:
+        assert execution_session.session_write(con, "fill", 7, lambda connection: "written") == "written"
+        assert seen == [(authority.Attempt("fill", 7), authority.Attempt("fill", 7), "running")]
+        with pytest.raises(Refusal) as error:
+            execution_session.session_write(con, "fill", 8, lambda connection: pytest.fail("stale writer"))
+        assert error.value.code == "SESSION_TOKEN_MISMATCH"
+    finally:
+        con.close()
+
+
+@pytest.mark.parametrize("change", ["fencing_token=8", "state='done'"])
+def test_fill_graph_write_rejects_authority_changed_after_preflight(change):
+    con = _connection()
+
+    class RacingConnection:
+        def execute(self, sql, *args):
+            if sql == "BEGIN IMMEDIATE":
+                con.execute("UPDATE execution_sessions SET " + change)
+            return con.execute(sql, *args)
+
+    try:
+        with pytest.raises(Refusal) as error:
+            execution_session.session_write(
+                RacingConnection(), "fill", 7, lambda connection: pytest.fail("lost authority"))
+        assert error.value.code == "SESSION_TOKEN_MISMATCH"
+        assert not con.in_transaction
+    finally:
+        con.close()
+
+
+@pytest.mark.parametrize(("change", "code"), [
+    ("fencing_token=8", "SESSION_TOKEN_MISMATCH"),
+    ("state='done'", "SESSION_STATE_INVALID"),
+])
+def test_fill_recovery_rejects_authority_changed_before_fenced_transaction(monkeypatch, change, code):
+    con = _connection()
+
+    @contextmanager
+    def controller():
+        con.execute("UPDATE execution_sessions SET " + change)
+        yield
+
+    @contextmanager
+    def drives(*args):
+        yield
+
+    monkeypatch.setattr(execution_recovery, "child_fence_still_held", lambda **kw: False)
+    monkeypatch.setattr(execution_recovery, "owned_dirty_generations", lambda *args, **kw: ())
+    services = SimpleNamespace(controller_flock=SimpleNamespace(hold=controller),
+                               drive_fences=SimpleNamespace(hold_all_sorted=drives))
+    try:
+        with pytest.raises(Refusal) as error:
+            execution_recovery.recover_expired_session(con, session_id="fill", services=services)
+        assert error.value.code == code
+        assert not con.in_transaction
+    finally:
+        con.close()
+
+
+def test_fill_recovery_checks_shared_attempt_under_fences_and_transaction(monkeypatch):
+    con = _connection()
+    held = []
+    seen = []
+    original = authority.require_current
+
+    @contextmanager
+    def hold(*args):
+        held.append(True)
+        try:
+            yield
+        finally:
+            held.pop()
+
+    def check(expected, actual, state, allowed_states):
+        assert con.in_transaction and len(held) == 2
+        seen.append((expected, actual, state))
+        original(expected, actual, state, allowed_states)
+
+    monkeypatch.setattr(authority, "require_current", check)
+    monkeypatch.setattr(execution_recovery, "child_fence_still_held", lambda **kw: False)
+    monkeypatch.setattr(execution_recovery, "owned_dirty_generations", lambda *args, **kw: ())
+    monkeypatch.setattr(execution_recovery, "release_child_fences", lambda *args: None)
+    services = SimpleNamespace(controller_flock=SimpleNamespace(hold=hold),
+                               drive_fences=SimpleNamespace(hold_all_sorted=hold))
+    try:
+        assert execution_recovery.recover_expired_session(con, session_id="fill", services=services)
+        assert len(seen) == 2
+        assert all(item == (authority.Attempt("fill", 7), authority.Attempt("fill", 7), "running")
+                   for item in seen)
+        assert con.execute("SELECT state,terminal_code FROM execution_sessions").fetchone() == (
+            "failed", "EXPIRED_RECOVERED")
+    finally:
+        con.close()

--- a/tests/test_slice_authority.py
+++ b/tests/test_slice_authority.py
@@ -201,3 +201,85 @@ def test_first_reservation_keeps_snapshot_while_waiting_for_writer(setup, monkey
     assert intervened and not list(destination.root.iterdir())
     with t.start(store, tx, destination, sources) as resumed:
         assert resumed.run().state == "complete"
+
+
+@pytest.mark.parametrize("stop_at", ["boundary", "chunk_written", "file_prepared"])
+def test_acknowledged_stop_releases_attempt_without_caller_close(setup, stop_at):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    with t.start(store, tx, destination, sources) as stopped:
+        old_attempt = stopped.authority.attempt
+        if stop_at == "boundary":
+            store.request_stop(tx)
+        else:
+            stopped._fault = lambda point: store.request_stop(tx) if point == stop_at else None
+        assert stopped.run().state == "stopped"
+        assert not stopped.can_write
+        assert not stopped.lease.retained(plan.destination.device_id, old_attempt)
+        assert store.owner(plan.destination.device_id) == tx
+        with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+            stopped.step()
+        with t.start(store, tx, destination, sources) as resumed:
+            assert resumed.can_write and resumed.authority.attempt != old_attempt
+            stopped.close()  # A retained old object must not release or stop the fresh attempt.
+            assert resumed.run().state == "complete"
+
+
+def test_stop_release_returns_its_outcome_when_new_start_wins(setup, monkeypatch):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    successors = []
+    with t.start(store, tx, destination, sources) as stopped:
+        close = stopped.lease.close
+        def release_and_restart():
+            close()
+            if not successors:
+                successors.append(t.start(store, tx, destination, sources))
+        monkeypatch.setattr(stopped.lease, "close", release_and_restart)
+        store.request_stop(tx)
+        try:
+            assert stopped.run().state == "stopped"
+            assert not stopped.can_write
+            assert len(successors) == 1 and successors[0].can_write
+            assert store.status(tx).state == "transferring"
+            assert successors[0].run().state == "complete"
+        finally:
+            monkeypatch.setattr(stopped.lease, "close", close)
+            for successor in successors:
+                successor.close()
+
+
+def test_stop_revokes_attempt_even_when_acknowledgment_write_fails(setup, monkeypatch):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    with t.start(store, tx, destination, sources) as stopped:
+        store.request_stop(tx)
+        def busy(*args, **kwargs):
+            raise t.TransferRefusal("STATE_BUSY")
+        with monkeypatch.context() as patch:
+            patch.setattr(store, "transition", busy)
+            with pytest.raises(t.TransferRefusal, match="STATE_BUSY"):
+                stopped.run()
+        assert not stopped.can_write
+        with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+            stopped.run()
+        # A failed persistence attempt is not a durable acknowledgment.
+        with pytest.raises(t.TransferRefusal, match="STOPPED"):
+            t.start(store, tx, destination, sources)
+        with t.start(store, tx, destination, sources) as resumed:
+            assert resumed.run().state == "complete"
+
+
+def test_stop_winning_over_source_wait_releases_attempt(setup, monkeypatch):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    with t.start(store, tx, destination, sources) as stopped:
+        def source_gap(*args):
+            store.request_stop(tx)
+            raise t.TransferRefusal("WAITING_SOURCE")
+        with monkeypatch.context() as patch:
+            patch.setattr(sources, "open", source_gap)
+            assert stopped.run().state == "stopped"
+        assert not stopped.can_write
+        with t.start(store, tx, destination, sources) as resumed:
+            assert resumed.run().state == "complete"

--- a/tests/test_slice_authority.py
+++ b/tests/test_slice_authority.py
@@ -1,0 +1,203 @@
+"""Delivery authority regressions: disposable state, devices and original bytes only."""
+import multiprocessing
+import os
+from contextlib import contextmanager
+
+import pytest
+
+from test_slice_transaction import api as api, setup as setup, d
+
+
+def test_stale_acquisition_confuses_a_delayed_completed_starter(setup, monkeypatch):
+    t, store, plan, first, destination, sources = setup
+    second = store.create(plan, d.approve(plan.proposal, expected_seal=plan.proposal.seal,
+                                        current_snapshot=sources.snapshot))
+    store.approve(first, expected_seal=plan.seal)
+    store.approve(second, expected_seal=plan.seal)
+    observed = []
+    def delayed(point):
+        if point != "reservation_committed":
+            return
+        with t.start(store, first, destination, sources) as winner:
+            assert winner.run().state == "complete"
+        def transient_failure(*args):
+            raise t.TransferRefusal("STATE_BUSY")
+        with monkeypatch.context() as patch:
+            patch.setattr(destination, "check", transient_failure)
+            with pytest.raises(t.TransferRefusal, match="STATE_BUSY"):
+                t.start(store, second, destination, sources)
+        assert store.owner(plan.destination.device_id) == second
+        status = store.status
+        def after_old_starter_binds(tx):
+            if tx == first and not observed:
+                try:
+                    observed.append(t.start(store, second, destination, sources))
+                except t.TransferRefusal as exc:
+                    observed.append(exc)
+            return status(tx)
+        monkeypatch.setattr(store, "status", after_old_starter_binds)
+    assert t.start(store, first, destination, sources, fault=delayed).state == "complete"
+    assert len(observed) == 1
+    assert isinstance(observed[0], t.TransferRefusal), repr(observed[0])
+    assert observed[0].code == "DESTINATION_BUSY"
+
+
+def test_completion_between_status_and_reservation_returns_terminal_status(setup, monkeypatch):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    reserve = store.reserve
+    def completion_wins(*args):
+        monkeypatch.setattr(store, "reserve", reserve)
+        with t.start(store, tx, destination, sources) as winner:
+            assert winner.run().state == "complete"
+        return reserve(*args)
+    monkeypatch.setattr(store, "reserve", completion_wins)
+    outcome = t.start(store, tx, destination, sources)
+    assert outcome.state == "complete" and not outcome.can_write
+
+
+def _die_after_operator_stop(store, tx, destination, sources):
+    from modelark.slice import transaction as t
+    def die(point):
+        if point == "reserved":
+            store.request_stop(tx)
+            os._exit(73)
+    with t.start(store, tx, destination, sources, fault=die):
+        pass
+
+
+def test_recovery_preserves_unacknowledged_stop_after_writer_death(setup):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    process = multiprocessing.get_context("fork").Process(
+        target=_die_after_operator_stop, args=(store, tx, destination, sources))
+    process.start()
+    process.join()
+    assert process.exitcode == 73
+    assert store.status(tx).state == "transferring" and store.stop_requested(tx)
+    assert not list(destination.root.iterdir())
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        with t.start(store, tx, destination, sources):
+            pass
+    assert not list(destination.root.iterdir())
+    with t.start(store, tx, destination, sources) as resumed:
+        assert resumed.run().state == "complete"
+
+
+def test_marker_queries_do_not_queue_and_release_precedes_device(api):
+    from modelark.slice.authority import Lease
+    lease = Lease("authority-marker-test", "transaction")
+    try:
+        for _ in range(1000):
+            assert Lease.retained(lease.device, lease.attempt)
+        lease.marker.close()
+        assert not Lease.retained(lease.device, lease.attempt)
+        with pytest.raises(api[0].TransferRefusal, match="DESTINATION_BUSY"):
+            Lease(lease.device, "another")
+    finally:
+        lease.close()
+
+
+def test_replaced_attempt_cannot_publish_state_or_journal(setup):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    first = t.start(store, tx, destination, sources)
+    old = first.authority.attempt
+    first.close()
+    with t.start(store, tx, destination, sources) as current:
+        before = store.head(tx)
+        for operation in (
+            lambda: store.transition(old, plan.destination.device_id, "failed"),
+            lambda: store.append(tx, "hostile", {}, attempt=old, device=plan.destination.device_id),
+        ):
+            with pytest.raises(t.TransferRefusal, match="EXECUTION_FENCE_LOST"):
+                operation()
+        assert store.head(tx) == before
+        assert store.status(tx).state == "transferring"
+        assert current.run().state == "complete"
+
+
+def test_stopped_attempt_cannot_restart_without_new_claim(setup):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    with t.start(store, tx, destination, sources) as session:
+        session.authority.transition("stopped")
+        for operation in (
+            lambda: session.authority.transition("transferring"),
+            lambda: session.authority.append("hostile", {}, expected_head=store.head(tx)),
+        ):
+            with pytest.raises(t.TransferRefusal, match="STATE_TRANSITION_INVALID"):
+                operation()
+
+
+@pytest.mark.parametrize("legacy_state", ["starting", "stopped"])
+def test_v4_migration_never_treats_process_history_as_live_identity(setup, api, legacy_state):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    store.reserve(tx, plan.destination.device_id)
+    store.request_stop(tx)
+    with store._connection() as con:
+        con.execute("UPDATE transactions SET state=?", (legacy_state,))
+        con.execute("UPDATE owners SET process_seen=1")
+        con.execute("ALTER TABLE owners DROP COLUMN attempt")
+        con.execute("ALTER TABLE transactions DROP COLUMN acknowledged_stop_serial")
+        con.execute("PRAGMA user_version=4")
+    upgraded = api[1].Store()
+    assert upgraded.current_attempt(plan.destination.device_id) is None
+    unrelated = t._Lease(plan.destination.device_id)
+    try:
+        for _ in range(2):
+            with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+                t.start(upgraded, tx, destination, sources)
+    finally:
+        unrelated.close()
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        t.start(upgraded, tx, destination, sources)
+    assert not list(destination.root.iterdir())
+    with t.start(upgraded, tx, destination, sources) as resumed:
+        assert resumed.run().state == "complete"
+
+
+def test_start_issued_before_stop_acknowledgment_cannot_resume_later(setup):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    with t.start(store, tx, destination, sources) as first:
+        store.request_stop(tx)
+        assert first.run().state == "stopped"
+    store.request_stop(tx)  # New request while stopped, not yet acknowledged.
+    before = tuple(destination.root.rglob("*"))
+    def acknowledge_from_another_caller(point):
+        if point == "reservation_committed":
+            with pytest.raises(t.TransferRefusal, match="STOPPED"):
+                t.start(store, tx, destination, sources)
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        t.start(store, tx, destination, sources, fault=acknowledge_from_another_caller)
+    assert tuple(destination.root.rglob("*")) == before
+    assert store.stop_requested(tx)
+    with t.start(store, tx, destination, sources) as resumed:
+        assert resumed.run().state == "complete"
+
+
+def test_first_reservation_keeps_snapshot_while_waiting_for_writer(setup, monkeypatch):
+    t, store, plan, tx, destination, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    connection = store._connection
+    intervened = False
+    @contextmanager
+    def delayed_writer(*, write=True):
+        nonlocal intervened
+        if write and not intervened:
+            intervened = True
+            def request_during_initialization(point):
+                if point == "reservation_committed":
+                    store.request_stop(tx)
+            with pytest.raises(t.TransferRefusal, match="STOPPED"):
+                t.start(store, tx, destination, sources, fault=request_during_initialization)
+        with connection(write=write) as con:
+            yield con
+    monkeypatch.setattr(store, "_connection", delayed_writer)
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        t.start(store, tx, destination, sources)
+    assert intervened and not list(destination.root.iterdir())
+    with t.start(store, tx, destination, sources) as resumed:
+        assert resumed.run().state == "complete"

--- a/tests/test_slice_fence_integration.py
+++ b/tests/test_slice_fence_integration.py
@@ -1,0 +1,142 @@
+"""Cross-workflow physical fencing, using only disposable catalogs and lock files."""
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+import fcntl
+import io
+import sqlite3
+import threading
+
+import pytest
+
+from modelark import drive_fence, drive_lifecycle, proposal
+from modelark.core import db
+from modelark.execution_service import production_services
+from modelark.slice import domain
+from modelark.slice.catalog import read_catalog
+from modelark.slice.sources import FencedSources
+from modelark.slice.transaction import TransferRefusal
+from test_slice_catalog import seed
+from test_slice_domain import spec
+
+
+class Reader:
+    def __init__(self):
+        self.opened = False
+        self.opens = 0
+
+    @contextmanager
+    def open(self, candidate):
+        self.opened = True
+        self.opens += 1
+        try:
+            with io.BytesIO(b"source bytes") as stream:
+                yield stream
+        finally:
+            self.opened = False
+
+
+@pytest.fixture
+def archive(tmp_path, monkeypatch):
+    monkeypatch.setattr(drive_fence, "_LOCK_DIR", tmp_path / "locks")
+
+    def no_global_catalog(*args, **kwargs):
+        pytest.fail("cross-workflow tests must use their explicit disposable catalog")
+
+    monkeypatch.setattr(db, "connect", no_global_catalog)
+    path = tmp_path / "catalog.sqlite"
+    con = seed(path, domain)
+    snapshot = read_catalog(path, spec(domain))
+    candidate = domain.preview(spec(domain), snapshot).closure[0].sources[0]
+    reader = Reader()
+    sources = FencedSources(path, reader)
+    try:
+        yield path, con, candidate, reader, sources
+    finally:
+        con.close()
+
+
+def test_fill_fence_blocks_slice_source_open_on_same_identity(archive, tmp_path):
+    path, con, candidate, reader, sources = archive
+    before = tuple(con.iterdump())
+    services = production_services(con, catalog_path=path, state_dir=tmp_path / "fill-state")
+    with services.drive_fences.hold_all_sorted([candidate.drive.drive_label]):
+        with pytest.raises(TransferRefusal) as error:
+            with sources.open(candidate):
+                pytest.fail("Slice must not open a source under Fill's drive fence")
+        assert error.value.code == "SOURCE_BUSY"
+        assert reader.opens == 0
+    with sources.open(candidate) as (_, stream):
+        assert stream.read() == b"source bytes"
+    assert tuple(con.iterdump()) == before
+
+
+def test_open_slice_reader_blocks_fill_on_same_fingerprint_epoch(archive, tmp_path, monkeypatch):
+    path, con, candidate, reader, sources = archive
+    expected_path = drive_fence.drive_lock_path(candidate.drive.identity_fingerprint,
+                                               candidate.drive.identity_epoch)
+    original_acquire = drive_fence._acquire
+    main_thread = threading.get_ident()
+    contention_proved = threading.Event()
+    acquired = threading.Event()
+
+    def observe_acquire(lock_path, blocking):
+        if threading.get_ident() != main_thread:
+            assert lock_path == expected_path and blocking is True
+            # Prove real kernel contention before the production blocking acquisition.
+            # The main thread will release the open reader after this event; no sleeps
+            # or scheduling-based assumption that an unstarted worker is blocked.
+            with lock_path.open("a") as probe:
+                with pytest.raises(BlockingIOError):
+                    fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            contention_proved.set()
+        return original_acquire(lock_path, blocking)
+
+    monkeypatch.setattr(drive_fence, "_acquire", observe_acquire)
+
+    def fill_contender():
+        worker_con = sqlite3.connect(path, isolation_level=None)
+        try:
+            services = production_services(worker_con, catalog_path=path,
+                                           state_dir=tmp_path / "another-fill-state")
+            with services.drive_fences.hold_all_sorted([candidate.drive.drive_label]):
+                acquired.set()
+        finally:
+            worker_con.close()
+
+    before = tuple(con.iterdump())
+    with ThreadPoolExecutor(max_workers=1) as workers:
+        with sources.open(candidate) as (_, stream):
+            assert reader.opened and stream.read(6) == b"source"
+            contender = workers.submit(fill_contender)
+            assert contention_proved.wait(5), "Fill did not reach its physical fence"
+            assert not acquired.is_set()
+        assert not reader.opened
+        contender.result(timeout=5)
+    assert acquired.is_set()
+    assert tuple(con.iterdump()) == before
+
+
+def test_lifecycle_revocation_waits_for_actual_slice_reader_close(archive):
+    path, con, candidate, reader, sources = archive
+    preview = drive_lifecycle.loss_preview(con, candidate.drive.drive_label)
+
+    def declare():
+        return drive_lifecycle.declare_lost(
+            con, candidate.drive.drive_label,
+            expected_revision=preview["planner_revision"],
+            expected_identity_epoch=preview["identity_epoch"],
+            expected_identity_fingerprint=preview["identity_fingerprint"],
+            confirmation=preview["confirmation"])
+
+    with sources.open(candidate) as (_, stream):
+        assert reader.opened
+        with pytest.raises(proposal.Refusal) as error:
+            declare()
+        assert error.value.code == "DRIVE_BUSY"
+        assert drive_lifecycle.loss_preview(con, candidate.drive.drive_label) == preview
+        assert stream.read() == b"source bytes"
+    assert not reader.opened
+    assert declare()["lifecycle"] == "lost"
+    refreshed = domain.preview(spec(domain), read_catalog(path, spec(domain)))
+    assert not refreshed.source_ready
+    assert any(gap.code == "SOURCE_INACTIVE" for gap in refreshed.gaps)

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -190,7 +190,7 @@ def test_private_v1_upgrade_preserves_transaction_authority(setup, api, missing_
     upgraded.activate(tx, plan.destination.device_id, serial)
     assert upgraded.stop_requested(tx)  # A newer stop still wins after migration.
     with upgraded._connection(write=False) as con:
-        assert con.execute("PRAGMA user_version").fetchone()[0] == 3
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 4
     assert api[1].Store().events(tx) == before  # Reopening is idempotent.
     assert not list(dest.root.iterdir())
 
@@ -537,6 +537,36 @@ def test_surviving_child_prevents_resume_after_parent_closes_session(setup):
     assert process.exitcode == 0
     with t.start(store, tx, dest, sources) as session:
         assert session.run().state == "complete"
+
+
+def test_completed_owners_child_is_not_a_new_transactions_writer(setup):
+    t, store, plan, tx, dest, sources = setup
+    second = store.create(plan, d.approve(plan.proposal, expected_seal=plan.proposal.seal,
+                                         current_snapshot=sources.snapshot))
+    store.approve(second, expected_seal=plan.seal)
+    with start(setup) as session:
+        parent, child = multiprocessing.Pipe()
+        process = multiprocessing.get_context("fork").Process(target=_retain_inherited_fence, args=(child,))
+        process.start()
+        child.close()
+        assert parent.recv() == "held"
+        try:
+            assert session.run().state == "complete"
+            assert store.owner(plan.destination.device_id) is None
+            for _ in range(2):
+                with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+                    t.start(store, second, dest, sources)
+            assert store.process_owner(plan.destination.device_id) is None
+            assert store.receipt(second) is None
+            assert store.status(tx).state == "complete"
+        finally:
+            parent.send("exit")
+            process.join()
+            parent.close()
+        assert process.exitcode == 0
+    # Exclusion is now available, but existing output is not adopted by the new transaction.
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION|CONTROL_CORRUPT"):
+        t.start(store, second, dest, sources)
 
 
 def test_unprepared_matching_temporary_requires_fresh_source(setup):
@@ -1072,11 +1102,33 @@ def test_new_reservation_cannot_observe_an_unrelated_process_as_its_writer(setup
     store.approve(tx, expected_seal=plan.seal)
     lease = t._Lease(plan.destination.device_id)
     try:
-        with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
-            t.start(store, tx, dest, sources)
+        for _ in range(2):
+            with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+                t.start(store, tx, dest, sources)
     finally:
         lease.close()
     with t.start(store, tx, dest, sources) as resumed:
+        assert resumed.run().state == "complete"
+
+
+def test_v3_migration_does_not_invent_process_ownership(setup, api):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    store.reserve(tx, plan.destination.device_id)
+    with store._connection() as con:
+        con.execute("ALTER TABLE owners DROP COLUMN process_seen")
+        con.execute("PRAGMA user_version=3")
+    upgraded = api[1].Store()
+    assert upgraded.owner(plan.destination.device_id) == tx
+    assert upgraded.process_owner(plan.destination.device_id) is None
+    lease = t._Lease(plan.destination.device_id)
+    try:
+        for _ in range(2):
+            with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+                t.start(upgraded, tx, dest, sources)
+    finally:
+        lease.close()
+    with t.start(upgraded, tx, dest, sources) as resumed:
         assert resumed.run().state == "complete"
 
 

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -1,0 +1,308 @@
+"""Expected-red Slice 2 contracts. Only disposable destinations and synthetic sources."""
+from contextlib import contextmanager
+from dataclasses import replace
+import hashlib
+import importlib
+import io
+import multiprocessing
+import os
+
+import pytest
+
+from modelark.slice import domain as d
+from test_slice_domain import facts, spec
+
+
+DATA = b"slice bytes!"
+
+
+@pytest.fixture
+def api(tmp_path, monkeypatch):
+    try:
+        t = importlib.import_module("modelark.slice.transaction")
+        s = importlib.import_module("modelark.slice.state")
+    except ModuleNotFoundError as exc:
+        if not exc.name.startswith("modelark.slice"):
+            raise
+        pytest.fail("Slice 2 transaction API is not implemented yet")
+    monkeypatch.setattr(s, "HOST_STATE_DIR", tmp_path / "host-state")
+    return t, s
+
+
+def proposal():
+    snapshot = facts(d)
+    sha = hashlib.sha256(DATA).hexdigest()
+    snapshot = replace(snapshot,
+                       files=(replace(snapshot.files[0], sha256=sha),),
+                       copies=(replace(snapshot.copies[0], orig_sha256=sha,
+                                       annex_key=f"SHA256E-s12--{sha}"),))
+    p = d.preview(spec(d), snapshot)
+    return p, d.approve(p, expected_seal=p.seal, current_snapshot=snapshot), snapshot
+
+
+class Destination:
+    """Test-only port: real files, simulated device identity and owned-object certificates.
+
+    Production discovery, descriptor confinement and certificates are Slice 3's adapter work.
+    This port never opens any path outside its pytest directory.
+    """
+    def __init__(self, root, t):
+        self.root = root
+        root.mkdir()
+        self.t = t
+        self.binding = t.DestinationBinding("test-device", "test-filesystem", "test-mount", 10000)
+        self.owned = {}
+        self.trace = []
+        self.available = True
+        self.changed = False
+
+    def check(self, binding, allocated):
+        if not self.available:
+            raise self.t.TransferRefusal("WAITING_DESTINATION")
+        if self.changed or self.binding != binding:
+            raise self.t.TransferRefusal("DESTINATION_CHANGED")
+        self.trace.append(("check", allocated))
+
+    def inspect(self, path):
+        p = self.root / path
+        if not p.exists():
+            return None
+        if p.is_symlink():
+            raise self.t.TransferRefusal("OUTPUT_COLLISION")
+        return self.t.ObjectInfo("directory" if p.is_dir() else "file", self.owned.get(path),
+                                 0 if p.is_dir() else p.stat().st_size)
+
+    def create_directory(self, path, token):
+        (self.root / path).mkdir()
+        self.owned[path] = token
+        self.trace.append(("mkdir", path))
+
+    def create_file(self, path, token):
+        with (self.root / path).open("xb"):
+            pass
+        self.owned[path] = token
+
+    def append(self, path, token, data):
+        assert self.owned[path] == token
+        with (self.root / path).open("ab") as out:
+            out.write(data)
+
+    def discard_temporary(self, path, token):
+        assert self.owned[path] == token
+        (self.root / path).unlink()
+        del self.owned[path]
+
+    def read(self, path):
+        return (self.root / path).open("rb")
+
+    def flush(self, path):
+        self.trace.append(("flush", path))
+        fd = os.open(self.root / path, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    def publish(self, temporary, path, token):
+        assert self.owned[temporary] == token
+        os.link(self.root / temporary, self.root / path)  # Atomic no-replace.
+        self.owned[path] = token
+        self.trace.append(("publish", path))
+
+    def list_paths(self, root):
+        p = self.root / root
+        return tuple(str(v.relative_to(self.root)) for v in p.rglob("*")) if p.exists() else ()
+
+
+class Sources:
+    def __init__(self, snapshot, t):
+        self.snapshot, self.t = snapshot, t
+        self.status = {}
+        self.data = DATA
+        self.reads = []
+        self.fenced = False
+
+    @contextmanager
+    def open(self, source):
+        label = source.drive.drive_label
+        if label in self.status:
+            raise self.t.TransferRefusal(self.status[label], label)
+        self.fenced = True
+        self.reads.append(label)
+        try:
+            yield self.snapshot, io.BytesIO(self.data)
+        finally:
+            self.fenced = False
+
+
+@pytest.fixture
+def setup(api, tmp_path):
+    t, s = api
+    p, approval, snapshot = proposal()
+    dest = Destination(tmp_path / "destination", t)
+    sources = Sources(snapshot, t)
+    store = s.Store()
+    plan = t.TransferPlan(p, dest.binding)
+    tx = store.create(plan, approval)
+    return t, store, plan, tx, dest, sources
+
+
+def start(setup, fault=None):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    return t.start(store, tx, dest, sources, fault=fault)
+
+
+def test_approval_is_durable_and_does_not_start_or_touch_destination(setup, api):
+    t, store, plan, tx, dest, sources = setup
+    with pytest.raises(t.TransferRefusal, match="APPROVAL_MISSING"):
+        t.start(store, tx, dest, sources)
+    with pytest.raises(t.TransferRefusal, match="PREVIEW_STALE"):
+        store.approve(tx, expected_seal="wrong")
+    store.approve(tx, expected_seal=plan.seal)
+    assert api[1].Store().status(tx).state == "approved"
+    assert not list(dest.root.iterdir()) and not sources.reads
+
+
+def test_run_records_actual_source_and_verified_receipt_without_catalog_mutation(setup):
+    t, store, plan, tx, dest, sources = setup
+    original = sources.snapshot
+    with start(setup) as session:
+        assert session.run().state == "complete"
+    assert (dest.root / "models/org/model/model.safetensors").read_bytes() == DATA
+    receipt = store.receipt(tx)
+    assert receipt["seal"] == plan.seal
+    assert receipt["files"][0]["source"]["drive"]["drive_label"] == "drive-a"
+    assert sources.snapshot == original
+    assert store.status(tx).state == "complete"
+
+
+def test_duplicate_start_is_observation_not_second_writer_and_stop_reserves_device(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        duplicate = t.start(store, tx, dest, sources)
+        assert not duplicate.can_write and duplicate.transaction_id == tx
+        store.request_stop(tx)
+        assert session.run().state == "stopped"
+    _, approval, _ = proposal()
+    another = store.create(plan, approval)
+    store.approve(another, expected_seal=plan.seal)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+        t.start(store, another, dest, sources)
+
+
+@pytest.mark.parametrize("code,state", [("WAITING_SOURCE", "waiting_source"),
+                                       ("SOURCE_BUSY", "blocked_source"),
+                                       ("SOURCE_MISSING", "blocked_source")])
+def test_source_waits_preserve_approval_and_can_resume(setup, code, state):
+    t, store, plan, tx, dest, sources = setup
+    sources.status["drive-a"] = code
+    with start(setup) as session:
+        assert session.run().state == state
+    sources.status.clear()
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+    assert store.receipt(tx)["seal"] == plan.seal
+
+
+@pytest.mark.parametrize("change", ["lifecycle", "generation", "copy", "digest"])
+def test_source_evidence_is_rechecked_under_read_fence(setup, change):
+    t, store, plan, tx, dest, sources = setup
+    snapshot = sources.snapshot
+    if change == "lifecycle":
+        snapshot = replace(snapshot, drives=(replace(snapshot.drives[0], lifecycle="lost"),))
+    elif change == "generation":
+        snapshot = replace(snapshot, drives=(replace(snapshot.drives[0], write_generation=3),))
+    elif change == "copy":
+        snapshot = replace(snapshot, copies=())
+    else:
+        sources.data = b"wrong bytes!"
+    sources.snapshot = snapshot
+    with start(setup) as session:
+        result = session.run()
+    assert result.state == "blocked_source"
+    assert store.receipt(tx) is None
+    assert not (dest.root / "models/org/model/model.safetensors").exists()
+
+
+@pytest.mark.parametrize("boundary", [
+    "reserved", "control_intent", "control_created", "control_flushed", "control_complete",
+    "directory_intent", "directory_created", "directory_flushed", "directory_parent_flushed",
+    "directory_complete", "file_intent", "temporary_created", "chunk_written", "file_flushed",
+    "file_prepared", "file_published", "file_parent_flushed", "file_complete",
+    "receipt_intent", "receipt_created", "receipt_flushed", "receipt_prepared",
+    "receipt_published", "receipt_parent_flushed", "receipt_complete",
+])
+def test_crash_boundaries_resume_without_unverified_receipts(setup, boundary):
+    t, store, plan, tx, dest, sources = setup
+    class Crash(BaseException):
+        pass
+    fired = False
+    def fault(point):
+        nonlocal fired
+        if point == boundary and not fired:
+            fired = True
+            raise Crash(point)
+    with pytest.raises(Crash):
+        with start(setup, fault) as session:
+            session.run()
+    assert fired
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+    assert (dest.root / "models/org/model/model.safetensors").read_bytes() == DATA
+    assert store.receipt(tx)["seal"] == plan.seal
+
+
+def test_unknown_content_is_not_adopted_even_with_matching_hash(setup):
+    t, store, plan, tx, dest, sources = setup
+    (dest.root / "models").mkdir()
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+        with start(setup) as session:
+            session.run()
+    assert not sources.reads
+
+
+def test_destination_change_blocks_before_any_bytes(setup):
+    t, store, plan, tx, dest, sources = setup
+    dest.changed = True
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CHANGED"):
+        start(setup)
+    assert not list(dest.root.iterdir())
+
+
+def test_missing_completed_file_is_restored_but_not_from_unavailable_source(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        assert session.step().state == "transferring"
+    (dest.root / "models/org/model/model.safetensors").unlink()
+    sources.status["drive-a"] = "WAITING_SOURCE"
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "waiting_source"
+    sources.status.clear()
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+
+
+def _contend(store, tx, dest, sources, conn):
+    t = importlib.import_module("modelark.slice.transaction")
+    try:
+        result = t.start(store, tx, dest, sources)
+        conn.send((result.can_write, result.transaction_id))
+        if result.can_write:
+            result.close()
+    finally:
+        conn.close()
+
+
+def test_second_process_observes_same_active_execution(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup):
+        parent, child = multiprocessing.Pipe()
+        process = multiprocessing.get_context("fork").Process(target=_contend,
+                                                               args=(store, tx, dest, sources, child))
+        process.start()
+        child.close()
+        assert parent.recv() == (False, tx)
+        process.join()
+        assert process.exitcode == 0
+        parent.close()

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -189,7 +189,7 @@ def test_private_v1_upgrade_preserves_transaction_authority(setup, api, missing_
     upgraded.activate(tx, plan.destination.device_id, serial)
     assert upgraded.stop_requested(tx)  # A newer stop still wins after migration.
     with upgraded._connection(write=False) as con:
-        assert con.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 3
     assert api[1].Store().events(tx) == before  # Reopening is idempotent.
     assert not list(dest.root.iterdir())
 
@@ -1023,6 +1023,60 @@ def test_stop_requested_during_startup_is_not_lost(setup):
         start(setup)
     assert not list(dest.root.iterdir())
     assert store.status(tx).state == "stopped"
+
+
+def test_overlapping_starter_preserves_stop_after_reservation(setup):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    def fault(point):
+        if point == "reservation_committed":
+            store.request_stop(tx)
+            with pytest.raises(t.TransferRefusal, match="STOPPED"):
+                t.start(store, tx, dest, sources)
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        t.start(store, tx, dest, sources, fault=fault)
+    assert store.stop_requested(tx)
+    assert not list(dest.root.iterdir())
+    with t.start(store, tx, dest, sources) as resumed:
+        assert resumed.run().state == "complete"
+
+
+def test_completed_retained_session_releases_process_lease(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        assert session.run().state == "complete"
+        assert not session.can_write
+        with t._Lease(plan.destination.device_id).socket:
+            pass
+
+
+def test_v2_initializing_reservation_migration_preserves_pending_stop(setup, api):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    store.reserve(tx, plan.destination.device_id)
+    store.request_stop(tx)
+    with store._connection() as con:
+        con.execute("ALTER TABLE owners DROP COLUMN activation_serial")
+        con.execute("PRAGMA user_version=2")
+    upgraded = api[1].Store()
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        t.start(upgraded, tx, dest, sources)
+    assert not list(dest.root.iterdir())
+    with t.start(upgraded, tx, dest, sources) as resumed:
+        assert resumed.run().state == "complete"
+
+
+def test_new_reservation_cannot_observe_an_unrelated_process_as_its_writer(setup):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    lease = t._Lease(plan.destination.device_id)
+    try:
+        with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+            t.start(store, tx, dest, sources)
+    finally:
+        lease.close()
+    with t.start(store, tx, dest, sources) as resumed:
+        assert resumed.run().state == "complete"
 
 
 def test_verification_checks_stop_between_read_chunks(setup):

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -5,6 +5,7 @@ import hashlib
 import importlib
 import io
 import multiprocessing
+import threading
 import os
 from pathlib import PurePosixPath
 
@@ -1324,6 +1325,43 @@ def test_delayed_first_starter_cannot_downgrade_a_completed_winner(setup):
     result = t.start(store, tx, dest, sources, fault=fault)
     assert finished and not result.can_write and result.state == "complete"
     assert store.status(tx).state == "complete"
+
+
+@pytest.mark.parametrize("adapter_refuses", [False, True])
+def test_starter_in_completion_commit_window_cannot_downgrade_completion(setup, adapter_refuses):
+    t, store, _, tx, dest, sources = setup
+    checked, committed = threading.Event(), threading.Event()
+    outcomes = []
+    def contender():
+        try:
+            outcomes.append(t.start(store, tx, dest, sources))
+        except BaseException as exc:
+            outcomes.append(exc)
+    process = threading.Thread(target=contender)
+    with start(setup) as winner:
+        original_check, original_close = dest.check, winner.lease.close
+        def check(*args):
+            if threading.current_thread() is process:
+                checked.set()
+                assert committed.wait(10)
+                if adapter_refuses:
+                    raise t.TransferRefusal("DESTINATION_CHANGED")
+            return original_check(*args)
+        def release():
+            original_close()
+            process.start()
+            assert checked.wait(10)
+        dest.check, winner.lease.close = check, release
+        try:
+            assert winner.run().state == "complete"
+        finally:
+            winner.lease.close = original_close
+            committed.set()
+            process.join()
+    assert store.status(tx).state == "complete"
+    assert len(outcomes) == 1 and isinstance(outcomes[0], t.Status)
+    assert outcomes[0].state == "complete" and not outcomes[0].can_write
+    assert store.owner(dest.binding.device_id) is None
 
 
 def test_crash_between_reservation_and_process_bind_is_resumable(setup):

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -166,6 +166,33 @@ def test_approval_is_durable_and_does_not_start_or_touch_destination(setup, api)
     assert not list(dest.root.iterdir()) and not sources.reads
 
 
+@pytest.mark.parametrize("missing_serial", [True, False])
+def test_private_v1_upgrade_preserves_transaction_authority(setup, api, missing_serial):
+    _, store, plan, tx, dest, _ = setup
+    store.approve(tx, expected_seal=plan.seal)
+    store.reserve(tx, plan.destination.device_id)
+    store.request_stop(tx)
+    store.append(tx, "test-marker", {"preserved": True})
+    before = store.events(tx)
+    with store._connection() as con:
+        if missing_serial:
+            con.execute("ALTER TABLE transactions DROP COLUMN stop_serial")
+        con.execute("PRAGMA user_version=1")
+    upgraded = api[1].Store()
+    assert upgraded.load(tx) == plan
+    assert upgraded.events(tx) == before
+    assert upgraded.owner(plan.destination.device_id) == tx
+    assert upgraded.stop_requested(tx)
+    serial = upgraded.reserve(tx, plan.destination.device_id)
+    upgraded.request_stop(tx)
+    upgraded.activate(tx, plan.destination.device_id, serial)
+    assert upgraded.stop_requested(tx)  # A newer stop still wins after migration.
+    with upgraded._connection(write=False) as con:
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert api[1].Store().events(tx) == before  # Reopening is idempotent.
+    assert not list(dest.root.iterdir())
+
+
 def test_run_records_actual_source_and_verified_receipt_without_catalog_mutation(setup):
     t, store, plan, tx, dest, sources = setup
     original = sources.snapshot

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -844,6 +844,100 @@ def test_streaming_does_not_replay_plan_and_journal_per_chunk(setup, monkeypatch
     assert counts["load"] == 0 and counts["events"] <= 2
 
 
+@pytest.mark.parametrize("recovered", [False, True])
+def test_completed_artifact_hashing_is_linear_per_session(api, tmp_path, recovered):
+    t, s = api
+    _, _, snapshot = proposal()
+    snapshot = replace(snapshot,
+                       files=tuple(replace(snapshot.files[0], rfilename=f"shard-{i}.safetensors") for i in range(5)),
+                       copies=tuple(replace(snapshot.copies[0], rfilename=f"shard-{i}.safetensors") for i in range(5)))
+    p = d.preview(replace(spec(d), destination_id="test-device"), snapshot)
+    approval = d.approve(p, expected_seal=p.seal, current_snapshot=snapshot)
+    dest, store = Destination(tmp_path / "destination", t), s.Store()
+    plan = t.TransferPlan(p, dest.binding)
+    tx = store.create(plan, approval)
+    store.approve(tx, expected_seal=plan.seal)
+    reads = []
+    reading = dest.read
+    def counted(path):
+        if path.endswith(".safetensors"):
+            reads.append(path)
+        return reading(path)
+    dest.read = counted
+    if recovered:
+        with t.start(store, tx, dest, Sources(snapshot, t)) as session:
+            session.step()
+            session.step()
+        reads.clear()
+    with t.start(store, tx, dest, Sources(snapshot, t)) as session:
+        assert session.run().state == "complete"
+    # New content is hashed during publication; each final file needs only its final pass.
+    assert len(reads) == len(p.closure) + (2 if recovered else 0)
+    directories = [payload for event, payload in store.events(tx)
+                   if event == "operation" and payload["kind"] == "directory" and payload["state"] == "complete"]
+    assert len(directories) == 3
+
+
+def test_session_verification_cache_does_not_skip_final_digest_pass(setup):
+    t, store, _, tx, dest, _ = setup
+    with start(setup) as session:
+        session.step()
+        (dest.root / "models/org/model/model.safetensors").write_bytes(b"wrong bytes!")
+        with pytest.raises(t.TransferRefusal, match="VERIFICATION_FAILED"):
+            session.run()
+    assert store.receipt(tx) is None
+
+
+def test_terminal_session_cannot_resume_after_adapter_condition_is_restored(setup):
+    t, store, _, tx, dest, _ = setup
+    with start(setup) as session:
+        dest.changed = True
+        with pytest.raises(t.TransferRefusal, match="DESTINATION_CHANGED"):
+            session.step()
+        assert store.status(tx).state == "invalidated"
+        dest.changed = False
+        before = tuple(dest.root.rglob("*"))
+        with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+            session.step()
+        assert not session.can_write
+        assert tuple(dest.root.rglob("*")) == before
+    assert store.receipt(tx) is None
+
+
+@pytest.mark.parametrize("kind", ["directory", "file", "receipt"])
+def test_parent_certificate_loss_is_refused_before_child_creation(setup, kind):
+    t, _, _, _, dest, _ = setup
+    with start(setup) as session:
+        if kind == "receipt":
+            session.step()
+            parent = "models"
+        else:
+            session._directory("models")
+            parent = "models"
+        os.removexattr(dest.root / parent, "user.slice-test-owner")
+        before = set(dest.root.rglob("*"))
+        with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+            if kind == "directory":
+                session._directory("models/org")
+            elif kind == "file":
+                op = session._op("models/test", "receipt", size=len(DATA), sha=hashlib.sha256(DATA).hexdigest())
+                session._write(op, io.BytesIO(DATA))
+            else:
+                session.step()
+        assert set(dest.root.rglob("*")) == before
+
+
+def test_completed_directory_has_no_redundant_durable_checkpoint(setup):
+    _, store, _, tx, dest, _ = setup
+    with start(setup) as session:
+        session._directory("models")
+        head = store.head(tx)
+        dest.trace.clear()
+        session._directory("models")
+        assert store.head(tx) == head
+        assert not [item for item in dest.trace if item[0] in {"mkdir", "flush"}]
+
+
 def test_cached_journal_requires_unchanged_durable_head(setup):
     t, store, plan, tx, dest, sources = setup
     with start(setup) as session:

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -904,6 +904,31 @@ def test_terminal_session_cannot_resume_after_adapter_condition_is_restored(setu
     assert store.receipt(tx) is None
 
 
+@pytest.mark.parametrize("failure", ["typed", "file_exists"])
+def test_terminal_revocation_survives_state_persistence_failure(setup, failure):
+    t, store, plan, tx, dest, _ = setup
+    with start(setup) as session:
+        setting = store.set_state
+        def busy(*args, **kwargs):
+            raise t.TransferRefusal("STATE_BUSY")
+        store.set_state = busy
+        if failure == "typed":
+            dest.changed = True
+        else:
+            def collision(*args):
+                raise FileExistsError("racing directory")
+            dest.create_directory = collision
+        with pytest.raises(t.TransferRefusal, match="STATE_BUSY"):
+            session.step()
+        store.set_state = setting
+        dest.changed = False
+        assert not session.can_write
+        assert store.owner(plan.destination.device_id) == tx
+        assert store.status(tx).state == "transferring"  # Persistence really did fail.
+        with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+            session.step()
+
+
 @pytest.mark.parametrize("kind", ["directory", "file", "receipt"])
 def test_parent_certificate_loss_is_refused_before_child_creation(setup, kind):
     t, _, _, _, dest, _ = setup

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -715,6 +715,82 @@ def test_fenced_sources_use_real_archive_fence_and_read_only_snapshot(api, tmp_p
     con.close()
 
 
+@pytest.mark.parametrize("fallback", [False, True])
+@pytest.mark.parametrize("error,code", [(FileNotFoundError, "SOURCE_MISSING"), (OSError, "SOURCE_READ_FAILED")])
+def test_lazy_source_read_failure_blocks_or_uses_sealed_fallback(setup, tmp_path, monkeypatch, fallback, error, code):
+    from modelark import drive_fence
+    from modelark.slice import sources as gate
+    t, store, original, _, dest, synthetic = setup
+    snapshot = synthetic.snapshot
+    if fallback:
+        snapshot = replace(snapshot, drives=(*snapshot.drives, replace(snapshot.drives[0], drive_label="drive-b")),
+                           copies=(*snapshot.copies, replace(snapshot.copies[0], drive_label="drive-b")),
+                           anchors=(*snapshot.anchors, replace(snapshot.anchors[0], drive_label="drive-b")))
+    p = d.preview(original.proposal.spec, snapshot)
+    plan = t.TransferPlan(p, dest.binding, metadata_reserve_bytes=65536)
+    tx = store.create(plan, d.approve(p, expected_seal=p.seal, current_snapshot=snapshot))
+    store.approve(tx, expected_seal=plan.seal)
+    monkeypatch.setattr(drive_fence, "_LOCK_DIR", tmp_path / "locks")
+    monkeypatch.setattr(gate, "read_catalog", lambda *args: snapshot)
+    closed = []
+    class Failing(io.BytesIO):
+        def read(self, size=-1):
+            if self.tell():
+                raise error("source disappeared mid-read")
+            return super().read(2)
+    class Reader:
+        @contextmanager
+        def open(self, candidate):
+            stream = Failing(DATA) if candidate.drive.drive_label == "drive-a" else io.BytesIO(DATA)
+            try:
+                yield stream
+            finally:
+                stream.close()
+                closed.append(candidate.drive.drive_label)
+    source = gate.FencedSources(tmp_path / "unused-catalog", Reader())
+    with t.start(store, tx, dest, source) as session:
+        result = session.run()
+    if fallback:
+        assert result.state == "complete"
+        assert store.receipt(tx)["files"][0]["source"]["drive"]["drive_label"] == "drive-b"
+        assert closed == ["drive-a", "drive-b"]
+    else:
+        assert result.state == "blocked_source" and code in result.reason
+        assert store.receipt(tx) is None and closed == ["drive-a"]
+
+
+@pytest.mark.parametrize("kind", ["control", "file", "receipt"])
+def test_stop_at_verification_eof_prevents_publication(setup, kind):
+    t, store, _, tx, dest, _ = setup
+    targets = []
+    class StopAtEOF(io.BytesIO):
+        def read(self, size=-1):
+            data = super().read(size)
+            if not data:
+                store.request_stop(tx)
+            return data
+    def fault(point):
+        if point == kind + "_prepared":
+            op = next(payload for event, payload in reversed(store.events(tx))
+                      if event == "operation" and payload["kind"] == kind)
+            targets.append(op["path"])
+            read = dest.read
+            def stopping_read(path):
+                if path == op["temporary"]:
+                    return StopAtEOF((dest.root / path).read_bytes())
+                return read(path)
+            dest.read = stopping_read
+    if kind == "control":
+        with pytest.raises(t.TransferRefusal, match="STOPPED"):
+            with start(setup, fault):
+                pass
+    else:
+        with start(setup, fault) as session:
+            assert session.run().state == "stopped"
+    assert targets and not (dest.root / targets[0]).exists()
+    assert store.receipt(tx) is None
+
+
 def test_capacity_drift_is_not_hidden_by_own_partial_allocation(setup):
     t, store, plan, tx, dest, sources = setup
     original_check = dest.check

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -888,6 +888,48 @@ def test_session_verification_cache_does_not_skip_final_digest_pass(setup):
     assert store.receipt(tx) is None
 
 
+@pytest.mark.parametrize("resume", [False, True])
+def test_foreign_descendant_blocks_next_artifact_before_any_mutation(api, tmp_path, resume):
+    t, s = api
+    _, _, snapshot = proposal()
+    snapshot = replace(snapshot,
+                       files=tuple(replace(snapshot.files[0], rfilename=f"part-{i}.safetensors") for i in range(2)),
+                       copies=tuple(replace(snapshot.copies[0], rfilename=f"part-{i}.safetensors") for i in range(2)))
+    p = d.preview(replace(spec(d), destination_id="test-device"), snapshot)
+    approval = d.approve(p, expected_seal=p.seal, current_snapshot=snapshot)
+    dest, store = Destination(tmp_path / "destination", t), s.Store()
+    sources = Sources(snapshot, t)
+    plan = t.TransferPlan(p, dest.binding)
+    tx = store.create(plan, approval)
+    store.approve(tx, expected_seal=plan.seal)
+    with t.start(store, tx, dest, sources) as session:
+        session.step()
+        if resume:
+            session.close()
+        (dest.root / "models/org/model/foreign").touch()  # No capacity signal.
+        before = set(dest.root.rglob("*"))
+        dest.trace.clear()
+        with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+            if resume:
+                with t.start(store, tx, dest, sources) as restarted:
+                    restarted.step()
+            else:
+                session.step()
+        assert set(dest.root.rglob("*")) == before
+        assert not [item for item in dest.trace if item[0] in {"mkdir", "flush", "publish"}]
+        assert len(sources.reads) == 1
+    assert store.receipt(tx) is None
+
+
+def test_unknown_consumer_root_blocks_initial_control_creation(setup):
+    t, _, _, _, dest, _ = setup
+    (dest.root / "models").mkdir()
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+        with start(setup) as session:
+            session.step()
+    assert set(path.name for path in dest.root.iterdir()) == {"models"}
+
+
 def test_terminal_session_cannot_resume_after_adapter_condition_is_restored(setup):
     t, store, _, tx, dest, _ = setup
     with start(setup) as session:

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -18,6 +18,17 @@ from test_slice_domain import facts, spec
 DATA = b"slice bytes!"
 
 
+def tamper_append(store, tx, event, payload):
+    """Explicit hostile private-state edit for journal-validation tests, not a writer API."""
+    encoded = d._json(payload).decode()
+    with store._connection() as con:
+        seq, previous = con.execute("SELECT journal_seq,journal_digest FROM transactions WHERE id=?", (tx,)).fetchone()
+        seq += 1
+        digest = hashlib.sha256(d._json([tx, seq, previous, event, encoded])).hexdigest()
+        con.execute("INSERT INTO journal VALUES(?,?,?,?,?)", (tx, seq, event, encoded, digest))
+        con.execute("UPDATE transactions SET journal_seq=?,journal_digest=? WHERE id=?", (seq, digest, tx))
+
+
 @pytest.fixture
 def api(tmp_path, monkeypatch):
     try:
@@ -170,11 +181,11 @@ def test_approval_is_durable_and_does_not_start_or_touch_destination(setup, api)
 
 @pytest.mark.parametrize("missing_serial", [True, False])
 def test_private_v1_upgrade_preserves_transaction_authority(setup, api, missing_serial):
-    _, store, plan, tx, dest, _ = setup
+    t, store, plan, tx, dest, _ = setup
     store.approve(tx, expected_seal=plan.seal)
     store.reserve(tx, plan.destination.device_id)
     store.request_stop(tx)
-    store.append(tx, "test-marker", {"preserved": True})
+    tamper_append(store, tx, "test-marker", {"preserved": True})
     before = store.events(tx)
     with store._connection() as con:
         if missing_serial:
@@ -187,10 +198,14 @@ def test_private_v1_upgrade_preserves_transaction_authority(setup, api, missing_
     assert upgraded.stop_requested(tx)
     serial = upgraded.reserve(tx, plan.destination.device_id)
     upgraded.request_stop(tx)
-    upgraded.activate(tx, plan.destination.device_id, serial)
+    lease = t._Lease(plan.destination.device_id, tx)
+    try:
+        assert upgraded.claim(tx, plan.destination.device_id, lease.attempt, serial).state == "stopped"
+    finally:
+        lease.close()
     assert upgraded.stop_requested(tx)  # A newer stop still wins after migration.
     with upgraded._connection(write=False) as con:
-        assert con.execute("PRAGMA user_version").fetchone()[0] == 4
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 5
     assert api[1].Store().events(tx) == before  # Reopening is idempotent.
     assert not list(dest.root.iterdir())
 
@@ -305,9 +320,15 @@ def test_activation_itself_checks_terminal_state(setup):
     t, store, plan, tx, _, _ = setup
     store.approve(tx, expected_seal=plan.seal)
     serial = store.reserve(tx, plan.destination.device_id)
-    store.set_state(tx, "invalidated")
-    with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
-        store.activate(tx, plan.destination.device_id, serial)
+    lease = t._Lease(plan.destination.device_id, tx)
+    try:
+        store.claim(tx, plan.destination.device_id, lease.attempt, serial)
+        with store._connection() as con:
+            con.execute("UPDATE transactions SET state='invalidated' WHERE id=?", (tx,))
+        with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+            store.transition(lease.attempt, plan.destination.device_id, "transferring")
+    finally:
+        lease.close()
     assert store.status(tx).state == "invalidated"
 
 
@@ -556,7 +577,7 @@ def test_completed_owners_child_is_not_a_new_transactions_writer(setup):
             for _ in range(2):
                 with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
                     t.start(store, second, dest, sources)
-            assert store.process_owner(plan.destination.device_id) is None
+            assert store.current_attempt(plan.destination.device_id) is None
             assert store.receipt(second) is None
             assert store.status(tx).state == "complete"
         finally:
@@ -859,7 +880,7 @@ def test_contradictory_journal_binding_is_rejected(setup):
     with start(setup):
         pass
     op = next(payload for event, payload in store.events(tx) if event == "operation")
-    store.append(tx, "operation", dict(op, seal="other-seal"))
+    tamper_append(store, tx, "operation", dict(op, seal="other-seal"))
     with pytest.raises(t.TransferRefusal, match="JOURNAL_CORRUPT"):
         t.start(store, tx, dest, sources)
 
@@ -1022,7 +1043,7 @@ def test_journal_rejects_nonhex_creation_tokens(setup):
     with store._connection() as con:
         con.execute("DELETE FROM journal WHERE tx=?", (tx,))
         con.execute("UPDATE transactions SET journal_seq=0,journal_digest='' WHERE id=?", (tx,))
-    store.append(tx, "operation", dict(op, token="x" * 32))
+    tamper_append(store, tx, "operation", dict(op, token="x" * 32))
     with pytest.raises(t.TransferRefusal, match="JOURNAL_CORRUPT"):
         t.start(store, tx, dest, sources)
 
@@ -1120,7 +1141,7 @@ def test_v3_migration_does_not_invent_process_ownership(setup, api):
         con.execute("PRAGMA user_version=3")
     upgraded = api[1].Store()
     assert upgraded.owner(plan.destination.device_id) == tx
-    assert upgraded.process_owner(plan.destination.device_id) is None
+    assert upgraded.current_attempt(plan.destination.device_id) is None
     lease = t._Lease(plan.destination.device_id)
     try:
         for _ in range(2):
@@ -1282,10 +1303,10 @@ def test_terminal_session_cannot_resume_after_adapter_condition_is_restored(setu
 def test_terminal_revocation_survives_state_persistence_failure(setup, failure):
     t, store, plan, tx, dest, _ = setup
     with start(setup) as session:
-        setting = store.set_state
+        setting = store.transition
         def busy(*args, **kwargs):
             raise t.TransferRefusal("STATE_BUSY")
-        store.set_state = busy
+        store.transition = busy
         if failure == "typed":
             dest.changed = True
         else:
@@ -1294,7 +1315,7 @@ def test_terminal_revocation_survives_state_persistence_failure(setup, failure):
             dest.create_directory = collision
         with pytest.raises(t.TransferRefusal, match="STATE_BUSY"):
             session.step()
-        store.set_state = setting
+        store.transition = setting
         dest.changed = False
         assert not session.can_write
         assert store.owner(plan.destination.device_id) == tx
@@ -1341,7 +1362,7 @@ def test_cached_journal_requires_unchanged_durable_head(setup):
     t, store, plan, tx, dest, sources = setup
     with start(setup) as session:
         op = next(payload for event, payload in store.events(tx) if event == "operation")
-        store.append(tx, "operation", op)
+        tamper_append(store, tx, "operation", op)
         with pytest.raises(t.TransferRefusal, match="JOURNAL_CORRUPT"):
             session.run()
 
@@ -1379,8 +1400,8 @@ def test_delayed_first_starter_cannot_downgrade_a_completed_winner(setup):
     assert store.status(tx).state == "complete"
 
 
-@pytest.mark.parametrize("adapter_refuses", [False, True])
-def test_starter_in_completion_commit_window_cannot_downgrade_completion(setup, adapter_refuses):
+@pytest.mark.parametrize("pause_at", ["snapshot", "claim"])
+def test_starter_in_completion_commit_window_cannot_downgrade_completion(setup, monkeypatch, pause_at):
     t, store, _, tx, dest, sources = setup
     checked, committed = threading.Event(), threading.Event()
     outcomes = []
@@ -1392,18 +1413,34 @@ def test_starter_in_completion_commit_window_cannot_downgrade_completion(setup, 
     process = threading.Thread(target=contender)
     with start(setup) as winner:
         original_check, original_close = dest.check, winner.lease.close
+        original_status, original_claim = store.status, store.claim
+        snapshots = 0
+        def pause():
+            checked.set()
+            assert committed.wait(10)
+        def status(*args):
+            nonlocal snapshots
+            result = original_status(*args)
+            if threading.current_thread() is process:
+                snapshots += 1
+                if pause_at == "snapshot" and snapshots == 2:
+                    pause()
+            return result
+        def claim(*args):
+            if threading.current_thread() is process and pause_at == "claim":
+                pause()
+            return original_claim(*args)
         def check(*args):
             if threading.current_thread() is process:
-                checked.set()
-                assert committed.wait(10)
-                if adapter_refuses:
-                    raise t.TransferRefusal("DESTINATION_CHANGED")
+                pytest.fail("a completed contender must not reach destination checking")
             return original_check(*args)
         def release():
             original_close()
             process.start()
             assert checked.wait(10)
         dest.check, winner.lease.close = check, release
+        monkeypatch.setattr(store, "status", status)
+        monkeypatch.setattr(store, "claim", claim)
         try:
             assert winner.run().state == "complete"
         finally:

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -206,6 +206,107 @@ def test_run_records_actual_source_and_verified_receipt_without_catalog_mutation
     assert store.status(tx).state == "complete"
 
 
+def test_destination_receipt_is_self_contained_without_private_state(setup):
+    import json
+    t, _, plan, _, dest, _ = setup
+    with start(setup) as session:
+        assert session.run().state == "complete"
+    receipt = json.loads((dest.root / "models/.modelark-slice-receipt.json").read_text())
+    reconstructed = t.TransferPlan.from_json(json.dumps(receipt["plan"]))
+    assert reconstructed == plan and reconstructed.seal == receipt["seal"]
+    assert receipt["plan"]["proposal"]["snapshot_id"] == plan.proposal.snapshot_id
+    assert receipt["plan"]["proposal"]["spec"]["consumer_profile"] == plan.proposal.spec.consumer_profile
+    assert receipt["topology"] == "direct"
+    assert receipt["status"] == "complete"
+    assert receipt["verification"] == {"content": "sha256-original-bytes", "layout": "authenticated",
+                                       "result": "verified", "file_count": len(plan.proposal.closure)}
+
+
+@pytest.mark.parametrize("version", ["modelark.slice.transaction.v1", "modelark.slice.transaction.v2"])
+def test_receipt_recovery_preserves_its_approved_protocol_version(setup, version):
+    t, store, original, tx, dest, sources = setup
+    plan = replace(original, version=version)
+    # Simulate an already-persisted plan from its original protocol implementation.
+    with store._connection() as con:
+        con.execute("UPDATE transactions SET plan=?,seal=?,state='approved' WHERE id=?",
+                    (plan.to_json(), plan.seal, tx))
+    def crash(point):
+        if point == "receipt_prepared":
+            raise RuntimeError("simulated receipt interruption")
+    with pytest.raises(RuntimeError, match="simulated receipt interruption"):
+        with t.start(store, tx, dest, sources, fault=crash) as session:
+            session.run()
+    assert store.load(tx).seal == plan.seal
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+    receipt = store.receipt(tx)
+    assert receipt["version"] == version
+    if version.endswith("v1"):
+        assert set(receipt) == {"version", "transaction", "seal", "destination", "files"}
+    else:
+        assert receipt["plan"]["version"] == version
+        assert receipt["status"] == "complete"
+
+
+def test_new_transactions_cannot_request_legacy_receipts(setup):
+    t, store, plan, _, _, _ = setup
+    _, approval, _ = proposal()
+    with pytest.raises(t.TransferRefusal, match="LEGACY_PLAN"):
+        store.create(replace(plan, version="modelark.slice.transaction.v1"), approval)
+
+
+@pytest.mark.parametrize("phase", ["start", "step", "status"])
+def test_state_contention_preserves_resumable_authority(setup, phase):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    def busy(*args, **kwargs):
+        raise t.TransferRefusal("STATE_BUSY")
+    if phase == "start":
+        original = store.events
+        store.events = busy
+        with pytest.raises(t.TransferRefusal, match="STATE_BUSY"):
+            t.start(store, tx, dest, sources)
+        store.events = original
+    else:
+        with t.start(store, tx, dest, sources) as session:
+            name = "guard" if phase == "step" else "status"
+            original = getattr(store, name)
+            setattr(store, name, busy)
+            with pytest.raises(t.TransferRefusal, match="STATE_BUSY"):
+                session.step()
+            setattr(store, name, original)
+            assert not session.can_write
+    assert store.status(tx).state in {"starting", "transferring", "stopped"}
+    assert store.owner(plan.destination.device_id) == tx
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+
+
+def test_delayed_starter_cannot_reactivate_a_terminal_winner(setup):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    def fault(point):
+        if point == "reservation_committed":
+            dest.changed = True
+            with pytest.raises(t.TransferRefusal, match="DESTINATION_CHANGED"):
+                t.start(store, tx, dest, sources)
+            dest.changed = False
+    with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+        t.start(store, tx, dest, sources, fault=fault)
+    assert store.status(tx).state == "invalidated"
+    assert not list(dest.root.iterdir())
+
+
+def test_activation_itself_checks_terminal_state(setup):
+    t, store, plan, tx, _, _ = setup
+    store.approve(tx, expected_seal=plan.seal)
+    serial = store.reserve(tx, plan.destination.device_id)
+    store.set_state(tx, "invalidated")
+    with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+        store.activate(tx, plan.destination.device_id, serial)
+    assert store.status(tx).state == "invalidated"
+
+
 def test_duplicate_start_is_observation_not_second_writer_and_stop_reserves_device(setup):
     t, store, plan, tx, dest, sources = setup
     with start(setup) as session:

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -6,6 +6,7 @@ import importlib
 import io
 import multiprocessing
 import os
+from pathlib import PurePosixPath
 
 import pytest
 
@@ -36,7 +37,7 @@ def proposal():
                        files=(replace(snapshot.files[0], sha256=sha),),
                        copies=(replace(snapshot.copies[0], orig_sha256=sha,
                                        annex_key=f"SHA256E-s12--{sha}"),))
-    p = d.preview(spec(d), snapshot)
+    p = d.preview(replace(spec(d), destination_id="test-device"), snapshot)
     return p, d.approve(p, expected_seal=p.seal, current_snapshot=snapshot), snapshot
 
 
@@ -51,7 +52,6 @@ class Destination:
         root.mkdir()
         self.t = t
         self.binding = t.DestinationBinding("test-device", "test-filesystem", "test-mount", 10000)
-        self.owned = {}
         self.trace = []
         self.available = True
         self.changed = False
@@ -69,28 +69,31 @@ class Destination:
             return None
         if p.is_symlink():
             raise self.t.TransferRefusal("OUTPUT_COLLISION")
-        return self.t.ObjectInfo("directory" if p.is_dir() else "file", self.owned.get(path),
+        try:
+            token = os.getxattr(p, "user.slice-test-owner").decode()
+        except OSError:
+            token = None
+        return self.t.ObjectInfo("directory" if p.is_dir() else "file", token,
                                  0 if p.is_dir() else p.stat().st_size)
 
     def create_directory(self, path, token):
         (self.root / path).mkdir()
-        self.owned[path] = token
+        os.setxattr(self.root / path, "user.slice-test-owner", token.encode())
         self.trace.append(("mkdir", path))
 
     def create_file(self, path, token):
         with (self.root / path).open("xb"):
             pass
-        self.owned[path] = token
+        os.setxattr(self.root / path, "user.slice-test-owner", token.encode())
 
     def append(self, path, token, data):
-        assert self.owned[path] == token
+        assert self.inspect(path).token == token
         with (self.root / path).open("ab") as out:
             out.write(data)
 
     def discard_temporary(self, path, token):
-        assert self.owned[path] == token
+        assert self.inspect(path).token == token
         (self.root / path).unlink()
-        del self.owned[path]
 
     def read(self, path):
         return (self.root / path).open("rb")
@@ -104,9 +107,8 @@ class Destination:
             os.close(fd)
 
     def publish(self, temporary, path, token):
-        assert self.owned[temporary] == token
+        assert self.inspect(temporary).token == token
         os.link(self.root / temporary, self.root / path)  # Atomic no-replace.
-        self.owned[path] = token
         self.trace.append(("publish", path))
 
     def list_paths(self, root):
@@ -203,6 +205,7 @@ def test_source_waits_preserve_approval_and_can_resume(setup, code, state):
     with t.start(store, tx, dest, sources) as session:
         assert session.run().state == "complete"
     assert store.receipt(tx)["seal"] == plan.seal
+    assert not list(dest.root.rglob(".slice-*"))
 
 
 @pytest.mark.parametrize("change", ["lifecycle", "generation", "copy", "digest"])
@@ -251,6 +254,7 @@ def test_crash_boundaries_resume_without_unverified_receipts(setup, boundary):
         assert session.run().state == "complete"
     assert (dest.root / "models/org/model/model.safetensors").read_bytes() == DATA
     assert store.receipt(tx)["seal"] == plan.seal
+    assert not list(dest.root.rglob(".slice-*"))
 
 
 def test_unknown_content_is_not_adopted_even_with_matching_hash(setup):
@@ -306,3 +310,349 @@ def test_second_process_observes_same_active_execution(setup):
         process.join()
         assert process.exitcode == 0
         parent.close()
+
+
+def _die_at_boundary(store, tx, dest, sources, boundary):
+    t = importlib.import_module("modelark.slice.transaction")
+    def fault(point):
+        if point == boundary:
+            os._exit(73)
+    with t.start(store, tx, dest, sources, fault=fault) as session:
+        session.run()
+
+
+@pytest.mark.parametrize("boundary", ["reserved", "directory_created", "chunk_written",
+                                      "file_prepared", "file_published", "receipt_published"])
+def test_process_death_releases_only_process_fence_and_recovers_owned_bytes(setup, boundary):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    process = multiprocessing.get_context("fork").Process(target=_die_at_boundary,
+                                                         args=(store, tx, dest, sources, boundary))
+    process.start()
+    process.join()
+    assert process.exitcode == 73
+    assert store.owner(plan.destination.device_id) == tx
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+
+
+def _retain_inherited_fence(conn):
+    conn.send("held")
+    conn.recv()
+    conn.close()
+
+
+def test_surviving_child_prevents_resume_after_parent_closes_session(setup):
+    t, store, plan, tx, dest, sources = setup
+    session = start(setup)
+    parent, child = multiprocessing.Pipe()
+    process = multiprocessing.get_context("fork").Process(target=_retain_inherited_fence, args=(child,))
+    process.start()
+    child.close()
+    assert parent.recv() == "held"
+    session.close()
+    try:
+        assert not t.start(store, tx, dest, sources).can_write
+    finally:
+        parent.send("exit")
+        process.join()
+        parent.close()
+    assert process.exitcode == 0
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+
+
+def test_unprepared_matching_temporary_requires_fresh_source(setup):
+    t, store, plan, tx, dest, sources = setup
+    class Crash(BaseException):
+        pass
+    def fault(point):
+        if point == "file_flushed":
+            raise Crash()
+    with pytest.raises(Crash):
+        with start(setup, fault) as session:
+            session.run()
+    sources.status["drive-a"] = "WAITING_SOURCE"
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "waiting_source"
+    assert not (dest.root / "models/org/model/model.safetensors").exists()
+
+
+def test_prepared_source_history_survives_later_source_lifecycle_change(setup):
+    t, store, plan, tx, dest, sources = setup
+    class Crash(BaseException):
+        pass
+    def fault(point):
+        if point == "file_prepared":
+            raise Crash()
+    with pytest.raises(Crash):
+        with start(setup, fault) as session:
+            session.run()
+    sources.snapshot = replace(sources.snapshot, drives=(replace(sources.snapshot.drives[0], lifecycle="lost"),))
+    sources.status["drive-a"] = "SOURCE_CHANGED"
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+    assert store.receipt(tx)["files"][0]["source"]["drive"]["lifecycle"] == "active"
+
+
+def test_destination_is_rechecked_before_publication(setup):
+    t, store, plan, tx, dest, sources = setup
+    def fault(point):
+        if point == "file_prepared":
+            dest.changed = True
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CHANGED"):
+        with start(setup, fault) as session:
+            session.run()
+    assert not (dest.root / "models/org/model/model.safetensors").exists()
+    assert store.receipt(tx) is None
+
+
+def test_directory_parent_flush_precedes_child_creation(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        session.run()
+    for path in ["models", "models/org", "models/org/model"]:
+        idx = dest.trace.index(("mkdir", path))
+        flush = dest.trace.index(("flush", str(PurePosixPath(path).parent)), idx)
+        child = next((i for i, (kind, p) in enumerate(dest.trace) if kind == "mkdir" and p.startswith(path + "/")), None)
+        assert flush > idx and (child is None or child > flush)
+
+
+def test_journal_corruption_fails_closed(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup):
+        pass
+    with store._connection() as con:
+        con.execute("UPDATE journal SET digest='broken' WHERE tx=?", (tx,))
+    with pytest.raises(t.TransferRefusal, match="JOURNAL_CORRUPT"):
+        t.start(store, tx, dest, sources)
+
+
+def test_resume_rejects_a_replaced_owned_object_even_if_its_bytes_match(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        session.step()
+    path = dest.root / "models/org/model/model.safetensors"
+    path.unlink()
+    path.write_bytes(DATA)
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+        t.start(store, tx, dest, sources)
+
+
+def test_restarted_file_cannot_reuse_old_prepared_source_proof(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        session.step()
+    (dest.root / "models/org/model/model.safetensors").unlink()
+    class Crash(BaseException):
+        pass
+    def fault(point):
+        if point == "file_flushed":
+            raise Crash()
+    with pytest.raises(Crash):
+        with t.start(store, tx, dest, sources, fault=fault) as session:
+            session.run()
+    sources.status["drive-a"] = "WAITING_SOURCE"
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "waiting_source"
+    assert store.receipt(tx) is None
+
+
+def test_only_sealed_alternatives_may_be_used_and_actual_choice_is_retained(setup):
+    t, store, plan, tx, dest, sources = setup
+    snapshot = sources.snapshot
+    drive = replace(snapshot.drives[0], drive_label="drive-b", fs_uuid="fs-b", annex_uuid="annex-b")
+    fp = d.identity_fingerprint_v1(fs_uuid=drive.fs_uuid, annex_uuid=drive.annex_uuid,
+                                   serial=drive.serial, filesystem_capacity_bytes=drive.filesystem_capacity_bytes)
+    drive = replace(drive, identity_fingerprint=fp)
+    snapshot = replace(snapshot, drives=(*snapshot.drives, drive),
+                       copies=(*snapshot.copies, replace(snapshot.copies[0], drive_label="drive-b")),
+                       anchors=(*snapshot.anchors, replace(snapshot.anchors[0], drive_label="drive-b",
+                                                            identity_fingerprint=fp)))
+    p = d.preview(plan.proposal.spec, snapshot)
+    plan2 = t.TransferPlan(p, dest.binding)
+    tx2 = store.create(plan2, d.approve(p, expected_seal=p.seal, current_snapshot=snapshot))
+    sources.snapshot = snapshot
+    sources.status["drive-a"] = "WAITING_SOURCE"
+    # A newly discovered copy is not a substitute for the sealed candidate set.
+    with start(setup) as session:
+        assert session.run().state == "waiting_source"
+    assert sources.reads == []
+    # Use a separate fixture destination/host namespace for the separately approved alternative
+    # plan: unfinished ownership of the first transaction must never be adopted.
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+        store.approve(tx2, expected_seal=plan2.seal)
+        t.start(store, tx2, dest, sources)
+
+
+def test_sealed_fallback_records_the_source_actually_read(setup):
+    t, store, plan, tx, dest, sources = setup
+    snapshot = sources.snapshot
+    b = replace(snapshot.drives[0], drive_label="drive-b")
+    snapshot = replace(snapshot, drives=(*snapshot.drives, b),
+                       copies=(*snapshot.copies, replace(snapshot.copies[0], drive_label="drive-b")),
+                       anchors=(*snapshot.anchors, replace(snapshot.anchors[0], drive_label="drive-b")))
+    p = d.preview(plan.proposal.spec, snapshot)
+    plan = t.TransferPlan(p, dest.binding)
+    tx = store.create(plan, d.approve(p, expected_seal=p.seal, current_snapshot=snapshot))
+    sources.snapshot = snapshot
+    sources.status["drive-a"] = "SOURCE_BUSY"
+    store.approve(tx, expected_seal=plan.seal)
+    with t.start(store, tx, dest, sources) as session:
+        session.run()
+    assert store.receipt(tx)["files"][0]["source"]["drive"]["drive_label"] == "drive-b"
+
+
+def test_fenced_sources_use_real_archive_fence_and_read_only_snapshot(api, tmp_path, monkeypatch):
+    from modelark import drive_fence
+    from modelark.slice.sources import FencedSources
+    from test_slice_catalog import seed
+    t, _ = api
+    monkeypatch.setattr(drive_fence, "_LOCK_DIR", tmp_path / "locks")
+    path = tmp_path / "catalog.sqlite"
+    con = seed(path, d)
+    before = tuple(con.iterdump())
+    from modelark.slice.catalog import read_catalog
+    snapshot = read_catalog(path, spec(d))
+    candidate = d.preview(spec(d), snapshot).closure[0].sources[0]
+    key = (candidate.drive.identity_fingerprint, candidate.drive.identity_epoch)
+    class Reader:
+        @contextmanager
+        def open(self, source):
+            with pytest.raises(drive_fence.FenceUnavailable):
+                with drive_fence.hold_drives_sorted([key], blocking=False):
+                    pass
+            yield io.BytesIO(DATA)
+    sources = FencedSources(path, Reader())
+    with drive_fence.hold_drives_sorted([key], blocking=False):
+        with pytest.raises(t.TransferRefusal, match="SOURCE_BUSY"):
+            with sources.open(candidate):
+                pass
+    with sources.open(candidate) as (fresh, stream):
+        assert fresh == snapshot and stream.read() == DATA
+    with drive_fence.hold_drives_sorted([key], blocking=False):
+        pass
+    assert tuple(con.iterdump()) == before
+    con.close()
+
+
+def test_capacity_drift_is_not_hidden_by_own_partial_allocation(setup):
+    t, store, plan, tx, dest, sources = setup
+    original_check = dest.check
+    seen = []
+    def check(binding, allocated):
+        seen.append(allocated)
+        original_check(binding, allocated)
+        if (dest.root / "foreign").exists():
+            raise t.TransferRefusal("DESTINATION_CAPACITY_CHANGED")
+    dest.check = check
+    def fault(point):
+        if point == "file_prepared":
+            (dest.root / "foreign").write_bytes(b"external bytes")
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_CHANGED"):
+        with start(setup, fault) as session:
+            session.run()
+    assert max(seen) >= len(DATA)
+    assert store.receipt(tx) is None
+
+
+def test_stop_during_stream_preserves_owned_partial_and_can_resume(setup):
+    t, store, plan, tx, dest, sources = setup
+    def fault(point):
+        if point == "chunk_written":
+            store.request_stop(tx)
+    with start(setup, fault) as session:
+        assert session.run().state == "stopped"
+    assert not (dest.root / "models/org/model/model.safetensors").exists()
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+
+
+def test_contradictory_journal_binding_is_rejected(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup):
+        pass
+    op = next(payload for event, payload in store.events(tx) if event == "operation")
+    store.append(tx, "operation", dict(op, seal="other-seal"))
+    with pytest.raises(t.TransferRefusal, match="JOURNAL_CORRUPT"):
+        t.start(store, tx, dest, sources)
+
+
+def test_truncated_journal_is_not_a_new_transaction(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup):
+        pass
+    with store._connection() as con:
+        con.execute("DELETE FROM journal WHERE tx=?", (tx,))
+    with pytest.raises(t.TransferRefusal, match="JOURNAL_CORRUPT"):
+        t.start(store, tx, dest, sources)
+
+
+def test_private_state_rejects_symlink_before_creating_anything(api, tmp_path, monkeypatch):
+    _, s = api
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    link = tmp_path / "alias"
+    link.symlink_to(elsewhere, target_is_directory=True)
+    monkeypatch.setattr(s, "HOST_STATE_DIR", link / "state")
+    with pytest.raises(ValueError, match="symlink"):
+        s.Store()
+    assert not list(elsewhere.iterdir())
+
+
+def test_plan_rejects_destination_substitution_and_known_insufficient_space(setup):
+    t, store, plan, tx, dest, sources = setup
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CHANGED"):
+        t.TransferPlan(plan.proposal, replace(dest.binding, device_id="another-device"))
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_INSUFFICIENT"):
+        t.TransferPlan(plan.proposal, replace(dest.binding, available_bytes=1))
+
+
+@pytest.mark.parametrize("flush_number", range(1, 7))
+def test_private_store_bootstrap_flush_failures_are_recoverable(api, monkeypatch, flush_number):
+    _, s = api
+    original = os.fsync
+    count = 0
+    class Crash(BaseException):
+        pass
+    def flush(fd):
+        nonlocal count
+        count += 1
+        if count == flush_number:
+            raise Crash()
+        original(fd)
+    with monkeypatch.context() as patch:
+        patch.setattr(s.os, "fsync", flush)
+        with pytest.raises(Crash):
+            s.Store()
+    store = s.Store()
+    assert store.root.is_dir() and store.path.is_file()
+
+
+def test_atomic_publication_race_never_overwrites_unknown_bytes(setup):
+    t, store, plan, tx, dest, sources = setup
+    publish = dest.publish
+    def race(temp, path, token):
+        (dest.root / path).write_bytes(b"not ours")
+        publish(temp, path, token)
+    dest.publish = race
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+        with start(setup) as session:
+            session.run()
+    assert (dest.root / "models/org/model/model.safetensors").read_bytes() == b"not ours"
+    assert store.receipt(tx) is None
+
+
+def test_different_consumer_roots_share_device_exclusion_and_busy_preserves_approval(setup):
+    t, store, plan, tx, dest, sources = setup
+    p = d.preview(replace(plan.proposal.spec, destination_root="another-root"), sources.snapshot)
+    second_plan = t.TransferPlan(p, dest.binding)
+    second = store.create(second_plan, d.approve(p, expected_seal=p.seal, current_snapshot=sources.snapshot))
+    store.approve(second, expected_seal=second_plan.seal)
+    with start(setup):
+        with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+            t.start(store, second, dest, sources)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+        t.start(store, second, dest, sources)
+    assert store.status(second).state == "approved"
+    assert not (dest.root / "another-root").exists()

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -51,16 +51,17 @@ class Destination:
         self.root = root
         root.mkdir()
         self.t = t
-        self.binding = t.DestinationBinding("test-device", "test-filesystem", "test-mount", 10000)
+        self.binding = t.DestinationBinding("test-device", "test-filesystem", "test-mount", 1_000_000)
         self.trace = []
         self.available = True
         self.changed = False
 
-    def check(self, binding, allocated):
+    def check(self, binding, allocated, required_bytes):
         if not self.available:
             raise self.t.TransferRefusal("WAITING_DESTINATION")
         if self.changed or self.binding != binding:
             raise self.t.TransferRefusal("DESTINATION_CHANGED")
+        assert required_bytes <= binding.available_bytes
         self.trace.append(("check", allocated))
 
     def inspect(self, path):
@@ -144,7 +145,7 @@ def setup(api, tmp_path):
     dest = Destination(tmp_path / "destination", t)
     sources = Sources(snapshot, t)
     store = s.Store()
-    plan = t.TransferPlan(p, dest.binding)
+    plan = t.TransferPlan(p, dest.binding, metadata_reserve_bytes=65536)
     tx = store.create(plan, approval)
     return t, store, plan, tx, dest, sources
 
@@ -222,7 +223,8 @@ def test_destination_receipt_is_self_contained_without_private_state(setup):
                                        "result": "verified", "file_count": len(plan.proposal.closure)}
 
 
-@pytest.mark.parametrize("version", ["modelark.slice.transaction.v1", "modelark.slice.transaction.v2"])
+@pytest.mark.parametrize("version", ["modelark.slice.transaction.v1", "modelark.slice.transaction.v2",
+                                      "modelark.slice.transaction.v3"])
 def test_receipt_recovery_preserves_its_approved_protocol_version(setup, version):
     t, store, original, tx, dest, sources = setup
     plan = replace(original, version=version)
@@ -248,11 +250,12 @@ def test_receipt_recovery_preserves_its_approved_protocol_version(setup, version
         assert receipt["status"] == "complete"
 
 
-def test_new_transactions_cannot_request_legacy_receipts(setup):
+@pytest.mark.parametrize("version", ["modelark.slice.transaction.v1", "modelark.slice.transaction.v2"])
+def test_new_transactions_cannot_request_legacy_receipts(setup, version):
     t, store, plan, _, _, _ = setup
     _, approval, _ = proposal()
     with pytest.raises(t.TransferRefusal, match="LEGACY_PLAN"):
-        store.create(replace(plan, version="modelark.slice.transaction.v1"), approval)
+        store.create(replace(plan, version=version), approval)
 
 
 @pytest.mark.parametrize("phase", ["start", "step", "status"])
@@ -334,6 +337,51 @@ def test_source_waits_preserve_approval_and_can_resume(setup, code, state):
         assert session.run().state == "complete"
     assert store.receipt(tx)["seal"] == plan.seal
     assert not list(dest.root.rglob(".slice-*"))
+
+
+@pytest.mark.parametrize("condition", ["WAITING_SOURCE", "SOURCE_BUSY", "destination"])
+def test_retained_session_run_finishes_after_attended_wait(setup, condition):
+    _, store, _, tx, dest, sources = setup
+    with start(setup) as session:
+        if condition == "destination":
+            dest.available = False
+        else:
+            sources.status["drive-a"] = condition
+        assert session.run().state in {"waiting_source", "blocked_source", "waiting_destination"}
+        sources.status.clear()
+        dest.available = True
+        assert session.run().state == "complete"
+    assert store.receipt(tx) is not None
+
+
+def test_plan_reserves_metadata_in_addition_to_original_artifact_bytes(api, tmp_path):
+    t, _ = api
+    p, _, _ = proposal()
+    dest = Destination(tmp_path / "destination", t)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_INSUFFICIENT"):
+        t.TransferPlan(p, replace(dest.binding, available_bytes=p.total_bytes), metadata_reserve_bytes=8192)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_INSUFFICIENT"):
+        t.TransferPlan(p, dest.binding, metadata_reserve_bytes=1)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_UNPROVEN"):
+        t.TransferPlan(p, dest.binding)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_INSUFFICIENT"):
+        t.TransferPlan(p, replace(dest.binding, available_bytes=p.total_bytes + 8191), metadata_reserve_bytes=8192)
+    plan = t.TransferPlan(p, replace(dest.binding, available_bytes=p.total_bytes + 8192), metadata_reserve_bytes=8192)
+    assert plan.required_bytes(tmp_path) == p.total_bytes + 8192
+    assert replace(plan, metadata_reserve_bytes=8191).seal != plan.seal
+
+
+def test_destination_gate_receives_the_full_sealed_capacity_requirement(setup):
+    t, _, plan, _, dest, _ = setup
+    check = dest.check
+    required = []
+    def checking(binding, allocated, required_bytes):
+        required.append(required_bytes)
+        check(binding, allocated, required_bytes)
+    dest.check = checking
+    with start(setup) as session:
+        assert session.run().state == "complete"
+    assert required and all(value == plan.proposal.total_bytes + plan.metadata_reserve_bytes for value in required)
 
 
 @pytest.mark.parametrize("change", ["lifecycle", "generation", "copy", "digest"])
@@ -598,7 +646,7 @@ def test_only_sealed_alternatives_may_be_used_and_actual_choice_is_retained(setu
                        anchors=(*snapshot.anchors, replace(snapshot.anchors[0], drive_label="drive-b",
                                                             identity_fingerprint=fp)))
     p = d.preview(plan.proposal.spec, snapshot)
-    plan2 = t.TransferPlan(p, dest.binding)
+    plan2 = t.TransferPlan(p, dest.binding, metadata_reserve_bytes=65536)
     tx2 = store.create(plan2, d.approve(p, expected_seal=p.seal, current_snapshot=snapshot))
     sources.snapshot = snapshot
     sources.status["drive-a"] = "WAITING_SOURCE"
@@ -621,7 +669,7 @@ def test_sealed_fallback_records_the_source_actually_read(setup):
                        copies=(*snapshot.copies, replace(snapshot.copies[0], drive_label="drive-b")),
                        anchors=(*snapshot.anchors, replace(snapshot.anchors[0], drive_label="drive-b")))
     p = d.preview(plan.proposal.spec, snapshot)
-    plan = t.TransferPlan(p, dest.binding)
+    plan = t.TransferPlan(p, dest.binding, metadata_reserve_bytes=65536)
     tx = store.create(plan, d.approve(p, expected_seal=p.seal, current_snapshot=snapshot))
     sources.snapshot = snapshot
     sources.status["drive-a"] = "SOURCE_BUSY"
@@ -671,9 +719,9 @@ def test_capacity_drift_is_not_hidden_by_own_partial_allocation(setup):
     t, store, plan, tx, dest, sources = setup
     original_check = dest.check
     seen = []
-    def check(binding, allocated):
+    def check(binding, allocated, required_bytes):
         seen.append(allocated)
-        original_check(binding, allocated)
+        original_check(binding, allocated, required_bytes)
         if (dest.root / "foreign").exists():
             raise t.TransferRefusal("DESTINATION_CAPACITY_CHANGED")
     dest.check = check
@@ -781,7 +829,7 @@ def test_atomic_publication_race_never_overwrites_unknown_bytes(setup, target):
 def test_different_consumer_roots_share_device_exclusion_and_busy_preserves_approval(setup):
     t, store, plan, tx, dest, sources = setup
     p = d.preview(replace(plan.proposal.spec, destination_root="another-root"), sources.snapshot)
-    second_plan = t.TransferPlan(p, dest.binding)
+    second_plan = t.TransferPlan(p, dest.binding, metadata_reserve_bytes=65536)
     second = store.create(second_plan, d.approve(p, expected_seal=p.seal, current_snapshot=sources.snapshot))
     store.approve(second, expected_seal=second_plan.seal)
     with start(setup):
@@ -808,10 +856,10 @@ def test_overlapping_first_start_observes_initializing_owner(setup):
     t, store, plan, tx, dest, sources = setup
     check = dest.check
     observed = []
-    def overlap(binding, allocated):
+    def overlap(binding, allocated, required_bytes):
         if not observed:
             observed.append(t.start(store, tx, dest, sources))
-        check(binding, allocated)
+        check(binding, allocated, required_bytes)
     dest.check = overlap
     with start(setup):
         assert len(observed) == 1 and not observed[0].can_write
@@ -891,9 +939,9 @@ def test_control_publication_is_recoverable_at_each_new_boundary(setup, boundary
 def test_stop_requested_during_startup_is_not_lost(setup):
     t, store, plan, tx, dest, sources = setup
     check = dest.check
-    def stop_at_check(binding, allocated):
+    def stop_at_check(binding, allocated, required_bytes):
         store.request_stop(tx)
-        check(binding, allocated)
+        check(binding, allocated, required_bytes)
     dest.check = stop_at_check
     with pytest.raises(t.TransferRefusal, match="STOPPED"):
         start(setup)
@@ -955,7 +1003,7 @@ def test_completed_artifact_hashing_is_linear_per_session(api, tmp_path, recover
     p = d.preview(replace(spec(d), destination_id="test-device"), snapshot)
     approval = d.approve(p, expected_seal=p.seal, current_snapshot=snapshot)
     dest, store = Destination(tmp_path / "destination", t), s.Store()
-    plan = t.TransferPlan(p, dest.binding)
+    plan = t.TransferPlan(p, dest.binding, metadata_reserve_bytes=65536)
     tx = store.create(plan, approval)
     store.approve(tx, expected_seal=plan.seal)
     reads = []
@@ -1000,7 +1048,7 @@ def test_foreign_descendant_blocks_next_artifact_before_any_mutation(api, tmp_pa
     approval = d.approve(p, expected_seal=p.seal, current_snapshot=snapshot)
     dest, store = Destination(tmp_path / "destination", t), s.Store()
     sources = Sources(snapshot, t)
-    plan = t.TransferPlan(p, dest.binding)
+    plan = t.TransferPlan(p, dest.binding, metadata_reserve_bytes=65536)
     tx = store.create(plan, approval)
     store.approve(tx, expected_seal=plan.seal)
     with t.start(store, tx, dest, sources) as session:

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -530,6 +530,9 @@ def test_fenced_sources_use_real_archive_fence_and_read_only_snapshot(api, tmp_p
                 pass
     with sources.open(candidate) as (fresh, stream):
         assert fresh == snapshot and stream.read() == DATA
+    with pytest.raises(FileNotFoundError, match="destination disappeared"):
+        with sources.open(candidate):
+            raise FileNotFoundError("destination disappeared")
     with drive_fence.hold_drives_sorted([key], blocking=False):
         pass
     assert tuple(con.iterdump()) == before
@@ -629,17 +632,21 @@ def test_private_store_bootstrap_flush_failures_are_recoverable(api, monkeypatch
     assert store.root.is_dir() and store.path.is_file()
 
 
-def test_atomic_publication_race_never_overwrites_unknown_bytes(setup):
+@pytest.mark.parametrize("target", ["model.safetensors", ".modelark-slice-owner", ".modelark-slice-receipt.json"])
+def test_atomic_publication_race_never_overwrites_unknown_bytes(setup, target):
     t, store, plan, tx, dest, sources = setup
     publish = dest.publish
     def race(temp, path, token):
-        (dest.root / path).write_bytes(b"not ours")
+        if path.endswith(target):
+            (dest.root / path).write_bytes(b"not ours")
         publish(temp, path, token)
     dest.publish = race
     with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
         with start(setup) as session:
             session.run()
-    assert (dest.root / "models/org/model/model.safetensors").read_bytes() == b"not ours"
+    path = (target if target == ".modelark-slice-owner" else "models/" + target
+            if target == ".modelark-slice-receipt.json" else "models/org/model/" + target)
+    assert (dest.root / path).read_bytes() == b"not ours"
     assert store.receipt(tx) is None
 
 
@@ -656,3 +663,211 @@ def test_different_consumer_roots_share_device_exclusion_and_busy_preserves_appr
         t.start(store, second, dest, sources)
     assert store.status(second).state == "approved"
     assert not (dest.root / "another-root").exists()
+
+
+def test_status_reads_do_not_require_the_active_writers_sqlite_lock(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup):
+        with store._connection() as con:
+            con.execute("UPDATE transactions SET reason='pending' WHERE id=?", (tx,))
+            assert store.status(tx).state == "transferring"
+            assert store.owner(plan.destination.device_id) == tx
+            assert store.events(tx)
+            assert not t.start(store, tx, dest, sources).can_write
+
+
+def test_overlapping_first_start_observes_initializing_owner(setup):
+    t, store, plan, tx, dest, sources = setup
+    check = dest.check
+    observed = []
+    def overlap(binding, allocated):
+        if not observed:
+            observed.append(t.start(store, tx, dest, sources))
+        check(binding, allocated)
+    dest.check = overlap
+    with start(setup):
+        assert len(observed) == 1 and not observed[0].can_write
+        assert observed[0].transaction_id == tx
+
+
+@pytest.mark.parametrize("change", ["removed", "changed"])
+def test_final_verification_requires_the_owned_control_record(setup, change):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        session.step()
+        control = dest.root / ".modelark-slice-owner"
+        if change == "removed":
+            control.unlink()
+        else:
+            control.write_bytes(b"changed control record")
+        with pytest.raises(t.TransferRefusal, match="CONTROL_CORRUPT"):
+            session.run()
+    assert store.receipt(tx) is None
+
+
+def test_final_layout_authenticates_reappeared_historical_temporary(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        session.step()
+        temporary = next(payload["temporary"] for event, payload in store.events(tx)
+                         if event == "operation" and payload["kind"] == "file")
+        assert not (dest.root / temporary).exists()
+        list_paths = dest.list_paths
+        def changed_layout(root):
+            (dest.root / temporary).mkdir()
+            return list_paths(root)
+        dest.list_paths = changed_layout
+        with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+            session.run()
+    assert store.receipt(tx) is None
+
+
+def test_source_wait_identifies_exact_artifact_and_candidate(setup):
+    t, store, plan, tx, dest, sources = setup
+    sources.status["drive-a"] = "WAITING_SOURCE"
+    with start(setup) as session:
+        result = session.run()
+    assert all(value in result.reason for value in ("org/model", "model.safetensors", "drive-a"))
+
+
+def test_journal_rejects_nonhex_creation_tokens(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup):
+        pass
+    op = next(payload for event, payload in store.events(tx) if event == "operation")
+    # Rewrite both the test's journal rows/head to isolate structural validation from hash checking.
+    with store._connection() as con:
+        con.execute("DELETE FROM journal WHERE tx=?", (tx,))
+        con.execute("UPDATE transactions SET journal_seq=0,journal_digest='' WHERE id=?", (tx,))
+    store.append(tx, "operation", dict(op, token="x" * 32))
+    with pytest.raises(t.TransferRefusal, match="JOURNAL_CORRUPT"):
+        t.start(store, tx, dest, sources)
+
+
+@pytest.mark.parametrize("boundary", ["control_chunk_written", "control_prepared", "control_published",
+                                      "control_parent_flushed"])
+def test_control_publication_is_recoverable_at_each_new_boundary(setup, boundary):
+    t, store, plan, tx, dest, sources = setup
+    class Crash(BaseException):
+        pass
+    def fault(point):
+        if point == boundary:
+            raise Crash()
+    with pytest.raises(Crash):
+        with start(setup, fault) as session:
+            session.run()
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"
+
+
+def test_stop_requested_during_startup_is_not_lost(setup):
+    t, store, plan, tx, dest, sources = setup
+    check = dest.check
+    def stop_at_check(binding, allocated):
+        store.request_stop(tx)
+        check(binding, allocated)
+    dest.check = stop_at_check
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        start(setup)
+    assert not list(dest.root.iterdir())
+    assert store.status(tx).state == "stopped"
+
+
+def test_verification_checks_stop_between_read_chunks(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        session.step()
+        read = dest.read
+        class StopOnRead(io.BytesIO):
+            def read(self, size=-1):
+                data = super().read(min(size, 1))
+                if data:
+                    store.request_stop(tx)
+                return data
+        def stopping_read(path):
+            if path.endswith("model.safetensors"):
+                return StopOnRead(DATA)
+            return read(path)
+        dest.read = stopping_read
+        assert session.run().state == "stopped"
+    assert store.receipt(tx) is None
+
+
+def test_streaming_does_not_replay_plan_and_journal_per_chunk(setup, monkeypatch):
+    t, store, plan, tx, dest, sources = setup
+    opening = sources.open
+    class OneByte(io.BytesIO):
+        def read(self, size=-1):
+            return super().read(min(size, 1))
+    @contextmanager
+    def chunked(source):
+        with opening(source) as (snapshot, _):
+            yield snapshot, OneByte(DATA)
+    sources.open = chunked
+    counts = {"events": 0, "load": 0}
+    for name in counts:
+        method = getattr(store, name)
+        def counted(*args, name=name, method=method, **kwargs):
+            counts[name] += 1
+            return method(*args, **kwargs)
+        monkeypatch.setattr(store, name, counted)
+    with start(setup) as session:
+        counts.update(events=0, load=0)
+        assert session.run().state == "complete"
+    assert counts["load"] == 0 and counts["events"] <= 2
+
+
+def test_cached_journal_requires_unchanged_durable_head(setup):
+    t, store, plan, tx, dest, sources = setup
+    with start(setup) as session:
+        op = next(payload for event, payload in store.events(tx) if event == "operation")
+        store.append(tx, "operation", op)
+        with pytest.raises(t.TransferRefusal, match="JOURNAL_CORRUPT"):
+            session.run()
+
+
+def _die_during_sqlite_write(store, tx):
+    with store._connection() as con:
+        con.execute("PRAGMA cache_size=1")
+        con.execute("UPDATE transactions SET reason=? WHERE id=?", ("uncommitted" * 100000, tx))
+        os._exit(73)
+
+
+def test_readers_recover_a_dead_sqlite_writer_without_committing_its_changes(setup):
+    t, store, plan, tx, dest, sources = setup
+    process = multiprocessing.get_context("fork").Process(target=_die_during_sqlite_write, args=(store, tx))
+    process.start()
+    process.join()
+    assert process.exitcode == 73
+    assert store.status(tx).reason == ""
+    with start(setup) as session:
+        assert session.run().state == "complete"
+
+
+def test_delayed_first_starter_cannot_downgrade_a_completed_winner(setup):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    finished = False
+    def fault(point):
+        nonlocal finished
+        if point == "reservation_committed":
+            with t.start(store, tx, dest, sources) as winner:
+                assert winner.run().state == "complete"
+            finished = True
+    result = t.start(store, tx, dest, sources, fault=fault)
+    assert finished and not result.can_write and result.state == "complete"
+    assert store.status(tx).state == "complete"
+
+
+def test_crash_between_reservation_and_process_bind_is_resumable(setup):
+    t, store, plan, tx, dest, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    process = multiprocessing.get_context("fork").Process(target=_die_at_boundary,
+                                                         args=(store, tx, dest, sources, "reservation_committed"))
+    process.start()
+    process.join()
+    assert process.exitcode == 73
+    assert store.owner(plan.destination.device_id) == tx
+    assert not list(dest.root.iterdir())
+    with t.start(store, tx, dest, sources) as session:
+        assert session.run().state == "complete"


### PR DESCRIPTION
Implements Slice 2 of the merged Usable Slice charter, building on PR #68 (`8408abe`).

- Private durable SQLite plans, explicit approval, unfinished device reservations, requested/acknowledged stop serials and hash-chained journals, separate from the catalog. Private schema v5 upgrades development v1/v2/v3/v4 layouts conservatively without inventing live attempts or stop acknowledgments.
- Central delivery-attempt authority: device-keyed Linux abstract-socket exclusion paired with a unique kernel-held attempt marker, guarded state/journal mutations, nonwriting repeated Start and inherited-child exclusion. Historical process-acquisition flags are no longer authority.
- Recoverable owned control/artifact/receipt publication: durable intent, source-fenced preparation, atomic no-replace publication, parent flushes and crash recovery.
- Existing nonblocking archive drive fence, fresh explicit read-only catalog evidence, sealed source alternatives and a retrieval-disabled injected reader. Lifecycle loss participates in the same fence through graph commit.
- Pre-mutation parent/layout authentication, including zero-byte unknown objects; original-byte verification, precise source waits and internal delivery receipts.
- Cached journal/allocations, one recovered-file hash per session plus mandatory final verification, and no redundant completed-directory checkpoints.
- Terminal Session revocation even if status persistence fails; transient STATE_BUSY preserves retry authority; delayed starters cannot overwrite terminal outcomes.
- New protocol-v3 plans seal an explicit metadata reserve above original artifact bytes, checked against control/receipt payloads and passed as the full required capacity to every destination gate. Filesystem-specific charge proof remains an explicit trusted-adapter obligation.
- New receipts embed the full approved plan, snapshot ID, definition/profile, closure/source evidence, direct topology, verification result and delivery status. Existing v1/v2 plans retain seals and receipt bytes for recovery; creating new v1/v2 transactions is refused.
- Retained attended-wait sessions return to transferring when their gates pass, so run continues through receipt publication.
- Stop checks cover verification EOF and the final publication boundary; lazy source read failures are typed without misclassifying destination errors, allowing sealed fallback after partial reads.

This remains an internal API. No CLI/portal Start or real USB/archive adapter is shipped. Trusted ports have explicit obligations; tests use disposable files with simulated identity and ownership certificates. They prove orchestration across port boundaries, not hardware confinement, atomic certificates inside port calls or real-device durability. Those remain Slice 3 gates. No live Fill, real mounts/archive paths, acquisition, deployment or catalog-schema changes. Receipts are delivery history, never archive replica evidence.

## Requested Codex P2 correction (current)

The operator requested correction of Codex finding 3954091840 before performing the merge.
An acknowledged Stop now ends and releases the Session attempt without requiring caller close,
while retaining durable transaction ownership for a fresh Start. The old Session becomes
non-writable and cannot resume or affect its successor. The stopped result is captured before
release, so an immediate successor cannot replace it with its own state. Failed acknowledgment
persistence still revokes the local attempt without claiming durable success, and Stop winning
over an attended wait follows the same release rule. Ordinary attended waits are unchanged.
Six disposable regressions cover boundary/stream/prepared stops, immediate successor handoff,
failed acknowledgment persistence, and Stop overriding a source wait. DEC-122 records the scope.
At `bb0d289`, all 300 affected tests pass against source (130.34s) and the rebuilt installed wheel
(132.48s), including all six new regressions. Ruff and diff checks pass. The installed transaction
module matches the source hash. Fresh push-triggered CI/review checks are pending; the prior head's
green checks are not evidence for this commit. No merge or deployment.

## Operator-authorized architectural follow-up (c5ec843)

After stopping the three-round patch loop and reporting its residual findings, the operator approved centralization of **Slice delivery execution** and consistency with existing Fill authority. This is the separate agreed architectural change, not continuation of that patch loop.

- `DeliveryAuthority` owns claim, activation, execution boundaries, outcomes and release; exact attempt tokens and a legal transition table fence durable state/journal changes. Completion is recognized during reservation and claim, before destination access.
- Duplicate observation requires a live marker for the exact current durable attempt, with identity revalidation. Datagram probes connect only: no messages, listener or helper service. Marker closes before device exclusion. Retention means exclusion, not progress or responsiveness.
- Start snapshots requested AND acknowledged stop serials. Crash recovery acknowledges an unhandled stop without destination mutation; only a later explicit Start can resume it. Delayed callers cannot borrow later acknowledgments. Legacy pending stops migrate conservatively, including stopped rows.
- Fill's existing session-write and recovery paths use the same neutral attempt/state contract; existing Fill storage, expiry/CAS behavior and portal stop Event remain unchanged. Cross-workflow tests exercise actual Slice reader contexts against Fill and lifecycle revocation using the common archive fence.
- The three previously reported residual schedules are now in the regression suite, plus stale-attempt, marker, delayed acknowledgment, migration and shared-fence coverage. Full non-browser run: 1242 passed, one skipped (406.63s); this began before the final two stop-audit refinements. Fresh final-source affected suite: 294 passed (125.82s), including those refinements. The same 294 tests passed against the rebuilt installed wheel (125.88s); installed authority modules match source hashes. Ruff and diff checks pass. Browser acceptance passed on one unchanged-code retry after the previously observed graph-link count assertion; the initial failure is retained as a validation caveat. Fresh external CI/review pending.
- No merge, deployment, live Fill changes, catalog schema changes or Slice 3 hardware adapters.

## Prior three-round history (not current-head validation)

Round 3 (final correction/re-review round at `9fe43c4`):
- Local boundary review found that a second retry after a new reservation loses its bind could still return a false active-writer observation. The extended retry regression failed before correction.
- Failed-bind duplicate observation now requires that the same durable reservation recorded actual process acquisition while holding exclusion. Otherwise every retry reports busy, including while a completed previous owner's child retains its descriptor. Older private states migrate without inventing process-acquisition evidence.
- At `9fe43c4`, all 249 source Slice/lifecycle/mutation-policy tests pass (127.72s), and the same 249 pass against the rebuilt installed wheel (123.95s), including v3 migration, real inherited-child completion and the strengthened retry test. Ruff and diff checks pass. CI `34179566865` passed: Python 3.10/3.12 each 1220 passed, one skipped; E2E and installed-wheel smoke passed.
- **STOPPED after all three correction/re-review rounds; not ready to merge.** Final Greptile review is 4/5 with P1 3953777477 (stale acquisition evidence misidentifies an unrelated incumbent). Final Codex review completed with P1 3953814662 (post-activation crash recovery clears an unacknowledged stop) and P2 3953814659 (completion winning between status and reservation yields NOT_RESUMABLE instead of completed status).
- All three residual findings are independently reproduced against both source and installed wheel using disposable standalone diagnostics outside the reviewed checkout. Three expected failures in each diagnostic run; the stop reproduction uses actual writer-process death. These are additional tests, not part of the green 249-test suites above. All three review threads remain unresolved. No fourth correction batch and no merge.

Round 2 completed at `46744c1`:
- Both reviewers independently found the same completion handoff race on `d3ae8fe` (Greptile 3953694180; Codex 3953703340).
- Activation and startup-refusal publication now check committed terminal authority inside their write transactions. A late pre-activation adapter failure cannot downgrade a completed or otherwise terminal winner.
- At `46744c1`, two deterministic threaded tests reproduced downgrades to `failed` and `invalidated` before correction. All 247 source Slice/lifecycle/mutation-policy tests pass (113.70s), and the same 247 pass against the rebuilt installed wheel (122.54s), along with Ruff and diff checks. CI run `34178970397` passed: Python 3.10/3.12 each 1218 passed, one skipped; E2E and installed-wheel smoke passed. Greptile returned 5/5 with no new findings; Codex explicitly reported no major issues on this head (comment 5578057522).

Round 1 completed at `d3ae8fe`:
- Corrected the three Codex findings on `83005fc`: overlapping initialization must preserve pending stops; lifecycle loss must share the source fence; completion must release process exclusion before freeing durable ownership.
- Added five regressions, including conservative private-schema migration. The four initial behavior regressions failed before the fixes.
- At `d3ae8fe`, all 245 source Slice/lifecycle/mutation-policy tests pass (106.47s), and the same 245 tests pass against the rebuilt installed wheel (108.45s). Ruff and whitespace checks pass. CI run `34178371346` passed: Python 3.10/3.12 each 1216 passed, one skipped; browser E2E and installed-wheel smoke passed. Both reviews completed with the shared completion finding above (Greptile 4/5).

Earlier validation at `83005fc` (not evidence for this new head):
- Tests-first commit `5fd168a` recorded 39 expected missing-API failures.
- All 203 source Slice contracts passed (115.26s).
- All 203 Slice contracts pass against the rebuilt installed wheel (128 transaction + 75 Slice 1; 120.12s).
- Ruff across modelark/scripts/tests and git diff checks pass.
- Latest-head CI run `34174959490` is green: Python 3.10/3.12 each passed 1211 tests, one skipped; Browser E2E and installed-wheel smoke passed.
- Greptile was clear at 5/5; Codex returned the three findings addressed in round 1 above.
- All 23 prior review findings have been checked, corrected, regression-tested and resolved. The latest seven regressions cover stop requests at verification EOF and lazy source read failures with/without sealed fallback.
- One earlier portal E2E graph-count assertion needed a single unchanged-code retry; subsequent heads passed first attempt.

DEC-108 through DEC-122 and `docs/usable-slice-transaction.md` document the authority, recovery, compatibility and adapter boundaries. DEC-121 supersedes the historical acquisition-evidence assumption in DEC-120; DEC-122 closes the stopped-attempt lifetime gap. The operator performs merges. Real-device execution requires separate authorization.
