### PR TITLE
feat: attended direct USB Slice delivery and launch exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Approval and execution are separate. Approving an exact placement never starts F
 |---|---|
 | Install ModelArk on a new Linux host and create the first archive | [Fresh install and first archive](docs/getting-started.md) |
 | Operate plans, drives, Fill, verification, and restore | [Operating ModelArk](docs/operations.md) |
+| Preview and execute an attended direct-USB Slice | [Direct USB delivery and qualification limits](docs/usable-slice-direct.md) |
 | Upgrade a 0.2.0 or other pre-v7 catalog | [Upgrading ModelArk](docs/upgrading.md) |
 | Install or update the supervised user service | [Deploying ModelArk](docs/deployment.md) |
 | Perform the stopped side-by-side provenance migration | [Live cutover procedure](docs/provenance-live-cutover.md) |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Approval and execution are separate. Approving an exact placement never starts F
 | Install ModelArk on a new Linux host and create the first archive | [Fresh install and first archive](docs/getting-started.md) |
 | Operate plans, drives, Fill, verification, and restore | [Operating ModelArk](docs/operations.md) |
 | Preview and execute an attended direct-USB Slice | [Direct USB delivery and qualification limits](docs/usable-slice-direct.md) |
+| Project into a new ext4 or FAT32 folder (acceptance in progress) | [Folder workflow, safety limits and remaining gates](docs/usable-slice-folders.md) |
 | Upgrade a 0.2.0 or other pre-v7 catalog | [Upgrading ModelArk](docs/upgrading.md) |
 | Install or update the supervised user service | [Deploying ModelArk](docs/deployment.md) |
 | Perform the stopped side-by-side provenance migration | [Live cutover procedure](docs/provenance-live-cutover.md) |

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2817,3 +2817,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Small Slice path helper and existing consumers, with unplug/recovery, CLI encoding and operator roundtrip regressions. No protocol/schema change, weaker descriptor confinement, new global authority, automatic ACL changes, live deployment or physical trial. The three-round review loop remains stopped; this approved correction is not a fourth review round.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md
 - `related`: DEC-125, DEC-126, DEC-127
+
+### DEC-129: Classify adapter IO from preserved evidence and resolve host roles physically
+- `id`: DEC-129
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Operator approved the bounded Linux/filesystem adapter refactor after PR #70 findings 3963808512, 3963808518 and 3963808522 exposed repeated evidence/representation disagreement.
+- `decision`: Preserve original probe IO failures and their fallback meaning until a shared attachment-aware classifier can apply proven loss/replacement evidence. Keep semantic policy failures distinct. Share filesystem-safe procfs decoding/parsing across observation, confinement presence and capacity consumers. Resolve protected system directories and swap files to actual descriptor-backed filesystem identities, retaining no-symlink confinement for destination/archive attachments and refreshing changed protected-role observations.
+- `rationale`: A failed metadata/ACL/marker probe is not proof of a permanently invalid destination; a lexical path is not proof of the backing filesystem's role. Independent helper interpretations and tests mocking whole helpers allowed the same contract gaps to recur. Fault injection below helpers tests the resulting durable transaction states rather than isolated exception strings.
+- `impact`: Slice hardware/Linux/capacity/destination/operator/source adapter boundaries and regression tests only. No transaction authority, Fill, launch guard, schema/seal, codec or supported-filesystem redesign; no weaker admission, permission changes, deployment or physical trial. The prior bounded review loop stays stopped; merge remains a separate operator gate.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md
+- `related`: DEC-123, DEC-125, DEC-126, DEC-127, DEC-128

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2751,3 +2751,25 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Slice Session outcome handling and six disposable stop/restart regressions only; no Fill, schema, hardware-adapter, deployment or live-service change.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-transaction.md
 - `related`: DEC-113, DEC-121
+
+### DEC-123: Refuse ambiguous pre-certificate directory residue in direct delivery
+- `id`: DEC-123
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Slice 3 architecture consultation identified the mkdir-to-certificate crash interval; operator explicitly agreed to the proposed recovery exception.
+- `decision`: A directory left without a verifiable ownership certificate after a crash is never adopted or deleted automatically. Direct delivery stops for operator intervention in that case; certified objects retain automatic recovery. The initial adapter fails closed when device, confinement, filesystem or decoding guarantees cannot be established.
+- `rationale`: Directory creation and ownership certification are separate operations. An intended name or empty directory shape cannot prove that an existing object belongs to this transaction. The prior universal crash-inside-create guarantee must not override the unknown-content boundary.
+- `impact`: Narrows only the ambiguous directory-creation recovery case in the Slice 3 contract; no automatic cleanup, formatting, takeover, archive mutation or real-device trial is authorized.
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, docs/usable-slice-transaction.md
+- `related`: DEC-108, DEC-121, DEC-122
+
+### DEC-124: Admit only one ModelArk application instance at launch
+- `id`: DEC-124
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Operator corrected the proposed concurrency scope: Start means launching another ModelArk instance, not starting Fill or Slice; reject the second instance right up front.
+- `decision`: Acquire one application-wide, nonblocking kernel-held launch guard before CLI configuration/dispatch or direct portal startup, independent of catalog directory, port, destination and operation. A second launch exits clearly without startup work. Retain the existing device/attempt and archive fences as internal safeguards. The local operator account is trusted; defending against unrelated processes deliberately substituting namespace entries is not a new Slice 3 requirement.
+- `rationale`: Competing ModelArk application instances should not coexist. Operation-level exclusion alone does not implement the requested launch policy; adversarial same-account namespace isolation would add a materially different threat model.
+- `impact`: All ModelArk CLI invocations are application launches, so a separate query, status, or other CLI command also refuses while the portal or another command holds the guard. Existing in-process portal controls remain available. No service restart, deployment, legacy-process termination or real-device trial is authorized. Processes launched from older unguarded versions are not retroactively enrolled.
+- `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, docs/usable-slice-transaction.md, docs/deployment.md
+- `related`: DEC-121, DEC-123

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2828,3 +2828,25 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Slice hardware/Linux/capacity/destination/operator/source adapter boundaries and regression tests only. No transaction authority, Fill, launch guard, schema/seal, codec or supported-filesystem redesign; no weaker admission, permission changes, deployment or physical trial. The prior bounded review loop stays stopped; merge remains a separate operator gate.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md
 - `related`: DEC-123, DEC-125, DEC-126, DEC-127, DEC-128
+
+### DEC-130: Own a projection folder, with native resume and session-only FAT32 export
+- `id`: DEC-130
+- `date`: 2026-09-09
+- `status`: accepted
+- `triggered_by`: Operator clarified projection means a folder rather than drive ownership, requested a Grok CLI scope critique, then approved the narrowed native-ext4 plus FAT32 proposal including new-root restart after FAT32 interruption.
+- `decision`: New folder projections own one exclusively created child under an existing parent, with all destination control/staging inside it. Separate folder target identity, attachment evidence, profile and advisory capacity. Allow qualified ordinary system-backed ext4 user folders, tolerate unrelated filesystem writes, retain authenticated native resume, and qualify FAT32 as session-only: Stop/interruption leaves residue untouched and requires a new root. Keep protected system/private paths and registered archive backing devices excluded. Preserve existing sealed direct-USB transactions under their original policy; do not silently reinterpret them.
+- `rationale`: The direct adapter used exclusive filesystem identity/accounting as a proxy for output-tree ownership. Merely relaxing mount-root or ext4 admission would retain the wrong capacity and recovery assumptions. FAT32 qualification must not weaken native certificates, no-clobber publication, required flushes or truthful final hashes/layout/receipt evidence.
+- `impact`: Staged folder contract, native adapter and FAT32 profile gates in docs/plans/folder-projection-scope.md. No Fill/source authority redesign, acquisition, archive reconciliation, deployment, formatting, automatic residue cleanup or cross-host resume. XFS/exFAT and FAT32 resume are outside this first delivery. Physical trial still requires exact reviewed target/source evidence. Legacy direct-USB constraints remain valid for legacy plans.
+- `docs_updated`: docs/decision_log.md, docs/plans/folder-projection-scope.md, docs/usable-slice-folders.md, README.md
+- `related`: DEC-124, DEC-125, DEC-129
+
+### DEC-131: Dispatch native folder authority explicitly and fence older private-state readers
+- `id`: DEC-131
+- `date`: 2026-09-09
+- `status`: accepted
+- `triggered_by`: DEC-130's approved native execution gate; integration review of folder-versus-device claims and real-host ext4/LUKS/LVM observation.
+- `decision`: Store executable native plans under a closed native-transaction v1 envelope in private Slice schema 7, retaining legacy seals and explicit strict direct-USB dispatch. Compare durable canonical folder ancestry and legacy backing claims within the existing reservation transaction. Keep all native control data below the exclusively certified output child. Treat native destination capacity exhaustion as ending the attempt, recoverable only through a fresh authenticated Start. Resolve explicit kernel-name mapper aliases without discarding ancestry conflict checks; require current inode/mount evidence for protected-role classification and retain birth identity for owned-object certificates.
+- `rationale`: Reusing a device ID field without versioned dispatch would let old binaries misread folder authority. Shared capacity is not identity, and a partial space failure requires allocation reconstruction. Device-mapper PATH/PKNAME spelling and pseudo-filesystem birth-time support are representation/role distinctions, not evidence that an ordinary encrypted ext4 user folder is unsafe or that owned-object identity can be weakened.
+- `impact`: Native adapter, observer, plan/operator assembly, shared transaction/private-store dispatch and narrow Linux inventory/role helpers. Private schema upgrade only; no catalog migration, Fill/source fence changes, live deployment, USB writes or permission rewriting. FAT32 remains the separate pending session-only gate under DEC-130.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-folders.md, docs/usable-slice-direct.md, docs/usable-slice-transaction.md, docs/plans/folder-projection-scope.md, README.md
+- `related`: DEC-123, DEC-124, DEC-125, DEC-129, DEC-130

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2773,3 +2773,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: All ModelArk CLI invocations are application launches, so a separate query, status, or other CLI command also refuses while the portal or another command holds the guard. Existing in-process portal controls remain available. No service restart, deployment, legacy-process termination or real-device trial is authorized. Processes launched from older unguarded versions are not retroactively enrolled.
 - `docs_updated`: docs/decision_log.md, docs/plans/usable-slice-implementation-charter.md, docs/usable-slice-transaction.md, docs/deployment.md
 - `related`: DEC-121, DEC-123
+
+### DEC-125: Seal direct delivery admission with a conservative ext4 workload budget
+- `id`: DEC-125
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Operator authorized continuing the broader Slice 3 arc; architecture consultation derived a bounded initial filesystem profile instead of treating observed inode allocation as a future metadata guarantee.
+- `decision`: Join the existing Slice engine and adapters through explicit attended CLI commands. Seal the catalog/admission capsule into the destination binding, atomically stored in private schema v6. Require verified direct USB ext4 with bounded features, new-directory fanout, a conservative data/extent/xattr/root-growth budget and inode budget. Force unique ownership markers outside inode bodies to exclude shared-xattr double counting. Reconcile actual owned bytes/inodes without drift tolerance and prove disappearance separately from attached-root replacement.
+- `rationale`: Stable hardware identity, filesystem capability, current free capacity and authenticated owned consumption answer different questions. The reserve is an explicit conservative workload bound, not a generic estimate or guarantee against media faults. Unavailable read-only superblock proof means refusal, not automatic privilege escalation.
+- `impact`: Operator assembly retains existing authorities without a scheduler, retrieval, catalog-schema change, service deployment, formatting or real-device trial. Legacy private plans remain readable without invented admission. First attended physical trial and merge remain separate approval gates.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md, docs/usable-slice-transaction.md, docs/plans/usable-slice-implementation-charter.md, README.md
+- `related`: DEC-108, DEC-121, DEC-123, DEC-124

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2784,3 +2784,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Operator assembly retains existing authorities without a scheduler, retrieval, catalog-schema change, service deployment, formatting or real-device trial. Legacy private plans remain readable without invented admission. First attended physical trial and merge remain separate approval gates.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md, docs/usable-slice-transaction.md, docs/plans/usable-slice-implementation-charter.md, README.md
 - `related`: DEC-108, DEC-121, DEC-123, DEC-124
+
+### DEC-126: Separate direct attachment admission from streaming checks
+- `id`: DEC-126
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: PR #70 round-1 Greptile/Codex findings at b751cee; disposable regressions reproduced loop-mount rejection, still-mounted unplug invalidation, missing effective permission admission, per-chunk inventory scans, source-path mismatch, recursive audit failure and the remaining deployment launch probe.
+- `decision`: Retain full identity/role/filesystem admission at attempt, artifact audit, file creation and publication boundaries; stream under lightweight retained-root/mount/backing checks with exact allocation reconciliation. Topology or archive-role changes force full observation. Missing block backing latches an attended wait even when the mount ID survives. Require read-only effective DAC/ACL creation and user-xattr namespace checks before admission. Ignore explicit unrelated loops only in sibling-partition comparison; keep protected and ambiguous ancestry fail-closed. Both deployment validation paths share metadata-only inspection without a second application launch.
+- `rationale`: Mount visibility is not media presence; writable mount flags are not effective operator permission; full hardware discovery is not a practical per-megabyte lease check. These signals need distinct scopes without weakening descriptor confinement or expanding the trusted-operator threat model.
+- `impact`: Direct adapters, read-only admission, source path normalization, iterative layout audit and deployment validation only. No schema change, live deployment or physical trial. Permission checks do not guarantee future LSM/media behavior; runtime errors still refuse.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md, docs/deployment.md
+- `related`: DEC-123, DEC-124, DEC-125

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2806,3 +2806,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Direct adapter eligibility and layout validation only; no schema change, automatic ACL removal, permission change, deployment or physical trial. Existing incompatible residue remains untouched and refuses.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md, docs/deployment.md
 - `related`: DEC-125, DEC-126
+
+### DEC-128: Share Slice attachment spelling and strict output-byte validation
+- `id`: DEC-128
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: Operator approved the two residual Codex findings after PR #70's three-round review loop and the proposed narrow shared path contract.
+- `decision`: Use one lexical attachment-root normalizer across operator preview/Start, Linux observation and cached-loss recovery, descriptor binding and local source reads. Expand home and collapse parent segments without resolving symlinks. Separately share strict UTF-8 output-byte counting across final paths, generated temporary paths and directory components; unsupported encodings refuse as DESTINATION_LAYOUT_UNSUPPORTED.
+- `rationale`: Admission, successful observation and recovery must agree on path spelling. Byte admission must validate encoding before counting; surrogate-escaped Linux input must not escape as an unstructured traceback. Host attachment encodings and sealed relative-path serialization remain distinct contracts.
+- `impact`: Small Slice path helper and existing consumers, with unplug/recovery, CLI encoding and operator roundtrip regressions. No protocol/schema change, weaker descriptor confinement, new global authority, automatic ACL changes, live deployment or physical trial. The three-round review loop remains stopped; this approved correction is not a fourth review round.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md
+- `related`: DEC-125, DEC-126, DEC-127

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2795,3 +2795,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Direct adapters, read-only admission, source path normalization, iterative layout audit and deployment validation only. No schema change, live deployment or physical trial. Permission checks do not guarantee future LSM/media behavior; runtime errors still refuse.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md, docs/deployment.md
 - `related`: DEC-123, DEC-124, DEC-125
+
+### DEC-127: Admit the complete direct-delivery filesystem workload
+- `id`: DEC-127
+- `date`: 2026-09-08
+- `status`: accepted
+- `triggered_by`: PR #70 round-2 Greptile/Codex findings at 60995ca; kernel ENOSYS and real inherited-ACL admission regressions, temporary-path length and lexical parent-segment gaps.
+- `decision`: State and probe direct-delivery Linux 5.8+ interface capabilities; unavailable confinement/access syscalls refuse as unsupported, without weaker fallbacks. Exclude default ACL inheritance on the destination root and authenticated existing directories to retain the bounded ownership-marker xattr profile. Validate temporary as well as final full-path byte lengths; normalize source attachment parent segments lexically without following symlinks.
+- `rationale`: Admission must cover runtime prerequisites and intermediate filesystem objects, not only final names or writable mount flags. Default ACLs surviving in existing children matter on ordinary resume even after the root default is removed; checking them does not expand the trusted-account threat model.
+- `impact`: Direct adapter eligibility and layout validation only; no schema change, automatic ACL removal, permission change, deployment or physical trial. Existing incompatible residue remains untouched and refuses.
+- `docs_updated`: docs/decision_log.md, docs/usable-slice-direct.md, docs/deployment.md
+- `related`: DEC-125, DEC-126

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,6 +5,22 @@ checkout-local virtual environment plus a `systemd --user` service. The deployer
 does not install operating-system packages, edit sudoers, prepare drives, attach storage, migrate a
 catalog, or start archive work unless the operator explicitly asks for resume behavior.
 
+## One application instance
+
+ModelArk acquires a nonblocking launch guard before CLI configuration/dispatch or portal startup
+(DEC-124). A second launch exits with `ModelArk is already running`; changing the catalog directory,
+state directory or portal port does not bypass it. This includes separate help, query and status
+commands. Use controls inside the running portal, or stop that instance before running a CLI command.
+The standalone migration tools share the guard; deployment health checks inspect the installed
+package and existing portal without launching another application. Internal compression/download
+helpers remain children of the active application, not independently admitted instances.
+
+Exclusion uses a Linux kernel-held abstract socket, not a PID file. It releases when its final
+descriptor closes, including after process death; a surviving fork child can conservatively retain
+it. Separate network namespaces/containers and old versions without this guard are outside this
+guarantee. Existing archive/device/attempt fences remain in place. Installing this code does not
+retroactively guard or stop an already running older version; deployment/restart stays explicit.
+
 ## Prerequisites
 
 ModelArk currently supports the supervised deployment on Linux with Python 3.10+ and systemd. Install

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,8 +11,9 @@ ModelArk acquires a nonblocking launch guard before CLI configuration/dispatch o
 (DEC-124). A second launch exits with `ModelArk is already running`; changing the catalog directory,
 state directory or portal port does not bypass it. This includes separate help, query and status
 commands. Use controls inside the running portal, or stop that instance before running a CLI command.
-The standalone migration tools share the guard; deployment health checks inspect the installed
-package and existing portal without launching another application. Internal compression/download
+The standalone migration tools share the guard; both post-install validation and deployment health
+checks inspect installed package metadata without launching another application. Health checks also
+inspect the existing portal. Internal compression/download
 helpers remain children of the active application, not independently admitted instances.
 
 Exclusion uses a Linux kernel-held abstract socket, not a PID file. It releases when its final

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,8 +24,14 @@ retroactively guard or stop an already running older version; deployment/restart
 
 ## Prerequisites
 
-ModelArk currently supports the supervised deployment on Linux with Python 3.10+ and systemd. Install
-the host tools separately so every privileged change remains visible:
+ModelArk currently supports the supervised deployment on Linux with Python 3.10+ and systemd.
+
+The optional attended direct-USB Slice additionally requires Linux 5.8+ capabilities on x86_64 or
+aarch64 (`openat2`, `faccessat2`, and `statx` birth/mount identity). These interfaces are checked at
+use, including on backported kernels; unavailable capabilities refuse without weakening permission
+or confinement checks. See [direct-delivery prerequisites](usable-slice-direct.md).
+
+Install the host tools separately so every privileged change remains visible:
 
 ```bash
 sudo apt-get install -y git-annex smartmontools

--- a/docs/plans/fat32-session-protocol.md
+++ b/docs/plans/fat32-session-protocol.md
@@ -1,0 +1,160 @@
+# FAT32 session export: approved protocol and qualification
+
+Status: intent/live-authority distinction approved by the operator, 2026-09-09; no additional
+DEC requested. DEC-130 remains the scope authority. FAT32 plan, live descriptor port,
+one-attempt private state, observer and public operator routing are implemented locally.
+Both attended kernel-vfat runs passed, including the supplemental public-flow/alias checks below.
+No physical USB or real archive acceptance is claimed.
+
+## Approved intent versus live authority
+
+Existing Preview, Approve and Start are separate guarded application launches. Native ext4 can
+reprove the approved parent's persistent identity. Gate A's FAT32 `FolderTarget.parent_identity`
+instead names a retained live parent binding. That descriptor is gone when preview exits; saved
+JSON cannot turn its token back into a capability. Do not change that token's meaning in place.
+
+Approved public contract: retain the three-command workflow, with a **new versioned FAT32
+pre-creation intent** binding the exact destination path, qualified backing filesystem, source
+closure, capacity policy and explicit one-attempt/no-resume warning. It does not promise that
+the parent is the same directory inode seen at Preview. At Start, revalidate path/backing/roles,
+bind a fresh parent descriptor, confirm the child is unused, acquire/consume authority, then
+exclusively create and retain the output child. No existing directory is adopted, even empty.
+
+Alternative: preview, interactive approval and Start in one process retaining the same parent
+descriptor. This preserves live-parent continuity but introduces a different attended CLI flow.
+The operator selected separate durable intent and fresh Start authority. The combined interactive
+alternative is not being implemented. Native identity, archive source evidence, no-clobber
+publication and the launch singleton are unchanged.
+
+## Live-only ownership and resource bounds
+
+The dedicated port holds every owned directory/file descriptor necessary to authenticate later
+operations and final layout. Tokens index that in-memory capability table; FAT inode numbers,
+birth-like timestamps, paths, marker contents and matching hashes never authorize fresh-process
+ownership. Reads/writes use descriptors; resolving a name checks it against the still-retained
+object. Parent/root/mount/backing checks remain active at mutation and publication boundaries.
+
+Require an explicit descriptor budget for the whole closure before the first output write.
+Do not evade that bound by closing earlier descriptors and later treating FAT inode numbers as
+persistent certificates. Mount permissions must establish the trusted-account writer boundary;
+FAT's mount-wide uid/masks are not per-directory ext4 mode/ACL enforcement. No chmod/remount to
+force eligibility. [Linux VFAT mount documentation](https://docs.kernel.org/filesystems/vfat.html).
+
+All destination control, staging and report objects are inside the new child. Named staging
+uses exclusive creation, not O_TMPFILE or hardlinks. Publish only through qualified no-replace
+rename; unsupported primitives refuse. The first disposable kernel-vfat test passed successful
+and colliding RENAME_NOREPLACE plus required directory flushes on this host.
+[rename(2)](https://man7.org/linux/man-pages/man2/rename.2.html).
+
+## Authority lifecycle and no-resume
+
+A schema-8 `consumed_attempt` record commits inside the fenced host claim transaction
+**before root creation**. Commit failure means no destination writes. A committed claim is spent
+even if the process dies before mkdir; this conservatively trades a retry for unambiguous lifetime.
+Any later fresh claim refuses regardless of whether the old state says starting, stopped, waiting
+or transferring. A repeated Start may observe an already-live attempt, never construct a new port.
+
+Any ended attempt requires a new folder: graceful Stop, process exit/death, destination loss,
+source wait, capacity wait or error. Source alternatives can still be tried within the same live
+attempt. The native retained-wait/resume behavior is not inherited by the FAT profile.
+
+The implementation retains old claims and compares component ancestry under the candidate
+ASCII/case-insensitive profile. A disjoint new sibling intent is permitted; the old root remains
+claimed and cannot be adopted. The dedicated observer requires exact enumerated parent spelling,
+rejects requested short aliases and refuses unqualified name/mount options. The supplemental driver
+run passed those alias test vectors for the narrowly admitted profile; pure Gate A FAT overlap
+remains conservative and is not relabeled as that qualification. No stale-claim/media cleanup is added.
+
+## Required persistence/failure table
+
+No branch below permits adoption, overwriting, automatic residue deletion or false completion.
+
+| Boundary reached | Required ordering and failure outcome |
+| --- | --- |
+| Read-only preview / unconsumed Start | No destination writes. Requalification/retry possible. |
+| Host one-attempt claim committed | Claim is irrevocably consumed; failure before mkdir still requires a new intent/root. |
+| Root intent, exclusive mkdir, live capture | Keep root and parent retained; flush required directory metadata. Uncertain capture/flush leaves residue and ends attempt. |
+| Control/file intent and exclusive named staging | Persist host intent first; retain created file. Creation/write/source failure may leave staging; no fresh-process recovery. |
+| Content verified and prepared | Flush file, then persist prepared evidence; failure is not prepared success. No capacity guarantee is inferred. |
+| No-replace publication | Authenticate retained source and parents; rename without replacement; collision/unsupported result ends attempt. |
+| Published name / parent flush | Required directory flush must succeed before publication is called durable. Failure ends attempt with residue. |
+| Final original hashes and exact live-owned layout | Verify all payloads again and record exact observed evidence; extra/changed objects refuse. |
+| Destination report publication | Flush report and parent. Report asserts verified export evidence, **not host transaction commit**. |
+| Host export-evidence journal append | Persist the non-final report evidence; failure ends the attempt without host completion. |
+| Final retained-descriptor close barrier | Attempt every close once; any close error prevents host completion. Never retry an already-closed descriptor number. |
+| Host completion commit | Only committed host state or its successful command result asserts transaction completion. Failure leaves host completion unproven. |
+| Host commit succeeded, response lost | Read-only status may report complete. Never reopen the output to retry writes. |
+
+An export-evidence report may survive when the host commit did not. It must identify that limit
+in its versioned schema instead of copying the native receipt's top-level completion assertion.
+No future Start infers committed completion or writable authority from that media report.
+Successful flush syscalls are observed evidence, not proof of arbitrary power-loss survival.
+
+## Layout preflight
+
+`modelark.slice.fat32_layout.admit_layout` takes relative payload path/size pairs, one output child,
+the canonical absolute host parent spelling, and exact control/report payload sizes. It validates
+the full directory/file tree and generated `.slice-<32 hex>` staging path lengths. Its return
+value always has `execution_ready=False` and cannot enter the execution store.
+
+Candidate v1 grammar is deliberately conservative ASCII: letters, digits, underscore, hyphen,
+dot and internal spaces. Refuse non-ASCII, control/forbidden characters, surrounding whitespace,
+trailing dots, DOS device stems, requested tilde/short-alias spellings, reserved staging prefixes,
+duplicate/case-equivalent names, inconsistent case in shared directories and file/directory
+collisions. Do not rename or split to fit. Each payload/control/report must be at most 2^32-1
+bytes, components at most 255 ASCII characters, and generated relative/absolute path byte lengths
+strictly below 4096. This is an admission proposal, not a claim to support every legal FAT name.
+
+These rules **do not prove driver alias disjointness**. In particular, `nonumtail` can generate
+short aliases without a tilde, so a tilde blacklist alone is insufficient. Mount-option
+qualification must establish the actual alias rules (or refuse the mount), and must not change
+them silently. Existing parent aliases are not validated by this pure layout function.
+[Linux VFAT name options](https://docs.kernel.org/filesystems/vfat.html).
+
+## Qualification evidence and remaining checks
+
+On 2026-09-09 the operator reported PASS from the first attended script. Retained artifacts:
+`/tmp/modelark-fat32-qualification-reohetp0`. It covered real kernel-vfat no-replace and directory
+flush, original-byte delivery/report, all 30 injected engine interruptions with no resumed
+authority, and sibling preservation. `physical_USB_or_archive_test: false` is intentional.
+The public workflow and parent case/short-alias checks were not in that first script.
+
+The operator subsequently reported PASS from the expanded script, with artifacts retained at
+`/tmp/modelark-fat32-qualification-ru4sibe7`. This includes the real parent case/numbered-short-alias
+checks and public Preview/Approve/Start with synthetic source/backing, in addition to every earlier
+writer/fault/sibling check. The planned disposable-image gate is complete, not physical acceptance.
+
+- Use a new disposable FAT32 image with the kernel vfat driver, not an ext4 test pretending to
+  be FAT and not mtools/FUSE as proof of kernel syscall behavior. Local FAT formatting and loop
+  facilities exist, but noninteractive sudo requires a password. The attended script below
+  requests sudo interactively for reruns; it never accepts an existing device.
+- Cover no-replace collision and successful rename with retained descriptors; directory/file
+  flush support and failure; exact long-name enumeration; case and short-name collisions;
+  mount options; zero-byte and size/name/path limits; descriptor budget and permission refusal.
+- Inject interruption before/after every row above, including SQLite FULL/busy/commit failure,
+  and assert no resumed authority, no unrelated writes and no false host-complete result.
+- Regress native and strict legacy protocols and a freshly installed wheel after write changes.
+- Only afterward: reviewed exact physical USB/source acceptance. Source clean-anchor
+  reconciliation remains a separate authorization requirement. No deliberate unplug/power loss,
+  formatting existing media, permission rewriting, archive repair or live deployment is included.
+
+## Attended disposable-image command
+
+Run as your ordinary user (not by putting sudo before Python):
+
+```text
+/home/phaze/PycharmProjects/modelark/.venv-dev/bin/python /tmp/modelark-folder-projection/scripts/qualify_fat32_slice.py
+```
+
+It creates a fresh private `/tmp/modelark-fat32-qualification-*` directory and a new 64 MiB regular
+image, formats only that new image, and requests sudo solely to mount/unmount it. It accepts no
+device or destination argument. The real FAT port checks include no-replace rename, directory
+flush, original-byte delivery/report, 30 interrupted engine boundaries and no resumed authority.
+The updated script also checks exact long-parent spelling, actual case and numbered-short-alias
+resolution/refusal, case-equivalent creation collision, and public Preview/Approve/Start using the
+real mount-routing hint and real vfat I/O. Its source and backing evidence are explicitly synthetic;
+it does not qualify physical USB observation or real archive eligibility. Admission is restricted
+to `codepage=437,iocharset=iso8859-1,utf8,shortname=mixed`; other codecs are not inferred safe.
+The image, synthetic private state and output residue remain available after unmount for inspection.
+Broader failure cases and physical acceptance remain separate checks.
+An unsuccessful unmount is reported, never hidden with lazy or forced detach.

--- a/docs/plans/folder-projection-review.md
+++ b/docs/plans/folder-projection-review.md
@@ -71,6 +71,40 @@ classification corrections; no additional physical-media result is claimed.
 
 ## Web review rounds
 
+Round 1 reviewed `163f60bf14df9e120fd23827a3e36c8c0db200c5`, requested in
+[comment 5599186847](https://github.com/Auspex-Aerie/modelark/pull/70#issuecomment-5599186847).
+Greptile completed with 5/5 and a trigger thumbs-up; Codex completed with two P2s.
+All three CI jobs passed on that head. Both findings were independently confirmed:
+
+- **Native inherited ACL/marker footprint:** a real disposable ext4 parent with 200 named-user
+  default ACL entries admitted successfully, then directory ownership-marker publication failed
+  with ENOSPC. The pre-mkdir check now budgets two full inherited ACL values, the actual marker
+  length and 256 bytes of xattr headers/entries/alignment/slack against one filesystem block.
+  It credits neither in-inode space nor ACL sharing/EA-inode support. Preview and each runtime
+  parent check enforce it. Ordinary small ACLs still complete real local transfers; large ACLs
+  refuse before creating the root, with parent ACL and sibling bytes unchanged. The same bound
+  refuses 1 KiB blocks even without ACLs because they cannot hold the padded marker. This remains
+  a conservative compatibility bound, not a promise against quota, concurrent allocation or
+  other security attributes. Ext4 layout basis: [kernel xattr documentation](https://www.kernel.org/doc/html/latest/filesystems/ext4/attributes.html).
+- **FAT owner masks:** fmask must preserve owner read/write and dmask owner read/write/search,
+  in addition to excluding group/other writes. Five newly added bad-mask cases reproduced prior
+  admission, including Codex's fmask=0477. Good 0077 and file-only 0177 masks remain admitted;
+  live recheck rejects a newly incompatible file mask. These are synthetic mount-observation
+  tests, not new mounted-vfat or physical-USB qualification. Mount-mask basis:
+  [kernel VFAT documentation](https://www.kernel.org/doc/html/latest/filesystems/vfat.html).
+
+The common cause is incomplete admission of the writer's **whole operation sequence**: creation
+permission alone did not establish later certification/read-back capability. The corrections
+extend existing shared Preview/runtime admission functions; they do not introduce a new adapter,
+permission rewriting, rollback/adoption policy, schema, seal version or archive behavior.
+
+Post-fix installed wheel `/tmp/modelark-web-round1-wheel.F5Tdqa/package`: **173 tests passed**
+(113 admission/import-location tests and 60 native transaction/public-flow tests). Packaged Slice
+sources exactly match the checkout. Ruff passes across `modelark`, `scripts` and `tests`; diff
+whitespace checks pass. No additional mounted-vfat or physical-media result is claimed.
+The full post-fix Slice suite passed **1,322 tests**, with five optional-codec skips and two
+upstream Torch deprecation warnings (509 seconds).
+
 Use the PR's exact-head trigger/result comments as the live round tracker. Count only newly
 requested rounds for this folder-projection extension; earlier
 PR #70 direct-USB reviews do not constitute review of the new code. Tie every result to the

--- a/docs/plans/folder-projection-review.md
+++ b/docs/plans/folder-projection-review.md
@@ -1,0 +1,81 @@
+# Folder projection review
+
+Scope: folder-projection candidate based on PR #70 head `6fd87c3`, including native ext4 and
+FAT32 single-attempt folder delivery. The operator authorized local Grok review first, then a
+fast-forward push to PR #70 (`codex/usable-slice-direct-usb`) and up to three Greptile/Codex web
+review rounds. No merge, deployment, archive repair or physical-device writes are authorized.
+
+## Qualification evidence
+
+- Full pre-review Slice suite: 1,287 passed, 5 optional-codec skips, two upstream Torch warnings.
+- Independently installed wheel: 622 passed with import-location assertion and source match.
+- Operator-reported expanded kernel-vfat disposable-image run: passed, retained at
+  `/tmp/modelark-fat32-qualification-ru4sibe7`. Includes public Preview/Approve/Start with synthetic
+  source/backing, real case/numbered-short-alias refusal, no-replace/flush, verified original
+  bytes/report, all 30 interruption boundaries and sibling preservation.
+- No physical USB or real archive acceptance. These evidence levels remain distinct.
+
+## Local review
+
+Pass 1: Grok returned **REQUEST_CHANGES** with two P2 findings and no established P1. Local
+session `01a0853d-6a61-7733-bcd4-dd3b0e7deb3c`; no tests were run by Grok itself.
+
+- FAT caught aborts dropped the lease before publishing ended state. Four corrected fault-hook
+  tests reproduced the stale `transferring` state at real creation/payload boundaries, for Ctrl+C
+  and RuntimeError. A FAT-only shared abort-close helper now requests/acknowledges Stop before
+  lease release, then always closes the destination. The public wrapper avoids a duplicate Stop
+  request after engine acknowledgment. Native/legacy abort behavior is unchanged. Four tests pass.
+- Native inode checks required only one free inode. The plan now computes the total file/directory
+  inode budget; Preview compares fresh known free inodes, and runtime subtracts distinct live
+  authenticated inodes. The shared allocation auditor counts identities once across temporary/final
+  hard links while preserving the legacy bytes-only interface. Tests cover pre-root refusal/retry,
+  partially published links, and zero free inodes after the final receipt exists.
+
+Both Grok corrections plus affected native/FAT paths: **240 source tests passed**. The legacy
+destination/transaction/authority/operator/direct-integration/probe subset passed **343 tests**.
+No schema or serialized plan field changed.
+The final rebuilt wheel in `/tmp/modelark-grok-review-wheel.MjCxF8/package` passed **642 native/
+FAT32 folder tests**, including installed-import-location proof and exact packaged-source match.
+
+Pass 2: Grok returned **ACCEPT**, closing both P2s and finding no new supported P1/P2 in the
+focused follow-up, including the independent IO corrections below. No third local pass needed.
+Residual limits explicitly retained: SIGKILL/private-state failure cannot guarantee a durable Stop;
+an interrupt inside acquisition after claim but before handoff can retain last-known active state.
+The consumed-attempt fence still forbids resumed FAT writes. Grok treated that narrow handoff
+window as non-blocking; it is not covered by the creation/payload fault-hook tests. Review acceptance
+is not physical-media acceptance or a claim that every abort publishes a final state.
+
+Independent Codex finding: both new Preview assemblies lacked the outer IO boundary after
+observer admission. Parent reopen, recheck or descriptor close failure could escape as raw
+`OSError`, bypassing the CLI's structured refusal. Six regressions reproduced this before the
+fix. Both assemblies now classify these failures as `DESTINATION_UNPROVEN`, preserving narrower
+annotated probe failures and leaving the destination untouched. Validation: 56 affected source
+tests passed; 57 passed against a freshly built, independently installed wheel (including import
+location proof). Ruff and diff whitespace checks pass. No writer protocol changed for this fix.
+
+Independent Codex finding: FAT32's IO error classifier rechecked only retained parent identity,
+omitting backing-device evidence from the supplied observer. A disconnect/replacement between
+the pre-IO boundary and an allocation error could be misreported as capacity failure. Two failing
+regressions reproduced this; two controls preserve the original error for unavailable/inconclusive
+probes. The adapter now uses the same full read-only recheck for normal boundaries and error
+classification. No new admission policy, resumed authority or destination mutation is introduced.
+The related reader setup path also left its initial live/owned-object probes outside its IO
+boundary. Two regressions reproduce raw setup errors; those probes now classify before yielding
+the reader, without catching or reclassifying consumer exceptions across the context-manager yield.
+
+Combined correction validation: **169 source tests passed**. A rebuilt wheel installed into
+`/tmp/modelark-review-final-wheel.tfg8JC/package` passed **634 native/FAT32 folder tests**, including
+installed-import-location proof; packaged Slice sources match the checkout. Ruff and the complete
+staged diff whitespace check pass. The existing real-vfat result predates these read-only error
+classification corrections; no additional physical-media result is claimed.
+
+## Web review rounds
+
+Use the PR's exact-head trigger/result comments as the live round tracker. Count only newly
+requested rounds for this folder-projection extension; earlier
+PR #70 direct-USB reviews do not constitute review of the new code. Tie every result to the
+exact pushed head. Request with `@greptileai review` and `@codex review`.
+
+After the third completed round, stop further fixes/triggers and summarize residual findings,
+common causes and any architectural recommendation. Do not infer acceptance from silence,
+an old thumbs-up, an outdated review, or green CI alone.

--- a/docs/plans/folder-projection-scope.md
+++ b/docs/plans/folder-projection-scope.md
@@ -1,0 +1,321 @@
+# Folder-based projection — approved scope
+
+Status: approved 2026-09-09 after Grok CLI critique (DEC-130). Gate A contracts and Gate B native
+ext4 and FAT32 session execution are implemented. Both FAT32 image qualification runs passed;
+PR review and real archive/USB acceptance remain pending. Native authority/versioning is in DEC-131.
+
+## Current checkpoint: public FAT32 routing
+
+- This checkpoint supersedes earlier "disabled" and "image not run" statements below; those
+  describe prior implementation stages. Changes remain local, uncommitted and undeployed.
+- Operator-reported first kernel-vfat image qualification passed on 2026-09-09; artifacts are in
+  `/tmp/modelark-fat32-qualification-reohetp0`. No-replace/flush, payload/report, 30 interruption
+  boundaries and sibling preservation passed. This was not a physical USB or archive test.
+- Public exact-folder Preview/Approve/Start routing is implemented. FAT Start dispatches by the
+  sealed plan; the mount hint cannot bypass actual admission or trigger fallback after refusal.
+  The name codec is narrowed to the image-tested codepage437/iso8859-1/utf8/shortname=mixed profile.
+- Supplemental real-driver exact/case/numbered-short-alias checks and public workflow with
+  synthetic source/backing passed in the operator's expanded attended run, with artifacts at
+  `/tmp/modelark-fat32-qualification-ru4sibe7`. Every earlier writer/fault/sibling check passed again.
+  Source reconciliation, physical target acceptance and review remain separate gates.
+- Final full Slice source regression: **1,287 passed, 5 optional-codec skips**, two upstream Torch
+  deprecation warnings. The new routing-error test exposed an unclassified mount-inventory IO
+  failure; the hint now returns a typed refusal and all six routing tests pass in the full run.
+- Fresh wheel installed without dependency resolution into
+  `/tmp/modelark-fat32-public-wheel.EtJEk4/package`: **622 passed** across FAT/native folder
+  contracts, plans, observation, transactions, public routing/operator and mapper integration,
+  including an installed-import-location assertion. Copied tests ran outside the checkout;
+  packaged Slice sources match the checkout. Ruff and diff whitespace checks pass.
+- The supplemental result, not the first image result, supplies public-flow/alias evidence.
+  Neither result supplies physical USB or real archive acceptance. No new DEC was added.
+
+## Implementation checkpoint: Gate A
+
+- Branch `codex/folder-projection`, worktree `/tmp/modelark-folder-projection`, based on reviewed
+  PR #70 head `6fd87c3`. PR #70 was still open when checked; it has not been merged by this task.
+- Additive non-executable folder target/profile/capacity/review contracts and conservative overlap
+  semantics. Legacy decoder rejects mixed/unknown envelopes before reconstruction. No public CLI,
+  folder writer, state migration or new lease namespace is enabled at this gate.
+- Validation: 160 new contract/isolation tests; 354 source tests including transaction/operator/
+  authority regressions; 160 new tests against a freshly built, separately installed wheel.
+  Ruff and diff whitespace checks pass. Legacy v1/v2/v3 seal hashes match `6fd87c3` goldens.
+- The initial sandboxed regression run failed on prohibited Unix-socket binds; the successful
+  regression run used approved socket access. Two new fixture-constructor mistakes were corrected
+  before the successful runs. No live media/service/archive operations were performed.
+- At that checkpoint neither filesystem writer was implemented. The following Gate B checkpoint
+  supersedes that implementation status, not the approved scope or legacy golden evidence.
+
+## Implementation checkpoint: Gate B
+
+- Same isolated branch/worktree and reviewed base as Gate A; no merge, commit, push or live
+  deployment has been performed. The main checkout and real USB/archive bytes are untouched.
+- Native exact-child CLI preview/Start dispatch, closed executable plan, private schema 7,
+  durable overlapping-root/legacy-device exclusion, shared capacity, internal control/receipt,
+  exclusively certified creation and authenticated Stop/fresh-Start resume are implemented.
+  Explicit preview `--root` retains the legacy strict path; old seals are not reinterpreted.
+- Integration review corrected canonical backing-ID ordering at the observer/plan boundary and
+  Ctrl+C acknowledgment before lease teardown. Real-host observation exposed PATH/KNAME mapper
+  spelling and protected procfs birth-time assumptions. Narrow shared-helper corrections preserve
+  ancestry conflicts and owned-object birth requirements; source qualification is unchanged.
+- Real observer plus native writer smoke completed with 12 synthetic bytes in a newly created
+  disposable `/tmp` directory on the host's ext4/LUKS/LVM storage. The sibling sentinel survived;
+  control/receipt and verified payload stayed inside the child. This is not a real archive/USB
+  trial or a power-loss/performance qualification. No live catalog or archive was opened.
+- Final full Slice source suite: **982 passed, 5 optional-codec skips**, with two upstream Torch
+  deprecation warnings. The earlier run's sole failure was the expected lsblk column list after
+  adding KNAME; the corrected expectation passes in this full rerun. Ruff and diff checks pass.
+- Fresh wheel built without isolation and installed without dependency resolution into
+  `/tmp/modelark-folder-native-wheel.v593HU/package`: **378 passed**, covering native contracts,
+  plans, observation, transactions, operator/CLI dispatch, legacy isolation and Linux role/mapper
+  helpers. Tests were copied outside the checkout and asserted the installed import location;
+  packaged Slice sources match the checkout. The first custom-runner approval timed out before
+  execution; the permitted retry used the approved pytest entry point and completed successfully.
+- Next: review the FAT32 write/failure table before its adapter, then qualify session-only export
+  in Gate C. Gate D still requires separately authorized source clean-anchor reconciliation and an
+  exact reviewed physical target. Native success does not make the user's FAT32 USB executable.
+
+## Gate C protocol checkpoint
+
+- Architecture consultation identified the separate-launch preview token lifetime, consumed
+  attempt fencing, execution-claim versus residue lifetime, descriptor budget and media-report
+  versus host-completion seams. [The FAT32 protocol review](fat32-session-protocol.md) records the
+  failure table and recommends separate durable path/backing intent from fresh live Start authority.
+  The operator approved that distinction and requested no new DEC. The public FAT path remains
+  disabled pending real kernel-driver qualification, not another design decision.
+- Additive non-executable FAT32 name/size/full-tree/staging-layout preflight is implemented.
+  It is not filesystem, short-alias, permission, flush or execution qualification. Actual vfat
+  mounted-image tests remain pending. Internal writer/state integration is covered below.
+- Validation: 96 new layout tests; 330 source contract/layout/legacy-isolation/native-plan tests;
+  331 checks against a fresh independently installed wheel (including import-location assertion).
+  Ruff and diff whitespace checks pass. No native/legacy writer behavior changed in this checkpoint.
+
+### Gate C internal runtime checkpoint
+
+- Distinct FAT intent/plan with no saved parent identity; fresh retained `Fat32Tree` and per-object
+  descriptor authority; dedicated named-staging/no-replace port; schema-8 claim consumption before
+  first destination write. Every ended attempt refuses fresh Start; disjoint new sibling intents
+  retain their own scope while old residue remains claimed and untouched.
+- Report says export verified, not host transaction committed. Any interrupted completion gap
+  remains nonresumable. Native/legacy default birth identity and resume policy remain unchanged.
+- Read-only observer requires direct USB/vfat/FAT32 evidence, closed name/mount options, canonical
+  parent enumeration and current-user non-group/other-writable masks; no permission rewriting.
+- Actual kernel-vfat image test is blocked on the operator's sudo password. The prepared
+  `scripts/qualify_fat32_slice.py` creates/formats only a new disposable image and mounts/unmounts
+  it interactively. Public FAT Start unconditionally refuses qualification-required; there is no
+  bypass flag. No existing USB, archive or live service has been changed.
+- Integrated full Slice source run: **1,258 passed, 5 optional-codec skips**, two upstream Torch
+  deprecation warnings. Subsequent review corrections separate consumer/read errors, enforce
+  retained-descriptor close before host completion and restore FAT inventory KNAME; their focused
+  regressions pass. The final independently installed package run covers those corrections.
+- Final installed-package regression: **800 passed**, including all FAT plan/layout/observer/
+  transaction/public-gate tests, native contracts/operator/transactions, Linux/hardware helpers,
+  legacy CLI/operator/authority and import-location proof. Packaged Slice sources match the
+  checkout; Ruff and diff checks pass. The attended image script's help path was exercised;
+  its privileged mount/driver test has not run. Changes remain local and uncommitted.
+
+## Outcome
+
+Project an approved, immutable slice of already archived artifacts into a new folder chosen by
+the operator. Own that folder, not its parent filesystem or drive. The full arc includes ordinary
+ext4 local folders and the user's existing FAT32 USB without formatting it. This is not a promise
+that every writable filesystem supports identical recovery or durability semantics.
+
+Example: `--destination /home/operator/exports/demo` names the exact new output root. Its parent
+must already exist. Preview creates no destination objects. Start creates the root exclusively;
+all destination staging, control and receipt files live inside it. Host-private journals remain
+in private state. Existing roots are refused except for authenticated same-transaction resume.
+Do not adopt/merge existing content, rename files to make them fit, or touch unrelated siblings.
+
+## Why this is more than a path change
+
+Code inspected in the reviewed direct-USB worktree at `6fd87c3`:
+
+- `hardware.py` combines attachment observation with exact mount-root, USB, direct-block, ext4
+  and non-system-device policy.
+- `capacity.py` and `destination.py:UsbDestination.check` both depend on exclusive-filesystem
+  free-space accounting. Merely changing the observer leaves shared folders unusable.
+- `destination.py` relies on O_TMPFILE, hardlink publication, xattrs and host-private inode/birth
+  certificates. `linux.py` requires mount and birth identity. These cannot be assumed on FAT.
+- `transaction.py`, `authority.py` and `state.py` bind plans, receipts, reservations and live
+  attempts to a device-oriented identifier. Folder identity needs explicit versioned semantics.
+- Control data is currently placed at the attachment root; that is no longer an acceptable
+  ownership boundary when the attachment is an existing shared parent.
+
+The recurring architectural assumption is **exclusive filesystem use standing in for exclusive
+output-tree ownership**. Fix the boundary and the dependent contracts, not just filesystem checks.
+
+## Proposed work
+
+### 1. Folder identity, ownership and protection
+
+Separate target identity, attachment evidence, filesystem capabilities and policy. Seal the
+existing parent's identity and intended child name; durably bind the created root after exclusive
+creation. Revalidate attachment and root identity on Start/resume and before mutation. A matching
+pathname, UUID or marker alone must not authorize recovery.
+
+Allow ordinary home/data folders even when their storage also backs the OS, including qualified
+local encrypted/mapped storage. Protect OS-managed subtrees and ModelArk private state by path/role,
+not by banning the entire system disk. Keep registered archive backing devices excluded initially.
+Specify the protected subtree policy explicitly during contract review, including how catalog and
+runtime paths are discovered; do not treat `/` as a blanket protected ancestor of every folder.
+
+Retain descriptor-relative confinement and no-clobber publication. Initially reject symlink
+ancestors, unsupported aliases and nested mounts inside the owned tree with precise diagnostics.
+Recognized mount/alias relationships must identify the same target; ambiguous ones fail closed.
+Target exclusion must detect same/overlapping roots, including roots not yet created, without
+locking a whole drive. Keep the existing application-launch singleton; no new concurrency system.
+Unrelated sibling changes are allowed. Mutations inside an active owned tree are not.
+
+### 2. Shared capacity and honest completion
+
+Replace strict free-space conservation with available-space/inode observations, explicit bounded
+or estimated metadata/headroom policy, and repeated remaining-space checks. Preview is not a
+reservation or guarantee against other applications consuming space. Record that distinction in
+approval and receipts. Do not invalidate merely because a sibling file changed.
+
+ENOSPC and quota exhaustion need typed outcomes rather than accidental identity invalidation.
+Native folders preserve only authenticated checkpoints; fresh Start can proceed after capacity is
+restored. Proposed FAT32 v1 instead requires a new root after an interrupted attempt, including a
+space-related stop. Include host journal/control-disk exhaustion and interrupted outcome persistence in the
+fault matrix. No automatic cleanup of uncertain objects. Preallocation, if used, is confined to
+owned files and never presented as reserving all future metadata needs.
+
+Final completion still requires full original-byte hashes, expected layout and successful receipt
+persistence under the declared profile. Distinguish current verification from stronger claims about
+surviving sudden power loss. Do not claim a portable profile inherits ext4's guarantees.
+
+### 3. Two concrete capability profiles
+
+**Native Linux folder profile:** qualify ext4 operations needed for confinement, ownership,
+no-replace publication, flush and recovery. Reuse existing certificates where applicable, without
+the raw-superblock/external-xattr-allocation capacity model. Handle effective permissions and ACL
+inheritance explicitly; do not change ownership, modes or ACLs to force admission. Ordinary folder
+use must not require privileged raw-device reads. Filesystem type alone is not capability proof.
+
+**FAT32 session profile:** a separate qualification task, not a flag on the native adapter.
+First specify a failure-state table for root creation, named staging,
+publication, control writes and receipt persistence without assuming xattrs, O_TMPFILE, hardlinks
+or persistent inode birth identity. Host-private records and destination markers corroborate
+ownership; a random marker or matching hash/path does not independently prove it.
+
+Recommended v1 scope: do not resume a stopped or interrupted FAT32 destination. Leave residue
+untouched and require operator recovery or a fresh output root, including after graceful Stop.
+This is a conservative release boundary, not a proof that future safe portable resume is impossible.
+Disclose those limits before approval. Do not silently
+adopt/delete a residue tree or weaken the native profile to accommodate portable media. The
+failure-state table still matters even without resume: it proves no unrelated data is touched and
+no interrupted run becomes a false completion. Native graceful Stop/fresh Start remains resumable.
+
+Use closed versioned profiles, not a combinatorial capability/plugin framework. XFS and exFAT
+qualification are proposed follow-on work, not part of this first delivery. FAT32 support does not
+implicitly qualify exFAT. Ordinary mapped/encrypted ext4 home storage is still an acceptance case
+when mounted backing-role checks are unambiguous; no new raw-device forensic subsystem is needed.
+
+Portable publication must prove no-replace behavior on the supported driver; ordinary overwriting
+rename is not a fallback. Required flush failures block completion, never become "best-effort"
+success. Explicitly specify the ordering of intent, file publication, receipt and host completion
+records, including failure to persist any one of them. Completion evidence must be profile-specific
+without calling any delivery copy newly verified archive evidence.
+
+Validate the entire closure, including staging/control filenames, against file-size, component,
+path, case-collision and name rules. Refuse unsupported layouts before the first output write;
+no splitting or mangling to bypass FAT limits. Do not format the existing USB. Remote shares,
+FUSE/cloud mounts and cross-platform execution are outside this first arc.
+
+### 4. Integration and compatibility
+
+Reuse domain/catalog closure, original-byte verification, source fences/readers, decoding,
+transaction Stop/Start machinery, journal concepts and shared IO error classification. Adapt the
+destination port and its budget/identity contracts where necessary rather than duplicating the
+whole transaction engine.
+
+Migrate the existing direct-USB public path to the same folder-facing contract for NEW plans.
+Keep old approved plans and in-flight state under their original versioned strict policy; do not
+reinterpret seals or certificates. Test compatibility dispatch across plans, admission data,
+receipts, reservations and certificates. Removing legacy execution support is a later explicit
+decision, not an incidental cleanup.
+
+Fill and archive write authority stay unchanged. Inspect existing restore for genuinely shared
+path/capability utilities, but do not force it through Slice planning, ownership or state merely
+for consistency. No generic backend/plugin framework; extract only contracts used here.
+
+## Reviewable delivery gates
+
+1. **Contract and identity:** agree semantics, protected paths, capability/receipt claims and state
+   versions; implement folder targeting/exclusion and legacy dispatch with focused safety tests.
+2. **Native folder execution:** replace both capacity assumptions, internalize destination control
+   files, qualify native IO; tests on system-backed/mapped storage, populated parents, unrelated
+   sibling writes, mount/root replacement, aliases/overlap, permissions, ENOSPC/quota, Stop/resume,
+   original hashes and installed-package regressions.
+3. **FAT32 session profile:** review the write/failure protocol BEFORE adapter implementation.
+   Capability tests on FAT32, then interruption-at-every-write-stage, name/case/file-limit,
+   no-clobber and truthful receipt tests. If safe recovery demands a broader protocol, return for
+   scope approval rather than silently expanding or weakening guarantees. Start with tiny fixture
+   data; preserve the original-byte closure rules for the later real archive trial.
+4. **Attended acceptance:** after separately authorized source reconciliation, preview a small
+   archived model against the actual FAT32 USB. Preserve sibling sentinels, verify output hashes,
+   layout and receipt, and exercise native resume versus FAT32 Stop/new-root restart. Deliberate unplug/power-loss
+   tests require separately approved disposable-media testing.
+
+These are bounded review gates, not a promise of exactly four PRs. The native gate alone does not
+complete the user's requested arc: the current FAT32 USB is an explicit acceptance target.
+Installed-package regression belongs on every write-path change, not only the native gate.
+
+## Exclusions and independent blockers
+
+No downloads, Fill changes, archive reshape, adoption/merge, projection garbage collection,
+cross-host resume, scheduler or portal redesign. No formatting, sudo/ACL changes or archive repair
+is authorized by this proposal. The observed source clean-anchor reconciliation requirement is
+independent of destination support and must not be bypassed to make the test pass.
+
+## Approved scope (2026-09-09)
+
+- Native ext4 folders plus the FAT32 session profile, staged as above; XFS/exFAT qualification
+  remains outside this first delivery.
+- FAT32 Stop/interruption requires a new output folder in v1; native ext4 retains authenticated
+  resume. Portable resume is not part of this implementation.
+- Observed/headroom capacity admission, not guaranteed exclusive capacity.
+
+Recommended default: native ext4 plus FAT32 only; keep safety and honest evidence invariant;
+accept explicit FAT32 restart-in-new-folder limits rather than fabricate ownership proof.
+
+## Grok review status
+
+Completed through the installed Grok CLI after the user explicitly approved sending the prepared
+summary. Tools and web search were disabled. The first connected run reached its one-turn limit
+after an acknowledgment; a four-turn retry returned the complete critique with exit code 0.
+Grok explicitly reviewed supplied facts only, not repository code. No independent filesystem
+experiment was performed. Reviewer model ID was not verified; attribution is to Grok CLI.
+
+Prepared review prompt: `/tmp/modelark-folder-projection-grok-scope.txt`. This is the INITIAL broader
+proposal sent for critique, not the revised recommendation above. It contains summarized contracts,
+not source-file uploads, credentials, catalog contents or user file contents.
+
+### Incorporated recommendations
+
+- Narrow first delivery to native ext4 plus FAT32 session export; propose XFS/exFAT separately.
+- Split capacity observation from target identity. An advisory snapshot may remain in the sealed
+  review record, but a later free-byte difference is not itself destination substitution.
+- Keep device-wide leases only for legacy strict transactions; folder transactions use target
+  scope and never acquire drive-wide destination authority.
+- Make parent-to-created-root transition, live attachment versus durable identity, exact owned-tree
+  layout, and host/destination persistence ordering explicit.
+- Use closed versioned profiles, preserve old seals, and regress installed packages per write PR.
+- Make FAT32 no-resume a visible operator choice rather than smuggling in a recovery project.
+
+### Qualifications and disagreements
+
+- Grok called the proposal a "second product." The portable ownership work is substantial, but
+  the existing closure/source/verification engine remains reusable; duplicating it is not justified.
+- Its categorical claim that safe FAT recovery is infeasible was not proven by a summary review.
+  No-resume is the recommended v1 boundary, not an impossibility result.
+- Its "best-effort" fsync suggestion and shorthand staging-plus-rename do not establish our
+  completion/no-clobber contract. Keep explicit required flush and no-replace qualification.
+- Do not drop ordinary encrypted/mapped ext4 home support merely to avoid a device-mapper project;
+  inspect mounted backing roles conservatively, while allowing normal system-backed user folders.
+- Its suggested PR-D Stop/fresh-Start acceptance needs profile distinction: native resumes;
+  proposed FAT32 v1 starts into a new root. The gates above correct that inconsistency.
+
+Grok's review was advisory. The operator subsequently approved the narrowed scope, including
+FAT32 restart in a new folder, on 2026-09-09 (DEC-130). Filesystem qualification and source
+reconciliation remain separate work; consultation alone did not establish them.

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -197,21 +197,21 @@ Certified objects retain automatic recovery; this exception grants no cleanup or
 
 ### Slice 3 implementation gates (2026-09-08)
 
-The Linux primitives and adapters under development are internal, unqualified components, not an
-operator-enabled direct-USB implementation. Disposable tests do not establish real-device safety.
-Before production assembly, resolve these additional gates without weakening DEC-123:
+The [direct-USB operator assembly](../usable-slice-direct.md) joins the concrete Linux components.
+Disposable tests do not establish a completed physical-device trial. DEC-125 adds the initial
+supported capacity profile without weakening DEC-123:
 
 - Launch exclusion (DEC-124): admit only one ModelArk application instance before configuration
   or startup, regardless of catalog path, port or operation. A competing launch exits immediately;
   internal attempt/device/archive fences remain. The operator account is trusted, and unrelated
   processes deliberately substituting destination entries are outside the threat model. This does
   not relax collision detection, unknown-content preservation, descriptor confinement or DEC-123.
-- Capacity admission: observed free space plus authenticated inode allocation and root-directory
-  allocation detects drift, but does not bound future filesystem-global metadata allocation.
-  A supported filesystem policy must justify the sealed reserve before approval or writes.
-- Physical identity/system-role exclusion, production source attachment observation, operator CLI,
-  integrated recovery and installed-wheel qualification remain unfinished. No attended USB trial
-  is authorized by the current coding work.
+- Capacity admission: a verified 4-KiB ext4 feature profile, bounded new-directory fanout, conservative
+  data/extent/xattr/root-growth charge and free-inode budget justify the sealed reserve. Actual owned
+  allocation is reconciled separately; unique external ownership markers avoid xattr sharing errors.
+- Physical identity/system-role exclusion, source observation and the operator CLI are integrated.
+  Installed-wheel qualification and PR review track the current code head; neither substitutes for
+  the separately approved first attended USB trial. No trial is authorized by this coding work.
 
 ## Transaction and state model
 
@@ -380,11 +380,11 @@ the delivery contract or making the first slice depend on content ModelArk does 
 - multiple consumer profiles and automatic destination preparation;
 - treating any delivery or scratch copy as archive durability evidence.
 
-## Safe stopping point
+## Original charter stopping point
 
-This charter and its ledger decisions are the stopping point. No implementation, live deployment,
+At charter approval, this document and its ledger decisions were the stopping point. No implementation, live deployment,
 service restart, Fill action, catalog expansion, or archive/destination byte movement is part of
-this change. The next implementation session starts with domain contracts and expected-red tests
+that change. Implementation subsequently proceeded through the slices below, starting with domain contracts and expected-red tests
 for eligibility, exact gap reporting, and the sealed direct-USB transaction.
 
 ## Development entry and review slices
@@ -397,10 +397,11 @@ Slice 2's private state, process fencing, journal, and trusted adapter boundary 
 [Usable Slice transaction](../usable-slice-transaction.md). Hardware adapters and real-device
 proof remain Slice 3 work; temporary-fixture success does not grant real-device execution authority.
 
-Finish PR #67's renewed bounded review (up to three iterations) at its exact pushed head and let the
-operator merge it. Then branch from that merged charter for implementation. The first test commit
-defines expected-red domain contracts; failures must identify missing behavior rather than broken
-fixtures. Preserve separate test and implementation commits so the contracts remain reviewable.
+PR #67's charter review and Slices 1/2 (PRs #68/#69) are merged. Slice 3 now supplies the direct-USB
+operator assembly; its current-head regression, installed-wheel qualification and bounded PR review
+must finish before the operator's merge decision. The later attended physical trial remains a
+separate authorization gate. Initial domain tests were expected-red contracts: failures had to
+identify missing behavior rather than broken fixtures.
 
 | Slice | Deliverable | Required evidence before advancing |
 |------|-------------|------------------------------------|

--- a/docs/plans/usable-slice-implementation-charter.md
+++ b/docs/plans/usable-slice-implementation-charter.md
@@ -1,8 +1,8 @@
 # Usable Slice implementation charter
 
-Status: Slice 1 merged; Slice 2 transaction implementation in progress
+Status: Slices 1 and 2 merged; Slice 3 direct-USB implementation in progress
 
-Updated: 2026-09-07
+Updated: 2026-09-08
 
 Decision anchors: DEC-081, DEC-098, BOT-006, DEC-101, DEC-102, DEC-103, DEC-104, DEF-041, DEF-043
 
@@ -189,6 +189,29 @@ first slice does not support checkpoint adoption across successor transactions. 
 retains its original seal and progress; changing the approved source set requires a separately
 approved transaction on an empty destination root, leaving earlier output intact. Other seal
 invalidations likewise preserve evidence without promising automatic successor resume.
+
+DEC-123 qualifies automatic directory recovery: a crash between directory creation and durable
+ownership certification can leave ambiguous residue. Such a directory is never adopted or deleted
+automatically, even if empty or at an intended name. Execution refuses for operator intervention.
+Certified objects retain automatic recovery; this exception grants no cleanup or takeover authority.
+
+### Slice 3 implementation gates (2026-09-08)
+
+The Linux primitives and adapters under development are internal, unqualified components, not an
+operator-enabled direct-USB implementation. Disposable tests do not establish real-device safety.
+Before production assembly, resolve these additional gates without weakening DEC-123:
+
+- Launch exclusion (DEC-124): admit only one ModelArk application instance before configuration
+  or startup, regardless of catalog path, port or operation. A competing launch exits immediately;
+  internal attempt/device/archive fences remain. The operator account is trusted, and unrelated
+  processes deliberately substituting destination entries are outside the threat model. This does
+  not relax collision detection, unknown-content preservation, descriptor confinement or DEC-123.
+- Capacity admission: observed free space plus authenticated inode allocation and root-directory
+  allocation detects drift, but does not bound future filesystem-global metadata allocation.
+  A supported filesystem policy must justify the sealed reserve before approval or writes.
+- Physical identity/system-role exclusion, production source attachment observation, operator CLI,
+  integrated recovery and installed-wheel qualification remain unfinished. No attended USB trial
+  is authorized by the current coding work.
 
 ## Transaction and state model
 

--- a/docs/usable-slice-direct.md
+++ b/docs/usable-slice-direct.md
@@ -69,6 +69,34 @@ mount and backing-device checks, effective destination permissions, and exact al
 Changed mount/swap topology or archive-role inputs trigger a fresh full observation immediately.
 No complete `lsblk` scan or archive-config parsing occurs for each megabyte of ordinary streaming.
 
+### Shared adapter evidence boundary (DEC-129)
+
+Filesystem probes preserve their original `OSError` and operation-specific fallback meaning until
+an attachment-aware boundary classifies the failure. Only a proven lost attachment or changed
+identity overrides that fallback. `EIO`, `ENODEV` and `ENXIO` alone are not disappearance proof;
+an inaccessible re-probe cannot turn an unknown failure into a resumable wait. Known policy failures
+(present default ACL, mismatched ownership marker, unsupported features) remain policy refusals.
+Private-state/database failures are not reclassified as USB failures.
+
+| Consumer | Shared contract |
+| --- | --- |
+| Root metadata, superblock, ACL, ownership marker and creation-capability probes | Preserve errno/cause and the specific fallback; classify before a port returns a transaction outcome |
+| Preview capture/verification | Classify while its retained descriptor is alive; failed preview creates no transaction |
+| Source setup and stream reads | Re-probe only the source attachment, then translate into source-side outcomes; never catch consumer work across a yielded stream |
+| Observer, mount-presence checks and capacity mount checks | Read procfs with filesystem byte semantics and a common parser, not default UTF-8 or Unicode whitespace splitting |
+| Protected system directories and swap files | Follow their host-role symlinks to descriptor-backed device/mount identity; attachment roots still reject symlinks |
+
+Protected-role observations must agree with the mount inventory and remain stable across admission.
+Resolved nested system mounts are excluded too. Changes to protected-role targets trigger fresh
+admission during retained checks even if mountinfo itself is unchanged. Genuinely absent optional
+system directories are distinct from dangling or unresolvable symlinks, which refuse. Namespace
+filesystem mount roots may be opaque kernel identities; parsing those unrelated records does not
+make them eligible delivery devices.
+
+Regression coverage injects failures below the probe helpers and checks wait/invalidated outcomes,
+source attribution, no-write preview refusal, and fresh-Start recovery of certified partial work.
+Synthetic device topology plus real disposable IO is still not a physical USB qualification.
+
 Host certificates bind transaction, seal, filesystem, path, token and inode birth identity. Files
 are certified while unnamed, then linked without replacement using the retained inode. Directories
 cannot be created and certified atomically: DEC-123 requires operator intervention for uncertified

--- a/docs/usable-slice-direct.md
+++ b/docs/usable-slice-direct.md
@@ -1,0 +1,122 @@
+# Attended direct USB delivery
+
+Slice 3 joins the domain preview, private transaction engine, local archive reader and Linux USB
+adapter. It never fetches missing content, modifies archives, formats/mounts drives or deploys a
+service. The first attended real-device trial and merge remain separate operator approval gates.
+
+## Operator workflow
+
+Stop any running ModelArk portal before invoking another CLI command (DEC-124). Each command is a
+separate guarded application launch. These examples explain the interface; they do not authorize
+writing an unreviewed physical drive.
+
+```text
+modelark slice preview --catalog /explicit/catalog.sqlite --repo org/model \
+  --destination /mounted/usb --root delivery
+modelark slice approve TRANSACTION --seal REVIEWED_SEAL
+modelark slice start TRANSACTION --destination /mounted/usb \
+  --source drive-a=/mounted/archive/modelark
+modelark slice status TRANSACTION
+modelark slice stop TRANSACTION
+```
+
+Results are JSON. Preview reports the exact closure, gaps, source alternatives, destination identity,
+capacity policy and reserve. A blocked closure creates no transaction and does not probe hardware.
+A ready preview persists private state; approval and Start are separate actions. Global runtime
+overrides are rejected for Slice: the explicit preview catalog is sealed, and transaction state uses
+one operator-wide namespace outside the catalog.
+
+Start runs synchronously until completion, wait or refusal. **Ctrl+C** requests and acknowledges Stop
+while running. A separate `stop` launch records a durable request; if the old attempt already ended,
+the next Start first acknowledges it, and a subsequent explicit Start can resume. No background
+worker/control server is introduced. An exiting CLI releases its process descriptors while retaining
+completed work and the durable reservation. Unreviewed source labels are rejected on resume.
+
+Completion means original-byte SHA-256 verification plus authenticated layout and receipt publication,
+not that every catalog entry is archived, loadable or currently physically verified. Completed status
+is readable without the USB. New transactions require unused output/control paths; previous control
+records are not adopted or automatically cleaned up.
+
+## Identity, IO and recovery
+
+Writable admission requires a direct USB disk/partition with unique filesystem and parent-disk
+identity, at its exact mount root. System/swap disks and their siblings, all registered archive
+identities, stacked/ambiguous devices, aliases and nested mounts are excluded. Filesystem capacity is
+distinct from block-device capacity. Stable capabilities are sealed separately from transient Linux
+mount IDs, which are checked through retained descriptors.
+Each fresh observation must match the retained descriptor's mount ID and attachment path before use.
+
+Descendant IO uses `openat2` confinement with no symlink/mount crossing. A vanished pinned mount waits
+and never redirects writes into an uncovered host mountpoint; the old binding cannot reacquire.
+Fresh Start must prove the sealed identity again. Replacement of a still-attached root refuses.
+Each mutation also passes the existing transaction authority and capacity gate.
+
+Host certificates bind transaction, seal, filesystem, path, token and inode birth identity. Files
+are certified while unnamed, then linked without replacement using the retained inode. Directories
+cannot be created and certified atomically: DEC-123 requires operator intervention for uncertified
+crash residue, without adoption/deletion. DEC-124 trusts the operator account and does not introduce
+adversarial same-account namespace isolation. Ordinary collisions still refuse.
+
+Source reads retain the shared archive fence, refresh the explicit read-only catalog and validate
+filesystem/serial/annex identity. Stored paths are repository-relative. Only a final annex link to the
+sealed key beneath the pinned object store is permitted. No annex command or retrieval runs. Raw,
+bounded ZipNN 0.5 byte-format, StreamZNN and optional zstd streams yield original bytes. The default
+64-MiB limit bounds individual frames/windows, not the native codec's entire working set; oversized
+legacy whole-ZipNN blobs and unsupported modes refuse. Consumer errors are not relabeled as source IO.
+
+## Initial ext4 capacity profile
+
+This deliberately conservative profile is not a general ext4 estimator. Read-only superblock proof
+comes from an opened block-device handle whose device number matches the mounted filesystem. Read
+permission must already exist: there is no automatic sudo or permissive override. An unsupported
+volume refuses; do not reformat an archive or a drive with wanted data to satisfy this profile.
+
+Require 4-KiB blocks/clusters, internal journal, supported inode/xattr capabilities and an initially
+one-block nonindexed mount root. Quotas, bigalloc, EA-inodes, inline data, encryption/casefold/verity,
+large-directory extensions and unknown/newer optional features are excluded. Allowed feature masks:
+compat `0x023c`, incompat `0x22c6`, ro-compat `0x047b`; required masks respectively `0x000c`, `0x0042`,
+`0x000a`. Conflicting GDT/metadata checksums refuse. Large/huge-file features must already exist so the
+transfer cannot change its own sealed profile or admit files beyond the filesystem's limit.
+
+For `B=4096`, `F=artifacts+2` includes control/receipt, `D` is new directories, `N` sums each file's
+rounded payload blocks, and `E` counts planned root-level names including temporary links:
+
+```text
+required bytes  = B × [6N + F + 2D + 6(2 + 4E)]
+required inodes = F + D
+```
+
+The `6N` term conservatively charges data plus five extent-mapping levels; it is not expected actual
+usage. Files get one external xattr block each; new directories get one data and one xattr block.
+Every new directory's complete live name set must fit one block including dot entries and checksum
+tail. Names are limited by UTF-8 bytes, not characters. Root growth separately covers conversion and
+splits, without assuming preexisting dirent slots are compact. Control/receipt serialization includes
+the full sealed plan and largest eligible source records, bounding reserve-number width before seal.
+Thus required capacity can substantially exceed model payload sizes.
+
+Ownership markers exceed the supported inode's inline-xattr capacity. Each external xattr block
+therefore contains a unique token, preventing ext4's shared-xattr optimization from causing duplicate
+charges across different owned inodes. Live inode identities are counted once across publication
+hardlinks. Settled allocation includes xattrs/directories and root growth. Free bytes/inodes must
+reconcile with the sealed baseline; unexplained usage is not hidden inside a tolerance.
+
+The derivation follows kernel [extent trees](https://www.kernel.org/doc/html/latest/filesystems/ext4/ifork.html),
+[directory records](https://www.kernel.org/doc/html/latest/filesystems/ext4/directory.html),
+[non-largedir insertion](https://github.com/torvalds/linux/blob/v6.12/fs/ext4/namei.c#L2352), and
+[feature definitions](https://github.com/torvalds/linux/blob/v6.12/fs/ext4/ext4.h#L1883).
+Media, fragmentation and IO faults may still stop execution; none authorizes a successful receipt.
+
+## Private state and qualification
+
+Private schema v6 atomically stores each plan with its direct-admission capsule. Catalog path,
+filesystem policy, root evidence and budgets are hashed into the sealed destination binding. Legacy
+internal plans remain readable without invented direct-admission evidence. No catalog migration occurs.
+The separate certificate registry uses schema v2: durable identities retain inode number and birth
+time within the sealed disk/filesystem scope, not Linux's transient device number. Trusted v1
+certificates migrate atomically; malformed or ambiguous identities refuse without partial migration.
+This permits the same USB filesystem to return under a different kernel device number while live
+descriptor checks continue to enforce the current attachment.
+
+Tests exercise real disposable IO, certificates, process fences and journals with synthetic physical
+device/free-space observations. They do not prove a completed attended physical USB trial. Deployment,
+that trial and merge are not performed by this implementation work.

--- a/docs/usable-slice-direct.md
+++ b/docs/usable-slice-direct.md
@@ -14,6 +14,11 @@ There is no fallback to path-based IO or older ACL-blind permission emulation. S
 
 ## Operator workflow
 
+This is the retained strict direct-USB interface, selected by preview's explicit `--root`.
+Without `--root`, new previews use the [native folder interface](usable-slice-folders.md):
+`--destination` names the exact new folder, not a mount root. Old approved plans retain their
+sealed policy; Start dispatches by plan version, not by the current destination's filesystem.
+
 Stop any running ModelArk portal before invoking another CLI command (DEC-124). Each command is a
 separate guarded application launch. These examples explain the interface; they do not authorize
 writing an unreviewed physical drive.
@@ -176,7 +181,7 @@ Media, fragmentation and IO faults may still stop execution; none authorizes a s
 
 ## Private state and qualification
 
-Private schema v6 atomically stores each plan with its direct-admission capsule. Catalog path,
+Private schema v8 retains the v6 atomic plan/direct-admission capsule protocol. Catalog path,
 filesystem policy, root evidence and budgets are hashed into the sealed destination binding. Legacy
 internal plans remain readable without invented direct-admission evidence. No catalog migration occurs.
 The separate certificate registry uses schema v2: durable identities retain inode number and birth

--- a/docs/usable-slice-direct.md
+++ b/docs/usable-slice-direct.md
@@ -4,6 +4,14 @@ Slice 3 joins the domain preview, private transaction engine, local archive read
 adapter. It never fetches missing content, modifies archives, formats/mounts drives or deploys a
 service. The first attended real-device trial and merge remain separate operator approval gates.
 
+Direct delivery requires Linux 5.8+ capabilities on x86_64 or aarch64: `openat2` confinement,
+`faccessat2` effective-access checks, and `statx` inode/birth-time/mount identity (with libc `statx`).
+Admission probes the actual interfaces rather than trusting the kernel version string; absent
+syscalls or required identity fields refuse as `FILESYSTEM_UNSUPPORTED`. Backports may supply these
+capabilities, while syscall filters or filesystem limitations may prevent them on newer kernels.
+There is no fallback to path-based IO or older ACL-blind permission emulation. See the Linux
+[`faccessat2` contract](https://man7.org/linux/man-pages/man2/access.2.html).
+
 ## Operator workflow
 
 Stop any running ModelArk portal before invoking another CLI command (DEC-124). Each command is a
@@ -73,7 +81,8 @@ sealed key beneath the pinned object store is permitted. No annex command or ret
 bounded ZipNN 0.5 byte-format, StreamZNN and optional zstd streams yield original bytes. The default
 64-MiB limit bounds individual frames/windows, not the native codec's entire working set; oversized
 legacy whole-ZipNN blobs and unsupported modes refuse. Consumer errors are not relabeled as source IO.
-Explicit source attachments expand `~` and become absolute before observation, without following
+Explicit source attachments expand `~` and become lexically normalized absolute paths (including
+collapsing `..`) before observation, without following
 symlinks; their required location remains `<mount>/modelark`. Layout auditing is iterative, including
 valid deep paths, and still treats unowned files, directories and symlinks as collisions.
 
@@ -88,6 +97,14 @@ read-only user-xattr namespace probe. `nouser_xattr` mounts refuse before sealin
 current DAC/ACL and namespace eligibility, not success under every future LSM policy, permission
 change or media fault; runtime IO errors remain typed refusals. No permission-changing or write probe
 is performed to make a destination pass.
+Default POSIX ACLs are excluded from the initial ownership-marker profile: admission and streaming
+checks require their absence on the destination root, and allocation revalidation requires their
+absence on every authenticated owned directory, including resumed work. This prevents inherited
+ACL xattrs from competing with the ownership marker for ext4's external xattr block. Removing a
+root default ACL does not erase defaults already inherited by children; ModelArk never strips ACLs
+or modifies permissions automatically. Noninherited access ACLs remain subject to effective-access
+checks. Unknown ACL-read errors refuse rather than being treated as absence. See Linux
+[default ACL inheritance](https://man7.org/linux/man-pages/man5/acl.5.html).
 
 Require 4-KiB blocks/clusters, internal journal, supported inode/xattr capabilities and an initially
 one-block nonindexed mount root. Quotas, bigalloc, EA-inodes, inline data, encryption/casefold/verity,
@@ -105,7 +122,9 @@ required inodes = F + D
 ```
 
 The `6N` term conservatively charges data plus five extent-mapping levels; it is not expected actual
-usage. Files get one external xattr block each; new directories get one data and one xattr block.
+usage. Full-path byte limits include both final names and generated `.slice-<token>` temporary
+names, including control and receipt files. Files get one external xattr block each; new directories
+get one data and one xattr block.
 Every new directory's complete live name set must fit one block including dot entries and checksum
 tail. Names are limited by UTF-8 bytes, not characters. Root growth separately covers conversion and
 splits, without assuming preexisting dirent slots are compact. Control/receipt serialization includes

--- a/docs/usable-slice-direct.md
+++ b/docs/usable-slice-direct.md
@@ -45,11 +45,21 @@ identities, stacked/ambiguous devices, aliases and nested mounts are excluded. F
 distinct from block-device capacity. Stable capabilities are sealed separately from transient Linux
 mount IDs, which are checked through retained descriptors.
 Each fresh observation must match the retained descriptor's mount ID and attachment path before use.
+Unrelated loop mounts are not sibling partitions; unresolved protected/system/swap or registered
+archive ancestry still refuses. Loop-backed system roles are not inferred from an unrelated mount.
 
 Descendant IO uses `openat2` confinement with no symlink/mount crossing. A vanished pinned mount waits
 and never redirects writes into an uncovered host mountpoint; the old binding cannot reacquire.
 Fresh Start must prove the sealed identity again. Replacement of a still-attached root refuses.
 Each mutation also passes the existing transaction authority and capacity gate.
+Loss of the backing sysfs block device also waits, even if the disconnected mount remains listed.
+That loss is sticky on the retained tree: reattachment requires a fresh Start, not cached reacquisition.
+
+Full inventory runs at Start, artifact/layout audits, file creation and publication; source opening
+observes before binding and after opening its confined content. Chunk boundaries use retained-root,
+mount and backing-device checks, effective destination permissions, and exact allocation checks.
+Changed mount/swap topology or archive-role inputs trigger a fresh full observation immediately.
+No complete `lsblk` scan or archive-config parsing occurs for each megabyte of ordinary streaming.
 
 Host certificates bind transaction, seal, filesystem, path, token and inode birth identity. Files
 are certified while unnamed, then linked without replacement using the retained inode. Directories
@@ -63,6 +73,9 @@ sealed key beneath the pinned object store is permitted. No annex command or ret
 bounded ZipNN 0.5 byte-format, StreamZNN and optional zstd streams yield original bytes. The default
 64-MiB limit bounds individual frames/windows, not the native codec's entire working set; oversized
 legacy whole-ZipNN blobs and unsupported modes refuse. Consumer errors are not relabeled as source IO.
+Explicit source attachments expand `~` and become absolute before observation, without following
+symlinks; their required location remains `<mount>/modelark`. Layout auditing is iterative, including
+valid deep paths, and still treats unowned files, directories and symlinks as collisions.
 
 ## Initial ext4 capacity profile
 
@@ -70,6 +83,11 @@ This deliberately conservative profile is not a general ext4 estimator. Read-onl
 comes from an opened block-device handle whose device number matches the mounted filesystem. Read
 permission must already exist: there is no automatic sudo or permissive override. An unsupported
 volume refuses; do not reformat an archive or a drive with wanted data to satisfy this profile.
+Admission additionally uses kernel effective-credential/ACL directory write+search checks and a
+read-only user-xattr namespace probe. `nouser_xattr` mounts refuse before sealing. These checks prove
+current DAC/ACL and namespace eligibility, not success under every future LSM policy, permission
+change or media fault; runtime IO errors remain typed refusals. No permission-changing or write probe
+is performed to make a destination pass.
 
 Require 4-KiB blocks/clusters, internal journal, supported inode/xattr capabilities and an initially
 one-block nonindexed mount root. Quotas, bigalloc, EA-inodes, inline data, encryption/casefold/verity,

--- a/docs/usable-slice-direct.md
+++ b/docs/usable-slice-direct.md
@@ -81,9 +81,10 @@ sealed key beneath the pinned object store is permitted. No annex command or ret
 bounded ZipNN 0.5 byte-format, StreamZNN and optional zstd streams yield original bytes. The default
 64-MiB limit bounds individual frames/windows, not the native codec's entire working set; oversized
 legacy whole-ZipNN blobs and unsupported modes refuse. Consumer errors are not relabeled as source IO.
-Explicit source attachments expand `~` and become lexically normalized absolute paths (including
-collapsing `..`) before observation, without following
-symlinks; their required location remains `<mount>/modelark`. Layout auditing is iterative, including
+Source and destination attachments share lexical absolute-path normalization, expanding `~` and
+collapsing `..` without following symlinks. Operator preview/Start, observation and cached-loss
+recovery, descriptor binding and source reads use the same spelling. Descriptor opening still
+enforces no-symlink confinement; source locations remain `<mount>/modelark`. Layout auditing is iterative, including
 valid deep paths, and still treats unowned files, directories and symlinks as collisions.
 
 ## Initial ext4 capacity profile
@@ -126,7 +127,9 @@ usage. Full-path byte limits include both final names and generated `.slice-<tok
 names, including control and receipt files. Files get one external xattr block each; new directories
 get one data and one xattr block.
 Every new directory's complete live name set must fit one block including dot entries and checksum
-tail. Names are limited by UTF-8 bytes, not characters. Root growth separately covers conversion and
+tail. Names are limited by strict UTF-8 bytes, not characters; unsupported encodings in final paths,
+temporary paths or components return `DESTINATION_LAYOUT_UNSUPPORTED`. This output rule does not
+change host attachment encoding or sealed relative-path serialization. Root growth separately covers conversion and
 splits, without assuming preexisting dirent slots are compact. Control/receipt serialization includes
 the full sealed plan and largest eligible source records, bounding reserve-number width before seal.
 Thus required capacity can substantially exceed model payload sizes.

--- a/docs/usable-slice-folders.md
+++ b/docs/usable-slice-folders.md
@@ -1,0 +1,149 @@
+# Folder projection
+
+Approved scope: DEC-130 and [the implementation scope](plans/folder-projection-scope.md).
+Native ext4 and separate FAT32 session execution are implemented. Disposable kernel-vfat writer,
+public-flow and alias qualification passed. PR review and real-source/USB acceptance remain
+outstanding. This is not a deployed or physical-media-qualified release.
+
+## Operator workflow
+
+Without `--root`, `--destination` names the **exact new output folder**. Its parent must exist.
+Preview makes no destination objects; it records a plan in private host state. Approval does not
+start copying. These examples describe the interface, not authorization to write a real device.
+
+```text
+modelark slice preview --catalog /explicit/catalog.sqlite --repo org/model \
+  --destination /home/operator/exports/demo
+modelark slice approve TRANSACTION --seal REVIEWED_SEAL
+modelark slice start TRANSACTION --destination /home/operator/exports/demo \
+  --source drive-a=/mounted/archive/modelark
+modelark slice status TRANSACTION
+modelark slice stop TRANSACTION
+```
+
+Review the exact closure, target, profile, advisory capacity and seal before approval. Start creates
+the child exclusively; an existing empty directory is not adoptable. Payload, staging, control and
+receipt files stay inside that child. Host-private journals remain in the existing fixed
+`~/.local/state/modelark/slice` namespace. No siblings are owned, cleaned up or overwritten.
+
+The existing application-launch singleton is unchanged. Stop a running portal before invoking the
+CLI. Start is synchronous; Ctrl+C acknowledges Stop while the attempt lease is still retained.
+Native fresh Start can resume only the same authenticated transaction/root. A pending Stop from an
+earlier launch must first be acknowledged; a subsequent explicit Start permits resume.
+
+Explicit preview `--root` retains the [strict direct-USB interface](usable-slice-direct.md), where
+`--destination` is the mount root. Existing seals keep their original policy. Start selects the
+adapter from the sealed plan, not a flag that can weaken old approvals.
+
+## Native eligibility and protection
+
+`native-ext4-folder.v1` supports qualified case-sensitive Linux ext4 folders, including ordinary
+system-backed encrypted/LVM storage with an unambiguous single-parent block chain. It does not
+require raw-device reads or exclusive use of the filesystem. The actual host test covered ext4
+on LUKS/LVM; that does not qualify every device-mapper target or kernel/filesystem combination.
+
+Admission checks stable backing identities, mount uniqueness, retained parent inode/birth identity,
+effective permissions, directory flags and xattr access. Runtime operations require the native
+confinement, durable certificates, unnamed staging, no-replace hardlink publication and flush
+interfaces. Missing capabilities refuse; no overwriting or path-based fallback is used.
+
+Initially refused: bind/duplicate mount aliases, symlink ancestors, nested output mounts,
+ambiguous/multi-parent storage, registered archive backing devices, casefold/fscrypt/inline-data
+directories, remote/FUSE storage, XFS and exFAT. A FAT32 type string never selects the ext4 writer.
+
+Protected subtrees are `/boot`, `/usr`, `/etc`, `/var`, `/bin`, `/sbin`, `/lib`, `/lib64`, `/dev`,
+`/proc`, `/sys`, `/run` and `/root`; ModelArk state/config/cache/share directories, the selected
+catalog and actual runtime code are protected too. File roles protect the file, not every sibling
+in its parent. Output cannot contain or be contained by a protected role. System-disk identity
+alone does not prohibit an ordinary home/data folder. Pseudo-filesystem role classification needs
+current inode/mount evidence, not persistent birth identity; owned destination certificates still
+require birth identity.
+
+The parent must be owned by the operator or root. Non-owner-writable parents require sticky-bit
+protection. A default ACL must preserve owner rwx; creating the owned root with mode 0700 masks
+inherited non-owner permissions. The implementation never changes existing ownership, modes or
+ACLs to force admission. This assumes a trusted operator account, not protection from malicious
+code running as that same UID or root.
+
+## Ownership, capacity and recovery
+
+`FolderTarget` seals the canonical filesystem scope, existing parent identity and intended child.
+It excludes free-space observations and the not-yet-created root identity. `NativePlan` adds the
+approved closure, backing/admission evidence, catalog, advisory snapshot and metadata allowance
+under `modelark.slice.native-transaction.v1`. `FolderReview` remains non-executable; parsing it
+cannot produce source approval, ownership or execution authority.
+
+Durable claims compare canonical same-filesystem paths: exact and ancestor/descendant roots
+conflict; disjoint native siblings do not. Stopped claims persist. Cross-profile checks also
+exclude a legacy whole-device claim that intersects a native backing identity. Authority is
+checked inside the durable claim transaction as well as before it; changing a target ID cannot
+erase an earlier overlapping path claim. FAT32 uses its separate case-insensitive claim rules;
+actual-driver alias checks passed for the narrowly admitted mount/name profile.
+
+Start revalidates parent, protected roles and authority, records root-creation intent, exclusively
+creates the child, and certifies its identity. Uncertain residue after interrupted certification
+is left untouched, never adopted or deleted. Resume must reprove created-root and descendant
+ownership. A missing/replaced certified root is not permission to create another one.
+
+Space is shared and **not reserved**. Metadata allowance includes serialized evidence and a
+per-object estimate; fresh checks compare available bytes/inodes with remaining requirements.
+Sibling allocation or parent-directory growth does not invalidate identity. Allocation inside
+the owned tree is still audited. Another process can consume space after any check.
+
+Destination ENOSPC/EDQUOT returns `waiting_destination` and ends that attempt. After restoring
+space, a fresh Start rebuilds authenticated allocation and may resume. Conclusive attachment
+loss/replacement takes precedence over a space diagnosis. Private-journal/certificate persistence
+errors are not relabeled as destination capacity waits or fabricated durable outcomes. There is
+no automatic uncertain-object cleanup.
+
+Mapped storage is conservatively re-observed at recheck boundaries to detect mapping changes;
+this can cost more than the direct-device fast path. Performance qualification for large mapped
+deliveries remains separate from the tiny correctness smoke test.
+
+Completion requires original-byte hashes, exact owned layout, required flushes and successful
+receipt/host-state publication. Receipts identify the native folder profile, shared-space policy
+and authenticated resume. A delivery receipt is not newly verified archive-copy evidence, nor
+proof of arbitrary power-loss survival. Source readers and clean-anchor/archive fences are
+unchanged; synthetic fixture success does not qualify a real source.
+
+## Compatibility
+
+Private store schema **8** upgrades prior development schemas while preserving legacy seals,
+approvals, journals and claims. It prevents older binaries from interpreting new executable
+folder authority and FAT's irrevocable consumed-attempt field. This is private Slice state,
+not a catalog schema migration. Legacy
+`TransferPlan` v1–v3 serialization, receipts and strict device/capacity policy remain unchanged;
+golden tests pin their seal hashes against reviewed commit `6fd87c3`. Unknown/mixed envelopes
+refuse before destination observation or writer authority. No public flag weakens an old seal.
+
+## FAT32 session workflow
+
+The same Preview → Approve → Start commands select the FAT32 adapter for a vfat parent;
+the selected observer must still admit the destination. There is no fallback to the native writer.
+The approved intent binds the exact path/backing, not parent inode continuity across launches.
+Start retains fresh live parent/object descriptors and exclusively creates the new child.
+
+Only direct USB with explicit FAT32 evidence and the tested name settings is admitted:
+`codepage=437,iocharset=iso8859-1,utf8,shortname=mixed`, current-user ownership, and masks excluding
+non-owner writes. Non-ASCII/short-alias spellings and unsupported full layouts refuse. Each file
+must fit FAT32's 2^32−1-byte limit. The application does not remount or change permissions.
+Protected paths still include all of `/run`, so `/run/media/...` is currently refused too.
+
+FAT32 has **one attempt, no resume**. Once the host claim is consumed, Stop, Ctrl+C, source or
+capacity waits and failures require a new intent and different output folder. Residue remains
+untouched. A known capacity shortfall before claim consumption is retryable. The media report
+says export verified, not host transaction committed; committed host status supplies that evidence.
+
+## Remaining gates
+
+- Gate C: finish qualification of the implemented `fat32-folder-session.v1`. The operator's first
+  disposable-image run passed no-replace/flush, original-byte/report delivery, 30 interruption
+  boundaries and sibling preservation. The updated [attended script](plans/fat32-session-protocol.md)
+  additionally exercises exact/case/numbered-short-alias parent checks and public Preview/Approve/
+  Start with synthetic source/backing evidence. The operator reported all additions passed in
+  `/tmp/modelark-fat32-qualification-ru4sibe7`; the planned disposable-image gate is complete.
+- Gate D: separately authorized real-source reconciliation and attended USB acceptance. The
+  existing FAT32 USB has not been qualified or written by this implementation.
+
+No reformat, permission rewriting, live deployment, archive reconciliation or deliberate media
+removal was performed as part of the native implementation.

--- a/docs/usable-slice-folders.md
+++ b/docs/usable-slice-folders.md
@@ -61,7 +61,10 @@ require birth identity.
 
 The parent must be owned by the operator or root. Non-owner-writable parents require sticky-bit
 protection. A default ACL must preserve owner rwx; creating the owned root with mode 0700 masks
-inherited non-owner permissions. The implementation never changes existing ownership, modes or
+inherited non-owner permissions. Both inherited ACL values plus the ownership marker and overhead
+must fit a conservative single-block xattr budget; oversized ACLs and 1 KiB blocks refuse before
+root creation. This check does not reserve space against quota or other security attributes.
+The implementation never changes existing ownership, modes or
 ACLs to force admission. This assumes a trusted operator account, not protection from malicious
 code running as that same UID or root.
 
@@ -125,7 +128,8 @@ Start retains fresh live parent/object descriptors and exclusively creates the n
 
 Only direct USB with explicit FAT32 evidence and the tested name settings is admitted:
 `codepage=437,iocharset=iso8859-1,utf8,shortname=mixed`, current-user ownership, and masks excluding
-non-owner writes. Non-ASCII/short-alias spellings and unsupported full layouts refuse. Each file
+non-owner writes while preserving owner directory rwx and file rw. Non-ASCII/short-alias spellings
+and unsupported full layouts refuse. Each file
 must fit FAT32's 2^32−1-byte limit. The application does not remount or change permissions.
 Protected paths still include all of `/run`, so `/run/media/...` is currently refused too.
 

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -1,12 +1,16 @@
 # Usable Slice transaction core
 
 Slice 2 adds private durable approval, device ownership, source-use gates, and recoverable
-publication orchestration. It remains an **internal API with no hardware adapter or CLI/portal
-entry point**. Do not use the test destination as a real USB adapter. Slice 1's domain approval
+publication orchestration. The core remains an internal port-based API; Slice 3's
+[attended direct-USB assembly](usable-slice-direct.md) supplies real adapters and CLI entry points.
+Do not use the test destination as a real USB adapter. Slice 1's domain approval
 still has no execution authority; a separately reviewed transaction seal binds destination
 evidence, and the destination port must validate that evidence before any writes.
 
 ## Authority and lifetime
+
+Direct admission uses private schema v6's optional sealed capsule (DEC-125). Older internal plans
+retain their semantics without invented hardware evidence; the attempt contract below is unchanged.
 
 `TransferPlan(proposal, destination_binding, metadata_reserve_bytes=...)` freezes the domain
 proposal, destination binding and explicit metadata capacity reservation
@@ -44,7 +48,7 @@ Reader operations use deferred transactions rather than requesting the writer re
 writers have a bounded SQLite busy wait and return typed `STATE_BUSY` on exhaustion. The private
 database handle retains SQLite rollback-recovery capability even for reader operations, so a hot
 journal from a dead writer is recovered rather than exposed as a read-only-database error.
-Private schema version 5 transactionally upgrades development version-1/2/3/4 databases while
+Private schema version 6 transactionally upgrades development version-1/2/3/4/5 databases while
 preserving plans, pending stops, reservations and journal heads. It adds a nullable live-attempt
 token and an acknowledged-stop serial; every pending legacy request remains unacknowledged,
 including on stopped rows which may contain a newer request. Legacy `process_seen` and `activation_serial`

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -197,6 +197,17 @@ implemented by arbitrary callbacks. Slice 3 must supply and test:
   adapter calls; device-bound reads/writes and atomic no-replace publication.
 - Actual device disappearance/replacement handling and the operator entry point.
 
+DEC-123 qualifies the crash-inside-create contract for directories: creation and certification are
+separate operations. An uncertified directory left in that interval requires operator intervention;
+the adapter must neither adopt nor delete it. Certified-object recovery remains automatic. This
+exception does not authorize cleanup, takeover, formatting, or an unattended real-device trial.
+
+DEC-124 additionally requires application-wide exclusion at launch, before CLI configuration or
+portal startup. It is not a replacement for these internal transaction/device/archive fences.
+Every separate CLI invocation is a launch and refuses while another instance runs, even for query
+or status; controls within the running portal remain available. The operator account is trusted,
+without adding protection against unrelated processes deliberately mutating delivery paths.
+
 The test adapter uses temporary files and simulated device/ownership evidence (test-only xattrs).
 It proves the orchestration's protocol ordering and recovery across port boundaries, not a real
 USB filesystem's identity, ownership-certificate or durability guarantees. Real mounts, live

--- a/docs/usable-slice-transaction.md
+++ b/docs/usable-slice-transaction.md
@@ -9,7 +9,10 @@ evidence, and the destination port must validate that evidence before any writes
 
 ## Authority and lifetime
 
-Direct admission uses private schema v6's optional sealed capsule (DEC-125). Older internal plans
+Direct admission retains private schema v6's optional sealed capsule (DEC-125), now in schema v8.
+The [native folder profile](usable-slice-folders.md) uses a separate tagged executable envelope,
+folder-scoped ownership and shared capacity. The direct-device behavior described below remains
+the legacy profile's policy, not a requirement that a native folder own its drive. Older internal plans
 retain their semantics without invented hardware evidence; the attempt contract below is unchanged.
 
 `TransferPlan(proposal, destination_binding, metadata_reserve_bytes=...)` freezes the domain
@@ -48,8 +51,11 @@ Reader operations use deferred transactions rather than requesting the writer re
 writers have a bounded SQLite busy wait and return typed `STATE_BUSY` on exhaustion. The private
 database handle retains SQLite rollback-recovery capability even for reader operations, so a hot
 journal from a dead writer is recovered rather than exposed as a read-only-database error.
-Private schema version 6 transactionally upgrades development version-1/2/3/4/5 databases while
-preserving plans, pending stops, reservations and journal heads. It adds a nullable live-attempt
+Private schema version 8 transactionally upgrades development version-1/2/3/4/5/6/7 databases while
+preserving plans, pending stops, reservations and journal heads. Version 7 fences older binaries
+from executable folder plans and cross-profile claims; it does not change legacy seals or add
+catalog columns. Version 8 adds FAT's irrevocable consumed-attempt field; native/legacy plans do
+not consume it. The earlier authority migration adds a nullable live-attempt
 token and an acknowledged-stop serial; every pending legacy request remains unacknowledged,
 including on stopped rows which may contain a newer request. Legacy `process_seen` and `activation_serial`
 columns are retained for compatibility but are never read as execution authority. Older owners

--- a/modelark/cli.py
+++ b/modelark/cli.py
@@ -171,7 +171,11 @@ def cmd_recompute(args):
 
 def cmd_serve(args):
     from modelark.web import server
-    server.serve(port=args.port, open_browser=not args.no_open, resume=args.resume)
+    permit = getattr(args, "_instance_permit", None)
+    if permit is None:
+        server.serve(port=args.port, open_browser=not args.no_open, resume=args.resume)
+    else:
+        server._serve_in_instance(permit, port=args.port, open_browser=not args.no_open, resume=args.resume)
 
 
 def cmd_fetch(args):
@@ -623,6 +627,12 @@ def cmd_drive_reconcile(args):
 
 
 def main(argv=None):
+    from modelark.instance import launch
+    with launch() as permit:
+        return _main(argv, permit)
+
+
+def _main(argv, permit):
     p = argparse.ArgumentParser(prog="modelark", description="Catalog & verify open model weights.")
     p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     p.add_argument("--data-dir", type=Path,
@@ -821,6 +831,7 @@ def main(argv=None):
     rec.set_defaults(func=cmd_drive_reconcile)
 
     args = p.parse_args(argv)
+    args._instance_permit = permit
     if args.data_dir is not None or args.state_dir is not None:
         db.configure(args.data_dir, args.state_dir)
     if args.config is not None:

--- a/modelark/cli.py
+++ b/modelark/cli.py
@@ -642,6 +642,8 @@ def _main(argv, permit):
     p.add_argument("--config", type=Path,
                    help="wishlist/config YAML (default: user config, source checkout, packaged default)")
     sub = p.add_subparsers(dest="cmd", required=True)
+    from modelark.slice.cli import add_subparser
+    add_subparser(sub)
 
     d = sub.add_parser("discover", help="record HF model metadata in the catalog")
     d.add_argument("--repo", action="append", help="explicit repo id (repeatable)")
@@ -832,6 +834,8 @@ def _main(argv, permit):
 
     args = p.parse_args(argv)
     args._instance_permit = permit
+    if args.cmd == "slice" and any(value is not None for value in (args.data_dir, args.state_dir, args.config)):
+        p.error("slice commands use explicit/sealed inputs; --data-dir, --state-dir and --config do not apply")
     if args.data_dir is not None or args.state_dir is not None:
         db.configure(args.data_dir, args.state_dir)
     if args.config is not None:

--- a/modelark/instance.py
+++ b/modelark/instance.py
@@ -1,0 +1,52 @@
+"""One ModelArk launch per host Linux network namespace, before app side effects.
+
+The fixed abstract address is independent of user, catalog, state directory and
+portal port. The kernel owns lifetime: no pidfiles, stale-owner takeover, waits,
+or process-local reentrancy. Fork descendants retain the descriptor until they
+close it or exit; exec children do not inherit it unless explicitly passed.
+Existing archive/device/attempt fences remain defense in depth.
+"""
+from contextlib import contextmanager
+import errno
+import os
+import socket
+import sys
+
+
+_ADDRESS = "\0modelark-instance-v1"
+
+
+class _LaunchPermit:
+    """Internal single-use CLI-to-portal handoff, not a second launch exemption."""
+
+    def __init__(self, held):
+        self._held = held
+        self._pid = os.getpid()
+        self._server_used = False
+
+    def consume_server(self):
+        if (self._pid != os.getpid() or self._held.fileno() < 0 or self._server_used):
+            raise SystemExit("invalid or already used ModelArk launch permit")
+        self._server_used = True
+
+
+@contextmanager
+def launch():
+    """Reject an additional CLI/direct portal launch immediately, before parsing."""
+    if sys.platform != "linux":
+        raise SystemExit("ModelArk instance exclusion requires Linux abstract Unix sockets")
+    held = None
+    try:
+        try:
+            held = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            held.bind(_ADDRESS)
+        except OSError as exc:
+            if exc.errno == errno.EADDRINUSE:
+                raise SystemExit(
+                    "ModelArk is already running; close the existing instance before launching another."
+                ) from None
+            raise SystemExit(f"cannot establish ModelArk instance exclusion: {exc}") from None
+        yield _LaunchPermit(held)
+    finally:
+        if held is not None:
+            held.close()

--- a/modelark/slice/authority.py
+++ b/modelark/slice/authority.py
@@ -26,7 +26,8 @@ TRANSITIONS = {
 
 def refusal_state(code):
     return {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
-            "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}.get(
+            "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source",
+            "DESTINATION_CAPACITY_WAIT": "waiting_destination"}.get(
                 code, "invalidated" if code.startswith("DESTINATION_") else "failed")
 
 

--- a/modelark/slice/capacity.py
+++ b/modelark/slice/capacity.py
@@ -14,6 +14,7 @@ import uuid
 
 from . import domain as d
 from .linux import require_no_default_acl
+from .paths import utf8_size
 from .transaction import DestinationBinding, TransferPlan, TransferRefusal
 
 
@@ -92,10 +93,7 @@ def _free(tree):
 
 
 def _record_size(name):
-    try:
-        size = len(name.encode('utf-8'))
-    except UnicodeError:
-        _refuse('non-UTF-8 directory name', 'DESTINATION_LAYOUT_UNSUPPORTED')
+    size = utf8_size(name)
     if size > 255:
         _refuse('component exceeds ext4 byte limit', 'DESTINATION_LAYOUT_UNSUPPORTED')
     return (8 + size + 3) // 4 * 4
@@ -105,14 +103,14 @@ def layout(file_paths):
     """Bound every new directory's complete live namespace, including dual publication links."""
     directories, names = set(), {}
     for path in file_paths:
-        if not d._path(path) or len(path.encode('utf-8')) >= 4096:
+        if not d._path(path) or utf8_size(path) >= 4096:
             _refuse('invalid or overlong path', 'DESTINATION_LAYOUT_UNSUPPORTED')
         value = PurePosixPath(path)
         # Session._op publishes from a sibling .slice-<32 hex token> for artifacts,
         # control and receipt alike. A short final basename does not bound that path.
         temporary_name = '.slice-' + '0' * 32
         temporary = str(value.parent / temporary_name)
-        if len(temporary.encode('utf-8')) >= 4096:
+        if utf8_size(temporary) >= 4096:
             _refuse('generated temporary path exceeds ext4 byte limit', 'DESTINATION_LAYOUT_UNSUPPORTED')
         for component in value.parts:
             _record_size(component)

--- a/modelark/slice/capacity.py
+++ b/modelark/slice/capacity.py
@@ -13,6 +13,7 @@ import struct
 import uuid
 
 from . import domain as d
+from .linux import require_no_default_acl
 from .transaction import DestinationBinding, TransferPlan, TransferRefusal
 
 
@@ -107,12 +108,18 @@ def layout(file_paths):
         if not d._path(path) or len(path.encode('utf-8')) >= 4096:
             _refuse('invalid or overlong path', 'DESTINATION_LAYOUT_UNSUPPORTED')
         value = PurePosixPath(path)
+        # Session._op publishes from a sibling .slice-<32 hex token> for artifacts,
+        # control and receipt alike. A short final basename does not bound that path.
+        temporary_name = '.slice-' + '0' * 32
+        temporary = str(value.parent / temporary_name)
+        if len(temporary.encode('utf-8')) >= 4096:
+            _refuse('generated temporary path exceeds ext4 byte limit', 'DESTINATION_LAYOUT_UNSUPPORTED')
         for component in value.parts:
             _record_size(component)
         for parent in value.parents:
             if str(parent) != '.':
                 directories.add(str(parent))
-        names.setdefault(str(value.parent), []).extend([value.name, '.slice-' + '0' * 32])
+        names.setdefault(str(value.parent), []).extend([value.name, temporary_name])
     for directory in directories:
         value = PurePosixPath(directory)
         names.setdefault(str(value.parent), []).append(value.name)
@@ -255,6 +262,8 @@ def verify(tree, evidence, proposal, caps, adapter=None, *, refresh_volume=True)
                         if tree.identity(marker_fd) != tree.identity(fd):
                             _refuse('object replaced during allocation proof', 'OUTPUT_COLLISION')
                         _require_unique_marker(marker_fd, info.token)
+                        if info.kind == 'directory':
+                            require_no_default_acl(marker_fd)
                     finally:
                         os.close(marker_fd)
                     if info.kind == 'directory' and os.fstat(fd).st_size > BLOCK:

--- a/modelark/slice/capacity.py
+++ b/modelark/slice/capacity.py
@@ -5,14 +5,17 @@ Only read-only probes are used; there is no sudo, formatting, or probing by writ
 """
 from dataclasses import asdict
 import array
+import errno
 import fcntl
 import os
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 import stat
 import struct
 import uuid
 
 from . import domain as d
+from .io_errors import probe_io
+from .host_observation import parse_mounts, read_fs_text
 from .linux import require_no_default_acl
 from .paths import utf8_size
 from .transaction import DestinationBinding, TransferPlan, TransferRefusal
@@ -46,6 +49,7 @@ def parse_superblock(data, expected_uuid):
             'journal_inode': u32(0xe0)}
 
 
+@probe_io('DESTINATION_CAPACITY_UNPROVEN', 'read-only volume feature proof unavailable')
 def _volume(tree, evidence):
     device = os.fstat(tree.fd).st_dev
     path = f'/dev/block/{os.major(device)}:{os.minor(device)}'
@@ -60,27 +64,26 @@ def _volume(tree, evidence):
             result = parse_superblock(os.pread(fd, 1024, 1024), evidence.fs_uuid)
         finally:
             os.close(fd)
-        matching = [line for line in Path('/proc/self/mountinfo').read_text().splitlines()
-                    if line.split()[0] == str(tree.mount_id)]
+        matching = [mount for mount in parse_mounts(read_fs_text('/proc/self/mountinfo'))
+                    if mount.mount_id == tree.mount_id]
         if len(matching) != 1:
             _refuse('mounted feature evidence unavailable')
-        left, right = matching[0].split(' - ', 1)
-        options = left.split()[5].split(',') + right.split()[2].split(',')
+        options = matching[0].options
         if any('quota' in option or option.startswith('jqfmt=') for option in options):
             _refuse('quota-enabled mounts are outside the supported profile')
         if 'ro' in options:
             _refuse('read-only destination')
         return result
-    except (OSError, ValueError, IndexError) as exc:
+    except TransferRefusal:
+        raise
+    except (ValueError, IndexError) as exc:
         _refuse('read-only volume feature proof unavailable (no privilege escalation): ' + str(exc))
 
 
+@probe_io('DESTINATION_CAPACITY_UNPROVEN', 'root inode feature proof unavailable')
 def _root_metadata(tree):
     flags = array.array('l', [0])
-    try:
-        fcntl.ioctl(tree.fd, 0x80086601, flags, True)  # FS_IOC_GETFLAGS on supported 64-bit ABIs
-    except OSError as exc:
-        _refuse('root inode feature proof unavailable: ' + str(exc))
+    fcntl.ioctl(tree.fd, 0x80086601, flags, True)  # FS_IOC_GETFLAGS on supported 64-bit ABIs
     return os.fstat(tree.fd).st_size, flags[0]
 
 
@@ -209,11 +212,14 @@ def metadata_reserve_bytes(proposal, binding, caps, store_root):
     return caps['reserve_bytes']
 
 
+@probe_io('DESTINATION_ALLOCATION_UNPROVEN', 'ownership marker proof unavailable')
 def _require_unique_marker(fd, token):
     from .destination import OWNER_XATTR, owner_marker
     try:
         valid = os.getxattr(fd, OWNER_XATTR) == owner_marker(token)
-    except OSError:
+    except OSError as exc:
+        if exc.errno != errno.ENODATA:
+            raise
         valid = False
     if not valid:
         _refuse('external unique ownership marker required', 'DESTINATION_ALLOCATION_UNPROVEN')

--- a/modelark/slice/capacity.py
+++ b/modelark/slice/capacity.py
@@ -1,0 +1,271 @@
+"""Conservative direct-USB ext4 admission, not a promise of fault-free media.
+
+See docs/usable-slice-direct.md for the supported feature mask and allocation derivation.
+Only read-only probes are used; there is no sudo, formatting, or probing by writing files.
+"""
+from dataclasses import asdict
+import array
+import fcntl
+import os
+from pathlib import Path, PurePosixPath
+import stat
+import struct
+import uuid
+
+from . import domain as d
+from .transaction import DestinationBinding, TransferPlan, TransferRefusal
+
+
+POLICY = 'modelark.ext4.direct.v1'
+BLOCK = 4096
+INDEX = 0x1000
+
+
+def _refuse(detail, code='DESTINATION_CAPACITY_UNPROVEN'):
+    raise TransferRefusal(code, detail)
+
+
+def parse_superblock(data, expected_uuid):
+    if len(data) != 1024:
+        _refuse('short ext4 superblock')
+    u32 = lambda offset: struct.unpack_from('<I', data, offset)[0]
+    u16 = lambda offset: struct.unpack_from('<H', data, offset)[0]
+    compat, incompat, ro = u32(0x5c), u32(0x60), u32(0x64)
+    observed_uuid = str(uuid.UUID(bytes=bytes(data[0x68:0x78])))
+    if (u16(0x38) != 0xef53 or u32(0x4c) != 1 or u32(0x18) != 2 or u32(0x1c) != 2
+            or observed_uuid.casefold() != expected_uuid.casefold()
+            or compat & ~0x023c or compat & 0x000c != 0x000c
+            or incompat & ~0x22c6 or incompat & 0x0042 != 0x0042
+            or ro & ~0x047b or ro & 0x000a != 0x000a or ro & 0x410 == 0x410
+            or u32(0xe4) != 0 or u32(0xe0) == 0 or u16(0x58) not in {128, 256, 512, 1024}):
+        _refuse('volume is outside the supported 4-KiB ext4 feature profile')
+    return {'uuid': observed_uuid, 'block_size': BLOCK, 'inode_size': u16(0x58),
+            'compat': compat, 'incompat': incompat & ~4, 'ro_compat': ro,
+            'journal_inode': u32(0xe0)}
+
+
+def _volume(tree, evidence):
+    device = os.fstat(tree.fd).st_dev
+    path = f'/dev/block/{os.major(device)}:{os.minor(device)}'
+    try:
+        # /dev/block is a kernel-managed alias. Inspect the opened handle BEFORE reading;
+        # neither a regular file nor a different block device can supply this evidence.
+        fd = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NONBLOCK)
+        try:
+            info = os.fstat(fd)
+            if not stat.S_ISBLK(info.st_mode) or info.st_rdev != device:
+                _refuse('superblock descriptor differs from mounted device')
+            result = parse_superblock(os.pread(fd, 1024, 1024), evidence.fs_uuid)
+        finally:
+            os.close(fd)
+        matching = [line for line in Path('/proc/self/mountinfo').read_text().splitlines()
+                    if line.split()[0] == str(tree.mount_id)]
+        if len(matching) != 1:
+            _refuse('mounted feature evidence unavailable')
+        left, right = matching[0].split(' - ', 1)
+        options = left.split()[5].split(',') + right.split()[2].split(',')
+        if any('quota' in option or option.startswith('jqfmt=') for option in options):
+            _refuse('quota-enabled mounts are outside the supported profile')
+        if 'ro' in options:
+            _refuse('read-only destination')
+        return result
+    except (OSError, ValueError, IndexError) as exc:
+        _refuse('read-only volume feature proof unavailable (no privilege escalation): ' + str(exc))
+
+
+def _root_metadata(tree):
+    flags = array.array('l', [0])
+    try:
+        fcntl.ioctl(tree.fd, 0x80086601, flags, True)  # FS_IOC_GETFLAGS on supported 64-bit ABIs
+    except OSError as exc:
+        _refuse('root inode feature proof unavailable: ' + str(exc))
+    return os.fstat(tree.fd).st_size, flags[0]
+
+
+def _free(tree):
+    value = os.fstatvfs(tree.fd)
+    free, inodes = value.f_bavail * value.f_frsize, min(value.f_favail, value.f_ffree)
+    if free < 0 or inodes < 0:
+        _refuse('free block/inode counts unavailable')
+    return free, inodes
+
+
+def _record_size(name):
+    try:
+        size = len(name.encode('utf-8'))
+    except UnicodeError:
+        _refuse('non-UTF-8 directory name', 'DESTINATION_LAYOUT_UNSUPPORTED')
+    if size > 255:
+        _refuse('component exceeds ext4 byte limit', 'DESTINATION_LAYOUT_UNSUPPORTED')
+    return (8 + size + 3) // 4 * 4
+
+
+def layout(file_paths):
+    """Bound every new directory's complete live namespace, including dual publication links."""
+    directories, names = set(), {}
+    for path in file_paths:
+        if not d._path(path) or len(path.encode('utf-8')) >= 4096:
+            _refuse('invalid or overlong path', 'DESTINATION_LAYOUT_UNSUPPORTED')
+        value = PurePosixPath(path)
+        for component in value.parts:
+            _record_size(component)
+        for parent in value.parents:
+            if str(parent) != '.':
+                directories.add(str(parent))
+        names.setdefault(str(value.parent), []).extend([value.name, '.slice-' + '0' * 32])
+    for directory in directories:
+        value = PurePosixPath(directory)
+        names.setdefault(str(value.parent), []).append(value.name)
+    for directory in directories:
+        if 24 + 12 + sum(_record_size(name) for name in names.get(directory, [])) > BLOCK:
+            _refuse('consumer directory fanout exceeds one-block profile: ' + directory,
+                    'DESTINATION_LAYOUT_UNSUPPORTED')
+    return sorted(directories), names
+
+
+def _entries(tree):
+    result = {}
+    for name in sorted(os.listdir(tree.fd)):
+        _record_size(name)
+        fd = tree.open(name, os.O_PATH | os.O_NOFOLLOW)
+        try:
+            result[name] = list(tree.identity(fd)[1:])
+        finally:
+            os.close(fd)
+    return result
+
+
+def _payload_bounds(proposal, evidence, store_root):
+    # Use the largest possible reserve's decimal representation. The real reserve cannot
+    # lengthen these serialized controls; plan/destination hashes have fixed-length encodings.
+    binding = DestinationBinding(evidence.device_id, evidence.fs_uuid, 'direct-v1:' + '0' * 64,
+                                 evidence.available_bytes)
+    plan = TransferPlan(proposal, binding,
+                        metadata_reserve_bytes=evidence.available_bytes - proposal.total_bytes)
+    tx = '0' * 32
+    files = [{'path': str(PurePosixPath(proposal.spec.destination_root) / a.repo_id / a.rfilename),
+              'size': a.size_bytes, 'sha256': a.sha256,
+              'source': asdict(max(a.sources, key=lambda source: len(d._json(asdict(source)))))}
+             for a in proposal.closure]
+    control = d._json({'transaction': tx, 'seal': plan.seal, 'store': str(store_root),
+                      'destination': asdict(binding)})
+    return len(control), len(d._json(plan.receipt(tx, files)))
+
+
+def _attachment(tree, evidence):
+    if (evidence.mount_id != tree.mount_id or str(evidence.mount_path) != str(tree.path)):
+        _refuse('observation belongs to a different retained attachment', 'DESTINATION_CHANGED')
+
+
+def capture(tree, evidence, proposal, store_root):
+    tree.check()
+    _attachment(tree, evidence)
+    volume = _volume(tree, evidence)
+    size, flags = _root_metadata(tree)
+    if (evidence.block_size != BLOCK or evidence.name_max < 255 or size != BLOCK
+            or flags & INDEX or flags & (0x10 | 0x20 | 0x800 | 0x10000000)):
+        _refuse('initial root must be one ordinary nonindexed ext4 directory block')
+    root_entries = _entries(tree)
+    top = PurePosixPath(proposal.spec.destination_root).parts[0]
+    if top in root_entries or '.modelark-slice-owner' in root_entries:
+        _refuse('delivery root/control must not exist', 'OUTPUT_COLLISION')
+    file_paths = [str(PurePosixPath(proposal.spec.destination_root) / a.repo_id / a.rfilename)
+                  for a in proposal.closure]
+    file_paths += ['.modelark-slice-owner', str(PurePosixPath(proposal.spec.destination_root)
+                                             / '.modelark-slice-receipt.json')]
+    directories, names = layout(file_paths)
+    control, receipt = _payload_bounds(proposal, evidence, store_root)
+    sizes = [a.size_bytes for a in proposal.closure] + [control, receipt]
+    if any(size > (2**32 - 1) * BLOCK for size in sizes):
+        _refuse('file exceeds conservative ext4 logical block limit', 'DESTINATION_LAYOUT_UNSUPPORTED')
+    blocks = sum((size + BLOCK - 1) // BLOCK for size in sizes)
+    root_blocks = 6 * (2 + 4 * len(names.get('.', [])))
+    required = BLOCK * (6 * blocks + len(file_paths) + 2 * len(directories) + root_blocks)
+    free, inodes = _free(tree)
+    if free != evidence.available_bytes:
+        _refuse('free space changed during preview', 'DESTINATION_CAPACITY_CHANGED')
+    if required > free:
+        _refuse(f'conservative profile requires {required} bytes; available {free}',
+                'DESTINATION_CAPACITY_INSUFFICIENT')
+    required_inodes = len(file_paths) + len(directories)
+    if required_inodes > inodes:
+        _refuse('insufficient free inodes', 'DESTINATION_INODES_INSUFFICIENT')
+    return {'policy': POLICY, 'hardware_profile': evidence.profile, 'filesystem': volume,
+            'root_identity': list(tree.identity(tree.fd)[1:]), 'root_entries': root_entries,
+            'root_flags': flags, 'root_max_bytes': BLOCK * (2 + 4 * len(names.get('.', []))),
+            'available_bytes': free, 'free_inodes': inodes, 'required_inodes': required_inodes,
+            'reserve_bytes': required - proposal.total_bytes, 'file_paths': sorted(file_paths),
+            'directory_paths': directories}
+
+
+def metadata_reserve_bytes(proposal, binding, caps, store_root):
+    if caps.get('policy') != POLICY or type(caps.get('reserve_bytes')) is not int:
+        _refuse('unsupported sealed capacity policy')
+    return caps['reserve_bytes']
+
+
+def _require_unique_marker(fd, token):
+    from .destination import OWNER_XATTR, owner_marker
+    try:
+        valid = os.getxattr(fd, OWNER_XATTR) == owner_marker(token)
+    except OSError:
+        valid = False
+    if not valid:
+        _refuse('external unique ownership marker required', 'DESTINATION_ALLOCATION_UNPROVEN')
+
+
+def verify(tree, evidence, proposal, caps, adapter=None):
+    """Run from DestinationPort.check, never from BoundTree.verify (which would recurse)."""
+    tree.check()
+    _attachment(tree, evidence)
+    if (caps.get('policy') != POLICY or evidence.profile != caps['hardware_profile']
+            or list(tree.identity(tree.fd)[1:]) != caps['root_identity']
+            or _volume(tree, evidence) != caps['filesystem']):
+        _refuse('sealed filesystem/capability evidence changed', 'DESTINATION_CHANGED')
+    size, flags = _root_metadata(tree)
+    if size > caps['root_max_bytes'] or flags & ~INDEX != caps['root_flags'] & ~INDEX:
+        _refuse('root growth/flags outside sealed profile', 'DESTINATION_CHANGED')
+    current = _entries(tree)
+    for name, identity in caps['root_entries'].items():
+        if current.get(name) != identity:
+            _refuse('unrelated root entry changed: ' + name, 'OUTPUT_COLLISION')
+    for name in current.keys() - caps['root_entries'].keys():
+        info = adapter.inspect(name) if adapter else None
+        if not info or info.token is None:
+            _refuse('unowned root entry: ' + name, 'OUTPUT_COLLISION')
+    owned = 0
+    if adapter is not None:
+        # Count unique inode identities, not hardlink names or creation history.
+        identities = set()
+        with adapter._connection() as con:
+            paths = con.execute('SELECT DISTINCT path FROM certificates WHERE tx=? AND seal=? AND device=?'
+                                ' AND filesystem=? AND mount=?', adapter._scope).fetchall()
+        for (path,) in paths:
+            info = adapter.inspect(path)
+            if info is not None:
+                if info.token is None:
+                    _refuse('certificate no longer authenticates object', 'OUTPUT_COLLISION')
+                fd = tree.open(path, os.O_PATH | os.O_NOFOLLOW)
+                try:
+                    identities.add(tree.identity(fd))
+                    # fgetxattr does not accept O_PATH; inspect through a confined ordinary
+                    # descriptor, retaining the same authenticated inode identity.
+                    marker_fd = tree.open(path, os.O_RDONLY | os.O_NONBLOCK)
+                    try:
+                        if tree.identity(marker_fd) != tree.identity(fd):
+                            _refuse('object replaced during allocation proof', 'OUTPUT_COLLISION')
+                        _require_unique_marker(marker_fd, info.token)
+                    finally:
+                        os.close(marker_fd)
+                    if info.kind == 'directory' and os.fstat(fd).st_size > BLOCK:
+                        _refuse('consumer directory outgrew sealed profile', 'DESTINATION_CHANGED')
+                finally:
+                    os.close(fd)
+        owned = len(identities)
+    free, inodes = _free(tree)
+    if inodes + owned != caps['free_inodes']:
+        _refuse('unexplained inode consumption', 'DESTINATION_CAPACITY_CHANGED')
+    if owned > caps['required_inodes'] or inodes < caps['required_inodes'] - owned:
+        _refuse('sealed inode budget exhausted', 'DESTINATION_INODES_INSUFFICIENT')
+    if adapter is None and free != caps['available_bytes']:
+        _refuse('free space changed before transfer', 'DESTINATION_CAPACITY_CHANGED')

--- a/modelark/slice/capacity.py
+++ b/modelark/slice/capacity.py
@@ -214,13 +214,13 @@ def _require_unique_marker(fd, token):
         _refuse('external unique ownership marker required', 'DESTINATION_ALLOCATION_UNPROVEN')
 
 
-def verify(tree, evidence, proposal, caps, adapter=None):
+def verify(tree, evidence, proposal, caps, adapter=None, *, refresh_volume=True):
     """Run from DestinationPort.check, never from BoundTree.verify (which would recurse)."""
     tree.check()
     _attachment(tree, evidence)
     if (caps.get('policy') != POLICY or evidence.profile != caps['hardware_profile']
             or list(tree.identity(tree.fd)[1:]) != caps['root_identity']
-            or _volume(tree, evidence) != caps['filesystem']):
+            or (refresh_volume and _volume(tree, evidence) != caps['filesystem'])):
         _refuse('sealed filesystem/capability evidence changed', 'DESTINATION_CHANGED')
     size, flags = _root_metadata(tree)
     if size > caps['root_max_bytes'] or flags & ~INDEX != caps['root_flags'] & ~INDEX:

--- a/modelark/slice/cli.py
+++ b/modelark/slice/cli.py
@@ -1,0 +1,70 @@
+"""Minimal attended Slice commands; explicit inputs and JSON results only.
+
+The operator is imported only after parsing and launch exclusion. No catalog,
+Store, device observation, or global runtime configuration is opened here.
+"""
+import argparse
+import importlib
+import json
+import re
+
+
+class _Attachments(argparse.Action):
+    def __call__(self, parser, namespace, value, option_string=None):
+        label, separator, path = value.partition("=")
+        if (not separator or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]*", label)
+                or not path.strip() or path != path.strip() or "\0" in path):
+            raise argparse.ArgumentError(self, "expected LABEL=ARCHIVE with nonempty label and archive path")
+        sources = dict(getattr(namespace, self.dest, None) or {})
+        if label in sources:
+            raise argparse.ArgumentError(self, f"duplicate source label: {label}")
+        sources[label] = path
+        setattr(namespace, self.dest, sources)
+
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser("slice", help="preview and execute attended direct Slice delivery")
+    commands = parser.add_subparsers(dest="slice_command", required=True)
+    preview = commands.add_parser("preview", help="review explicit catalog, repositories and USB destination")
+    preview.add_argument("--catalog", required=True, help="explicit source catalog path (read-only)")
+    preview.add_argument("--destination", required=True, help="attached destination mount root")
+    preview.add_argument("--repo", required=True, action="append", help="repository ID (repeatable)")
+    preview.add_argument("--root", required=True, help="new relative destination delivery root")
+    approval = commands.add_parser("approve", help="approve the exact reviewed transaction seal")
+    approval.add_argument("transaction")
+    approval.add_argument("--seal", required=True)
+    start = commands.add_parser("start", help="run synchronously until completion or an attended wait/refusal")
+    start.add_argument("transaction")
+    start.add_argument("--destination", required=True, help="attached destination mount root")
+    start.add_argument("--source", action=_Attachments, default=None, metavar="LABEL=ARCHIVE",
+                       help="explicit archive attachment (repeatable; no retrieval)")
+    for name in ("status", "stop"):
+        command = commands.add_parser(name, help=f"{name} of a private Slice transaction")
+        command.add_argument("transaction")
+    parser.set_defaults(func=dispatch)
+    return parser
+
+
+def dispatch(args):
+    from .domain import SliceRefusal
+    from .transaction import TransferRefusal
+    operator = importlib.import_module("modelark.slice.operator")
+    try:
+        if args.slice_command == "preview":
+            result = operator.preview(args.catalog, args.destination, tuple(args.repo), args.root)
+        elif args.slice_command == "approve":
+            result = operator.approve(args.transaction, args.seal)
+        elif args.slice_command == "start":
+            result = operator.start(args.transaction, args.destination, args.source or {})
+        elif args.slice_command == "status":
+            result = operator.status(args.transaction)
+        elif args.slice_command == "stop":
+            result = operator.stop(args.transaction)
+        else:
+            raise ValueError("unknown Slice command")
+    except (SliceRefusal, TransferRefusal) as exc:
+        print(json.dumps({"ok": False, "code": exc.code, "detail": exc.detail}, sort_keys=True, allow_nan=False))
+        raise SystemExit(1) from None
+    print(json.dumps(result, sort_keys=True, allow_nan=False))
+    if result.get("ok") is False:
+        raise SystemExit(1)

--- a/modelark/slice/cli.py
+++ b/modelark/slice/cli.py
@@ -23,19 +23,20 @@ class _Attachments(argparse.Action):
 
 
 def add_subparser(subparsers):
-    parser = subparsers.add_parser("slice", help="preview and execute attended direct Slice delivery")
+    parser = subparsers.add_parser("slice", help="preview and execute attended Slice delivery")
     commands = parser.add_subparsers(dest="slice_command", required=True)
-    preview = commands.add_parser("preview", help="review explicit catalog, repositories and USB destination")
+    preview = commands.add_parser("preview", help="review explicit catalog, repositories and output folder")
     preview.add_argument("--catalog", required=True, help="explicit source catalog path (read-only)")
-    preview.add_argument("--destination", required=True, help="attached destination mount root")
+    preview.add_argument("--destination", required=True,
+                         help="exact new ext4 or FAT32 output folder (FAT32: one attempt, no resume)")
     preview.add_argument("--repo", required=True, action="append", help="repository ID (repeatable)")
-    preview.add_argument("--root", required=True, help="new relative destination delivery root")
+    preview.add_argument("--root", help="legacy direct-USB mode: --destination is mount root, --root is new relative delivery root")
     approval = commands.add_parser("approve", help="approve the exact reviewed transaction seal")
     approval.add_argument("transaction")
     approval.add_argument("--seal", required=True)
     start = commands.add_parser("start", help="run synchronously until completion or an attended wait/refusal")
     start.add_argument("transaction")
-    start.add_argument("--destination", required=True, help="attached destination mount root")
+    start.add_argument("--destination", required=True, help="approved output folder (legacy USB plan: mount root)")
     start.add_argument("--source", action=_Attachments, default=None, metavar="LABEL=ARCHIVE",
                        help="explicit archive attachment (repeatable; no retrieval)")
     for name in ("status", "stop"):

--- a/modelark/slice/decoding.py
+++ b/modelark/slice/decoding.py
@@ -1,0 +1,164 @@
+"""Retrieval-free original-byte streams with bounded codec allocations.
+
+The bound limits individual stored/decoded ZipNN frames and zstd windows, not
+the native codecs' total working set. No tensor input, whole-file scratch, or
+unbounded ``read()`` is accepted. Large legacy whole-ZipNN files fail closed.
+"""
+from __future__ import annotations
+
+import struct
+
+from .transaction import TransferRefusal
+
+
+def _refuse(code="SOURCE_DECODE_INVALID", detail=""):
+    raise TransferRefusal(code, detail)
+
+
+def _exact(stream, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = stream.read(size - len(data))
+        if not chunk:
+            _refuse(detail="truncated container")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def _zipnn_frame(stream, prefix, limit, remaining, stored_length=None):
+    header = prefix + _exact(stream, 32 - len(prefix))
+    original = int.from_bytes(header[16:24], "little")
+    stored = int.from_bytes(header[24:32], "little")
+    if original > limit or stored > limit or original > remaining:
+        _refuse("SOURCE_DECODE_LIMIT", "ZipNN frame exceeds configured or artifact bound")
+    # Only the byte-lossless, non-streaming 0.5 header layout used by this
+    # archive writer is supported. Tensor/shape, delta and lossy modes cannot
+    # be safely inferred from catalog SourceEvidence and must never reach C.
+    if (header[:4] != b"ZN\x00\x05" or header[8] != 1
+            or any(header[9:14]) or header[15] not in (1, 2, 4, 5, 6)
+            or header[7] not in (0, 1) or header[6] not in (0, 1)
+            or header[5] not in (10, 220)):
+        _refuse("SOURCE_DECODE_UNSUPPORTED", "unsupported ZipNN header")
+    if (stored < 32 or original == 0 or (stored_length is not None and stored != stored_length)
+            or header[14] > 26):
+        _refuse(detail="inconsistent ZipNN frame header")
+    from zipnn import ZipNN
+    blob = header + _exact(stream, stored - 32)
+    try:
+        decoded = ZipNN(input_format="byte", threads=1).decompress(blob)
+    except Exception as exc:
+        raise TransferRefusal("SOURCE_DECODE_INVALID", "ZipNN decoder refused frame") from exc
+    if not isinstance(decoded, (bytes, bytearray, memoryview)) or len(decoded) != original:
+        _refuse(detail="ZipNN decoded size differs from header")
+    return bytes(decoded)
+
+
+def _chunks(stream, compressed, expected, limit):
+    if not compressed:
+        while chunk := stream.read(min(limit, 1 << 20)):
+            yield chunk
+        return
+    prefix = stream.read(5)
+    if prefix == b"SZNN\x01":
+        remaining = expected
+        while length := stream.read(4):
+            if len(length) != 4:
+                _refuse(detail="truncated StreamZNN frame length")
+            size = struct.unpack("<I", length)[0]
+            if size > limit:
+                _refuse("SOURCE_DECODE_LIMIT", "stored StreamZNN frame exceeds bound")
+            if size < 32:
+                _refuse(detail="short StreamZNN frame")
+            data = _zipnn_frame(stream, b"", limit, remaining, size)
+            remaining -= len(data)
+            yield data
+    elif prefix.startswith(b"ZN"):
+        yield _zipnn_frame(stream, prefix, limit, expected)
+        if stream.read(1):
+            _refuse(detail="trailing whole-ZipNN data")
+    elif prefix.startswith(b"\x28\xb5\x2f\xfd"):
+        try:
+            import zstandard as zstd
+        except ImportError as exc:
+            raise TransferRefusal("SOURCE_DECODE_UNSUPPORTED", "zstandard is not installed") from exc
+        # zstd's maximum regenerated block is 128 KiB. Feeding no more
+        # than limit/128KiB input bytes bounds even maximally dense RLE output
+        # before Python gets the opportunity to check its length.
+        if limit < 128 << 10:
+            _refuse("SOURCE_DECODE_LIMIT", "zstd requires a 128 KiB decoding bound")
+        header = prefix
+        while True:
+            try:
+                params = zstd.get_frame_parameters(header)
+                break
+            except zstd.ZstdError:
+                if len(header) >= 18:
+                    _refuse(detail="invalid zstd header")
+                header += _exact(stream, 1)
+        if (params.window_size > limit
+                or params.content_size not in (zstd.CONTENTSIZE_UNKNOWN, zstd.CONTENTSIZE_ERROR)
+                and params.content_size > expected):
+            _refuse("SOURCE_DECODE_LIMIT", "zstd window/content exceeds bound")
+        decoder = zstd.ZstdDecompressor(max_window_size=max(1, limit // 1024)).decompressobj()
+        pending = header
+        try:
+            while pending:
+                data = decoder.decompress(pending)
+                if len(data) > limit:
+                    _refuse("SOURCE_DECODE_LIMIT", "zstd output block exceeds bound")
+                if data:
+                    yield data
+                if decoder.eof:
+                    if decoder.unused_data or stream.read(1):
+                        _refuse(detail="trailing/concatenated zstd data")
+                    break
+                pending = stream.read(max(1, limit // (128 << 10)))
+            if not decoder.eof:
+                _refuse(detail="truncated zstd frame")
+        except zstd.ZstdError as exc:
+            raise TransferRefusal("SOURCE_DECODE_INVALID", "zstd decoder refused frame") from exc
+    else:
+        _refuse("SOURCE_DECODE_UNSUPPORTED", "unknown compressed container")
+
+
+class _OriginalStream:
+    def __init__(self, stream, compressed, expected, limit, check):
+        self._chunks = iter(_chunks(stream, compressed, expected, limit))
+        self._pending = b""
+        self._offset = 0
+        self._total = 0
+        self._expected, self._limit, self._check = expected, limit, check
+        self._done = False
+
+    def read(self, size=-1):
+        if type(size) is not int or size < 0 or size > self._limit:
+            _refuse("SOURCE_DECODE_LIMIT", "explicit bounded read size required")
+        self._check()
+        if not size or self._done:
+            return b""
+        if self._offset == len(self._pending):
+            try:
+                self._pending = next(self._chunks)
+                self._offset = 0
+            except StopIteration:
+                self._done = True
+                if self._total != self._expected:
+                    _refuse(detail="decoded size differs from sealed original size")
+                return b""
+            self._total += len(self._pending)
+            if self._total > self._expected:
+                _refuse("SOURCE_DECODE_LIMIT", "decoded total exceeds sealed original size")
+        end = min(self._offset + size, len(self._pending))
+        data = self._pending[self._offset:end]
+        self._offset = end
+        self._check()
+        return data
+
+
+def original_stream(stream, *, compressed, expected_bytes, max_decode_bytes=64 << 20,
+                    check=lambda: None):
+    """Wrap an already confined binary stream; caller retains descriptor ownership."""
+    if (type(expected_bytes) is not int or expected_bytes < 0
+            or type(max_decode_bytes) is not int or max_decode_bytes <= 0):
+        raise ValueError("nonnegative original size and positive decoding bound required")
+    return _OriginalStream(stream, compressed, expected_bytes, max_decode_bytes, check)

--- a/modelark/slice/destination.py
+++ b/modelark/slice/destination.py
@@ -286,6 +286,22 @@ class UsbDestination:
             raise TransferRefusal("DESTINATION_CHANGED")
         if any(isinstance(n, bool) or not isinstance(n, int) or n < 0 for n in (allocated, required_bytes)):
             raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN")
+        actual = self._audit_allocated()
+        root_delta = self._blocks(os.fstat(self.tree.fd)) - self._root_blocks
+        if actual != allocated or root_delta < 0:
+            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN", "owned allocation differs")
+        available = self._available()
+        if available + actual + root_delta != binding.available_bytes:
+            raise TransferRefusal("DESTINATION_CAPACITY_CHANGED", "unexplained free-space change")
+        if (required_bytes > binding.available_bytes or actual + root_delta > required_bytes
+                or available < required_bytes - actual - root_delta):
+            raise TransferRefusal("DESTINATION_CAPACITY_INSUFFICIENT")
+
+    def _audit_allocated(self):
+        return self._audit_allocation()[0]
+
+    def _audit_allocation(self):
+        """Authenticate owned allocation/link counts independently of capacity policy."""
         seen, links, actual = set(), {}, 0
         with self._connection() as con:
             paths = con.execute("SELECT DISTINCT path FROM certificates WHERE tx=? AND seal=? AND device=?"
@@ -307,15 +323,7 @@ class UsbDestination:
                 continue
         if any(count != total for count, total in links.values()):
             raise TransferRefusal("OUTPUT_COLLISION", "unexplained hardlinks to delivery objects")
-        root_delta = self._blocks(os.fstat(self.tree.fd)) - self._root_blocks
-        if actual != allocated or root_delta < 0:
-            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN", "owned allocation differs")
-        available = self._available()
-        if available + actual + root_delta != binding.available_bytes:
-            raise TransferRefusal("DESTINATION_CAPACITY_CHANGED", "unexplained free-space change")
-        if (required_bytes > binding.available_bytes or actual + root_delta > required_bytes
-                or available < required_bytes - actual - root_delta):
-            raise TransferRefusal("DESTINATION_CAPACITY_INSUFFICIENT")
+        return actual, len(seen)
 
     @_port_io
     def inspect(self, path):

--- a/modelark/slice/destination.py
+++ b/modelark/slice/destination.py
@@ -23,6 +23,7 @@ import sqlite3
 import stat
 
 from . import linux
+from .io_errors import ProbeFailure, classify_io
 from .transaction import ObjectInfo, TransferRefusal
 
 
@@ -168,18 +169,13 @@ class UsbDestination:
                     raise TransferRefusal("DESTINATION_CHANGED", "certificate root differs")
                 self._root_blocks = row[5]
 
+    def _recheck_attachment(self):
+        self.tree.check()
+
     def _io_refusal(self, exc):
-        # Re-observe the pinned attachment before classifying an IO failure. A proven
-        # unplug is an attended wait; an attached-but-replaced root remains changed.
-        try:
-            self.tree.check()
-        except TransferRefusal as refusal:
-            return refusal
-        except OSError:
-            pass  # Without absence proof, preserve the original failure as terminal IO.
         code = "OUTPUT_COLLISION" if isinstance(exc, FileExistsError) or exc.errno in {
             errno.ELOOP, errno.EXDEV, errno.ENOTDIR} else "DESTINATION_IO_FAILED"
-        return TransferRefusal(code, str(exc))
+        return classify_io(exc, self._recheck_attachment, TransferRefusal(code, str(exc)))
 
     @contextmanager
     def _connection(self, *, write=False):
@@ -223,7 +219,7 @@ class UsbDestination:
         try:
             token = decode_owner_marker(os.getxattr(fd, OWNER_XATTR))
         except OSError as exc:
-            if exc.errno in {errno.ENODATA, errno.EOPNOTSUPP}:
+            if exc.errno == errno.ENODATA:
                 return None
             raise
         if token is None:
@@ -377,7 +373,7 @@ class UsbDestination:
                 fd = os.open(".", os.O_TMPFILE | os.O_RDWR | os.O_CLOEXEC, 0o600, dir_fd=parent)
             except OSError as exc:
                 if exc.errno in {errno.EOPNOTSUPP, errno.EINVAL, errno.EISDIR, errno.ENOSYS}:
-                    raise TransferRefusal("DESTINATION_UNPROVEN", "O_TMPFILE is required") from exc
+                    raise ProbeFailure(exc, "DESTINATION_UNPROVEN", "O_TMPFILE is required") from exc
                 raise
             try:
                 os.setxattr(fd, OWNER_XATTR, owner_marker(token), os.XATTR_CREATE)

--- a/modelark/slice/destination.py
+++ b/modelark/slice/destination.py
@@ -1,0 +1,374 @@
+"""INTERNAL / UNQUALIFIED Linux destination adapter; not a production entry point.
+
+DEC-124 requires one ModelArk application instance and trusts the operator account. Deliberate
+namespace substitution by unrelated same-account processes is outside that boundary: mkdirat
+cannot atomically return a descriptor and unlinkat cannot condition deletion on inode identity.
+Descriptor confinement alone does not solve those adversarial windows. Production assembly must
+hold the launch and transaction authorities, prove device eligibility, and supply a supported
+filesystem capacity policy before exposing this internal port. The host registry is trusted.
+Files use O_TMPFILE so a crash before certification never exposes an uncertified file.
+Directories interrupted before certification are deliberately left for operator intervention.
+
+st_blocks includes an inode's data and charged xattr/directory blocks. It does not account for
+every filesystem-global metadata/journal allocation. The strict free-space equation therefore
+refuses unexplained drift; it is not a universal proof of future filesystem metadata cost.
+"""
+from contextlib import contextmanager
+import errno
+import json
+import os
+from pathlib import PurePosixPath
+import sqlite3
+import stat
+
+from . import linux
+from .transaction import ObjectInfo, TransferRefusal
+
+
+OWNER_XATTR = "user.modelark.slice-owner"
+
+
+class UsbDestination:
+    """Unqualified DestinationPort for disposable tests and further safety design only."""
+
+    def __init__(self, tree, binding, store, tx):
+        self.tree, self.binding, self.store, self.tx = tree, binding, store, tx
+        plan = store.load(tx)
+        if plan.destination != binding:
+            raise TransferRefusal("DESTINATION_CHANGED")
+        self.seal = plan.seal
+        self._scope = (tx, self.seal, binding.device_id, binding.filesystem_id, binding.mount_id)
+        tree.check()
+        self._root_identity = tuple(tree.identity(tree.fd))
+        root = store.root
+        info = root.lstat()
+        if (not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid()
+                or stat.S_IMODE(info.st_mode) & 0o077):
+            raise TransferRefusal("STATE_CORRUPT", "certificate directory is not private")
+        self._database = root / "destination-certificates.sqlite"
+        try:
+            fd = os.open(self._database, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+        except FileExistsError:
+            pass
+        else:
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+            try:
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        info = self._database.lstat()
+        if (not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid()
+                or stat.S_IMODE(info.st_mode) & 0o077 or info.st_nlink != 1):
+            raise TransferRefusal("STATE_CORRUPT", "unsafe certificate database")
+        with self._connection(write=True) as con:
+            version = con.execute("PRAGMA user_version").fetchone()[0]
+            if version not in (0, 1):
+                raise TransferRefusal("STATE_CORRUPT", "unknown certificate schema")
+            con.execute("CREATE TABLE IF NOT EXISTS roots (tx TEXT PRIMARY KEY, seal TEXT NOT NULL,"
+                        "device TEXT NOT NULL, filesystem TEXT NOT NULL, mount TEXT NOT NULL,"
+                        "identity TEXT NOT NULL, blocks INTEGER NOT NULL)")
+            con.execute("CREATE TABLE IF NOT EXISTS certificates (tx TEXT NOT NULL, seal TEXT NOT NULL,"
+                        "device TEXT NOT NULL, filesystem TEXT NOT NULL, mount TEXT NOT NULL,"
+                        "path TEXT NOT NULL, token TEXT NOT NULL, identity TEXT NOT NULL, kind TEXT NOT NULL,"
+                        "PRIMARY KEY(tx,seal,device,filesystem,mount,path,identity))")
+            con.execute("PRAGMA user_version=1")
+            row = con.execute("SELECT seal,device,filesystem,mount,identity,blocks FROM roots WHERE tx=?",
+                              (tx,)).fetchone()
+            identity = json.dumps(self._root_identity)
+            if row is None:
+                self._root_blocks = self._blocks(os.fstat(tree.fd))
+                con.execute("INSERT INTO roots VALUES(?,?,?,?,?,?,?)", (*self._scope, identity, self._root_blocks))
+            else:
+                if row[:5] != (*self._scope[1:], identity):
+                    raise TransferRefusal("DESTINATION_CHANGED", "certificate root differs")
+                self._root_blocks = row[5]
+
+    @contextmanager
+    def _connection(self, *, write=False):
+        con = None
+        try:
+            con = sqlite3.connect(self._database, timeout=0)
+            con.execute("PRAGMA synchronous=FULL")
+            con.execute("BEGIN IMMEDIATE" if write else "BEGIN")
+            yield con
+            con.commit()
+        except sqlite3.OperationalError as exc:
+            if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                raise TransferRefusal("STATE_BUSY", "destination certificate registry") from exc
+            raise TransferRefusal("STATE_CORRUPT", "destination certificate registry") from exc
+        except sqlite3.DatabaseError as exc:
+            raise TransferRefusal("STATE_CORRUPT", "destination certificate registry") from exc
+        finally:
+            if con is not None:
+                con.close()
+
+    @staticmethod
+    def _blocks(info):
+        if not isinstance(info.st_blocks, int) or info.st_blocks < 0:
+            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN")
+        return info.st_blocks * 512
+
+    @staticmethod
+    def _path(path, *, root=False):
+        if root and path == ".":
+            return path
+        if not isinstance(path, str):
+            raise TransferRefusal("OUTPUT_COLLISION", "non-canonical destination path")
+        value = PurePosixPath(path)
+        if (not value.parts or value.is_absolute()
+                or str(value) != path or any(p in {".", ".."} for p in value.parts)):
+            raise TransferRefusal("OUTPUT_COLLISION", "non-canonical destination path")
+        return path
+
+    def _token(self, fd, path):
+        identity = json.dumps(tuple(self.tree.identity(fd)))
+        try:
+            token = os.getxattr(fd, OWNER_XATTR).decode("ascii")
+        except (OSError, UnicodeDecodeError):
+            return None
+        kind = "directory" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
+        with self._connection() as con:
+            found = con.execute("SELECT 1 FROM certificates WHERE tx=? AND seal=? AND device=?"
+                                " AND filesystem=? AND mount=? AND path=? AND token=? AND identity=? AND kind=?",
+                                (*self._scope, path, token, identity, kind)).fetchone()
+        return token if found else None
+
+    def _certify(self, fd, path, token, kind):
+        identity = json.dumps(tuple(self.tree.identity(fd)))
+        with self._connection(write=True) as con:
+            con.execute("INSERT OR IGNORE INTO certificates VALUES(?,?,?,?,?,?,?,?,?)",
+                        (*self._scope, path, token, identity, kind))
+
+    @contextmanager
+    def _parent(self, path):
+        self.tree.check()
+        self._path(path)
+        with self.tree.parent(path) as (fd, name):
+            parent = str(PurePosixPath(path).parent)
+            if parent == ".":
+                if tuple(self.tree.identity(fd)) != self._root_identity:
+                    raise TransferRefusal("DESTINATION_CHANGED")
+            elif self._token(fd, parent) is None:
+                raise TransferRefusal("OUTPUT_COLLISION", parent)
+            # A valid immediate parent must not be reached through foreign ancestors.
+            for ancestor in PurePosixPath(parent).parents:
+                if str(ancestor) == ".":
+                    continue
+                other = self.tree.open(str(ancestor), os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    if self._token(other, str(ancestor)) is None:
+                        raise TransferRefusal("OUTPUT_COLLISION", str(ancestor))
+                finally:
+                    os.close(other)
+            yield fd, name
+
+    @contextmanager
+    def _owned(self, path, token=None, *, write=False):
+        self._path(path)
+        self.tree.check()
+        fd = self.tree.open(path, (os.O_WRONLY | os.O_APPEND if write else os.O_RDONLY) | os.O_NONBLOCK)
+        try:
+            info = os.fstat(fd)
+            actual = self._token(fd, path)
+            if (actual is None or (token is not None and token != actual)
+                    or not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode))):
+                raise TransferRefusal("OUTPUT_COLLISION", path)
+            yield fd
+        finally:
+            os.close(fd)
+
+    def _available(self):
+        info = os.fstatvfs(self.tree.fd)
+        return info.f_bavail * info.f_frsize
+
+    def check(self, binding, allocated, required_bytes):
+        self.tree.check()
+        if binding != self.binding:
+            raise TransferRefusal("DESTINATION_CHANGED")
+        if any(isinstance(n, bool) or not isinstance(n, int) or n < 0 for n in (allocated, required_bytes)):
+            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN")
+        seen, links, actual = set(), {}, 0
+        with self._connection() as con:
+            paths = con.execute("SELECT DISTINCT path FROM certificates WHERE tx=? AND seal=? AND device=?"
+                                " AND filesystem=? AND mount=?", self._scope).fetchall()
+        for (path,) in paths:
+            try:
+                with self._owned(path) as fd:
+                    identity = tuple(self.tree.identity(fd))
+                    info = os.fstat(fd)
+                    if stat.S_ISREG(info.st_mode):
+                        count, previous_links = links.get(identity, (0, info.st_nlink))
+                        if previous_links != info.st_nlink:
+                            raise TransferRefusal("OUTPUT_COLLISION", "inode link count changed during audit")
+                        links[identity] = (count + 1, info.st_nlink)
+                    if identity not in seen:
+                        actual += self._blocks(info)
+                        seen.add(identity)
+            except FileNotFoundError:
+                continue
+        if any(count != total for count, total in links.values()):
+            raise TransferRefusal("OUTPUT_COLLISION", "unexplained hardlinks to delivery objects")
+        root_delta = self._blocks(os.fstat(self.tree.fd)) - self._root_blocks
+        if actual != allocated or root_delta < 0:
+            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN", "owned allocation differs")
+        available = self._available()
+        if available + actual + root_delta != binding.available_bytes:
+            raise TransferRefusal("DESTINATION_CAPACITY_CHANGED", "unexplained free-space change")
+        if (required_bytes > binding.available_bytes or actual + root_delta > required_bytes
+                or available < required_bytes - actual - root_delta):
+            raise TransferRefusal("DESTINATION_CAPACITY_INSUFFICIENT")
+
+    def inspect(self, path):
+        self._path(path)
+        self.tree.check()
+        try:
+            with self.tree.parent(path) as (parent, name):
+                info = os.stat(name, dir_fd=parent, follow_symlinks=False)
+            if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+                return ObjectInfo("unknown", None, self._blocks(info))
+            fd = self.tree.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        except FileNotFoundError:
+            return None
+        try:
+            info = os.fstat(fd)
+            kind = "directory" if stat.S_ISDIR(info.st_mode) else "file"
+            return ObjectInfo(kind, self._token(fd, path), self._blocks(info))
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _validate_token(token):
+        if (not isinstance(token, str) or len(token) != 32
+                or any(c not in "0123456789abcdef" for c in token)):
+            raise TransferRefusal("OUTPUT_COLLISION", "invalid creation token")
+
+    def create_directory(self, path, token):
+        self._validate_token(token)
+        with self._parent(path) as (parent, name):
+            try:
+                os.mkdir(name, mode=0o700, dir_fd=parent)
+            except FileExistsError as exc:
+                raise TransferRefusal("OUTPUT_COLLISION", "existing or uncertified directory: " + path) from exc
+            fd = self.tree.open(path, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.setxattr(fd, OWNER_XATTR, token.encode(), os.XATTR_CREATE)
+                os.fsync(fd)
+                os.fsync(parent)
+                self._certify(fd, path, token, "directory")
+            finally:
+                os.close(fd)
+
+    def _temporary(self, path, token):
+        self._validate_token(token)
+        self._path(path)
+        if PurePosixPath(path).name != ".slice-" + token:
+            raise TransferRefusal("OUTPUT_COLLISION", "not the operation's temporary name")
+
+    def create_file(self, path, token):
+        self._temporary(path, token)
+        with self._parent(path) as (parent, name):
+            try:
+                fd = os.open(".", os.O_TMPFILE | os.O_RDWR | os.O_CLOEXEC, 0o600, dir_fd=parent)
+            except OSError as exc:
+                raise TransferRefusal("DESTINATION_UNPROVEN", "O_TMPFILE is required") from exc
+            try:
+                os.setxattr(fd, OWNER_XATTR, token.encode(), os.XATTR_CREATE)
+                os.fsync(fd)
+                self._certify(fd, path, token, "file")
+                try:
+                    linux.link_fd(fd, parent, name)
+                except FileExistsError as exc:
+                    raise TransferRefusal("OUTPUT_COLLISION", path) from exc
+                os.fsync(parent)
+            finally:
+                os.close(fd)
+
+    def append(self, path, token, data):
+        self._temporary(path, token)
+        with self._parent(path), self._owned(path, token, write=True) as fd:
+            if not stat.S_ISREG(os.fstat(fd).st_mode) or os.fstat(fd).st_nlink != 1:
+                raise TransferRefusal("OUTPUT_COLLISION", "temporary has unexpected links")
+            view = memoryview(data)
+            while view:
+                written = os.write(fd, view)
+                if not written:
+                    raise OSError(errno.EIO, "short destination write")
+                view = view[written:]
+            # Settle delayed allocation before the next capacity/ownership boundary.
+            os.fsync(fd)
+
+    def discard_temporary(self, path, token):
+        self._temporary(path, token)
+        with self._parent(path) as (parent, name), self._owned(path, token) as fd:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise TransferRefusal("OUTPUT_COLLISION", path)
+            live = self.tree.open(path, os.O_RDONLY | os.O_NONBLOCK)
+            try:
+                if self.tree.identity(live) != self.tree.identity(fd):
+                    raise TransferRefusal("OUTPUT_COLLISION", path)
+            finally:
+                os.close(live)
+            os.unlink(name, dir_fd=parent)
+            os.fsync(parent)
+
+    @contextmanager
+    def read(self, path):
+        with self._owned(path) as fd:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise TransferRefusal("OUTPUT_COLLISION", path)
+            with os.fdopen(os.dup(fd), "rb") as stream:
+                yield stream
+            self.tree.check()
+
+    def flush(self, path):
+        self.tree.check()
+        self._path(path, root=True)
+        if path == ".":
+            os.fsync(self.tree.fd)
+        else:
+            with self._owned(path) as fd:
+                os.fsync(fd)
+
+    def publish(self, temporary, path, token):
+        self._temporary(temporary, token)
+        with self._parent(temporary):
+            with self._parent(path) as (target_parent, target_name), self._owned(temporary, token) as fd:
+                if not stat.S_ISREG(os.fstat(fd).st_mode) or os.fstat(fd).st_nlink != 1:
+                    raise TransferRefusal("OUTPUT_COLLISION", temporary)
+                self._certify(fd, path, token, "file")
+                try:
+                    # Link the authenticated retained inode, not a mutable source pathname.
+                    # The engine separately discards the temporary link after journal commit.
+                    linux.link_fd(fd, target_parent, target_name)
+                except FileExistsError as exc:
+                    raise TransferRefusal("OUTPUT_COLLISION", path) from exc
+                os.fsync(target_parent)
+
+    def list_paths(self, root):
+        self._path(root)
+        self.tree.check()
+        try:
+            fd = self.tree.open(root, os.O_RDONLY | os.O_DIRECTORY)
+        except FileNotFoundError:
+            return ()
+        result = []
+        def visit(directory, prefix):
+            for name in sorted(os.listdir(directory)):
+                path = prefix + "/" + name
+                result.append(path)
+                info = os.stat(name, dir_fd=directory, follow_symlinks=False)
+                if stat.S_ISDIR(info.st_mode):
+                    child = self.tree.open(path, os.O_RDONLY | os.O_DIRECTORY)
+                    try:
+                        visit(child, path)
+                    finally:
+                        os.close(child)
+        try:
+            visit(fd, root)
+        finally:
+            os.close(fd)
+        return tuple(sorted(result))

--- a/modelark/slice/destination.py
+++ b/modelark/slice/destination.py
@@ -13,8 +13,9 @@ st_blocks includes an inode's data and charged xattr/directory blocks. It does n
 every filesystem-global metadata/journal allocation. The strict free-space equation therefore
 refuses unexplained drift; it is not a universal proof of future filesystem metadata cost.
 """
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 import errno
+from functools import wraps
 import json
 import os
 from pathlib import PurePosixPath
@@ -26,10 +27,78 @@ from .transaction import ObjectInfo, TransferRefusal
 
 
 OWNER_XATTR = "user.modelark.slice-owner"
+_OWNER_PREFIX = b"modelark.slice.owner.v1:"
+_OWNER_PADDING = bytes(1024)
+
+
+def _valid_owner_token(token):
+    return (isinstance(token, str) and len(token) == 32
+            and all(c in "0123456789abcdef" for c in token))
+
+
+def owner_marker(token):
+    """Versioned marker forced outside every supported ext4 inode (size <=1024).
+
+    With EA_inode excluded by capacity admission, this value must inhabit the external
+    xattr block. Its unique operation token prevents sharing that block with another
+    owned inode even when inherited ACLs are identical. The marker remains corroboration,
+    not ownership authority: durable host certificates still bind inode birth identity.
+    """
+    if not _valid_owner_token(token):
+        raise TransferRefusal("OUTPUT_COLLISION", "invalid creation token")
+    return _OWNER_PREFIX + token.encode("ascii") + _OWNER_PADDING
+
+
+def decode_owner_marker(value):
+    """Recognize new markers and legacy internal tokens; admission can require new ones."""
+    if not isinstance(value, bytes):
+        return None
+    try:
+        token = (value.decode("ascii") if len(value) == 32
+                 else value[len(_OWNER_PREFIX):len(_OWNER_PREFIX) + 32].decode("ascii"))
+    except UnicodeDecodeError:
+        return None
+    if not _valid_owner_token(token):
+        return None
+    return token if len(value) == 32 or value == owner_marker(token) else None
+
+
+def _persistent_identity(identity):
+    """Filesystem-scoped inode birth identity; st_dev is attachment-local, not durable."""
+    if (not isinstance(identity, (tuple, list)) or len(identity) != 3
+            or any(type(value) is not int for value in identity)
+            or identity[0] < 0 or identity[1] <= 0 or identity[2] <= 0):
+        raise TransferRefusal("STATE_CORRUPT", "malformed legacy or observed inode identity")
+    return tuple(identity[1:])
+
+
+def _port_io(method):
+    """Translate only IO executed by a synchronous port operation, never fault hooks."""
+    @wraps(method)
+    def call(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        except OSError as exc:
+            raise self._io_refusal(exc) from exc
+    return call
+
+
+class _DestinationRead:
+    def __init__(self, destination, stream):
+        self.destination, self.stream = destination, stream
+
+    def read(self, size=-1):
+        try:
+            self.destination.tree.check()
+            data = self.stream.read(size)
+            self.destination.tree.check()
+            return data
+        except OSError as exc:
+            raise self.destination._io_refusal(exc) from exc
 
 
 class UsbDestination:
-    """Unqualified DestinationPort for disposable tests and further safety design only."""
+    """Internal DestinationPort; operator assembly supplies device/capacity admission."""
 
     def __init__(self, tree, binding, store, tx):
         self.tree, self.binding, self.store, self.tx = tree, binding, store, tx
@@ -39,7 +108,8 @@ class UsbDestination:
         self.seal = plan.seal
         self._scope = (tx, self.seal, binding.device_id, binding.filesystem_id, binding.mount_id)
         tree.check()
-        self._root_identity = tuple(tree.identity(tree.fd))
+        self._root_attachment_identity = tuple(tree.identity(tree.fd))
+        self._root_identity = _persistent_identity(self._root_attachment_identity)
         root = store.root
         info = root.lstat()
         if (not stat.S_ISDIR(info.st_mode) or info.st_uid != os.getuid()
@@ -66,7 +136,7 @@ class UsbDestination:
             raise TransferRefusal("STATE_CORRUPT", "unsafe certificate database")
         with self._connection(write=True) as con:
             version = con.execute("PRAGMA user_version").fetchone()[0]
-            if version not in (0, 1):
+            if version not in (0, 1, 2):
                 raise TransferRefusal("STATE_CORRUPT", "unknown certificate schema")
             con.execute("CREATE TABLE IF NOT EXISTS roots (tx TEXT PRIMARY KEY, seal TEXT NOT NULL,"
                         "device TEXT NOT NULL, filesystem TEXT NOT NULL, mount TEXT NOT NULL,"
@@ -75,7 +145,18 @@ class UsbDestination:
                         "device TEXT NOT NULL, filesystem TEXT NOT NULL, mount TEXT NOT NULL,"
                         "path TEXT NOT NULL, token TEXT NOT NULL, identity TEXT NOT NULL, kind TEXT NOT NULL,"
                         "PRIMARY KEY(tx,seal,device,filesystem,mount,path,identity))")
-            con.execute("PRAGMA user_version=1")
+            if version == 1:
+                # Trusted private legacy records already bind the sealed filesystem
+                # and parent disk. Remove only transient st_dev, atomically across
+                # roots and certificates; malformed/colliding rows roll back it all.
+                for table in ("roots", "certificates"):
+                    for rowid, encoded in con.execute(f"SELECT rowid,identity FROM {table}").fetchall():
+                        try:
+                            identity = _persistent_identity(json.loads(encoded))
+                        except (TypeError, json.JSONDecodeError) as exc:
+                            raise TransferRefusal("STATE_CORRUPT", "malformed legacy inode identity") from exc
+                        con.execute(f"UPDATE {table} SET identity=? WHERE rowid=?", (json.dumps(identity), rowid))
+            con.execute("PRAGMA user_version=2")
             row = con.execute("SELECT seal,device,filesystem,mount,identity,blocks FROM roots WHERE tx=?",
                               (tx,)).fetchone()
             identity = json.dumps(self._root_identity)
@@ -86,6 +167,19 @@ class UsbDestination:
                 if row[:5] != (*self._scope[1:], identity):
                     raise TransferRefusal("DESTINATION_CHANGED", "certificate root differs")
                 self._root_blocks = row[5]
+
+    def _io_refusal(self, exc):
+        # Re-observe the pinned attachment before classifying an IO failure. A proven
+        # unplug is an attended wait; an attached-but-replaced root remains changed.
+        try:
+            self.tree.check()
+        except TransferRefusal as refusal:
+            return refusal
+        except OSError:
+            pass  # Without absence proof, preserve the original failure as terminal IO.
+        code = "OUTPUT_COLLISION" if isinstance(exc, FileExistsError) or exc.errno in {
+            errno.ELOOP, errno.EXDEV, errno.ENOTDIR} else "DESTINATION_IO_FAILED"
+        return TransferRefusal(code, str(exc))
 
     @contextmanager
     def _connection(self, *, write=False):
@@ -125,10 +219,14 @@ class UsbDestination:
         return path
 
     def _token(self, fd, path):
-        identity = json.dumps(tuple(self.tree.identity(fd)))
+        identity = json.dumps(_persistent_identity(self.tree.identity(fd)))
         try:
-            token = os.getxattr(fd, OWNER_XATTR).decode("ascii")
-        except (OSError, UnicodeDecodeError):
+            token = decode_owner_marker(os.getxattr(fd, OWNER_XATTR))
+        except OSError as exc:
+            if exc.errno in {errno.ENODATA, errno.EOPNOTSUPP}:
+                return None
+            raise
+        if token is None:
             return None
         kind = "directory" if stat.S_ISDIR(os.fstat(fd).st_mode) else "file"
         with self._connection() as con:
@@ -138,7 +236,7 @@ class UsbDestination:
         return token if found else None
 
     def _certify(self, fd, path, token, kind):
-        identity = json.dumps(tuple(self.tree.identity(fd)))
+        identity = json.dumps(_persistent_identity(self.tree.identity(fd)))
         with self._connection(write=True) as con:
             con.execute("INSERT OR IGNORE INTO certificates VALUES(?,?,?,?,?,?,?,?,?)",
                         (*self._scope, path, token, identity, kind))
@@ -150,7 +248,7 @@ class UsbDestination:
         with self.tree.parent(path) as (fd, name):
             parent = str(PurePosixPath(path).parent)
             if parent == ".":
-                if tuple(self.tree.identity(fd)) != self._root_identity:
+                if tuple(self.tree.identity(fd)) != self._root_attachment_identity:
                     raise TransferRefusal("DESTINATION_CHANGED")
             elif self._token(fd, parent) is None:
                 raise TransferRefusal("OUTPUT_COLLISION", parent)
@@ -185,6 +283,7 @@ class UsbDestination:
         info = os.fstatvfs(self.tree.fd)
         return info.f_bavail * info.f_frsize
 
+    @_port_io
     def check(self, binding, allocated, required_bytes):
         self.tree.check()
         if binding != self.binding:
@@ -222,6 +321,7 @@ class UsbDestination:
                 or available < required_bytes - actual - root_delta):
             raise TransferRefusal("DESTINATION_CAPACITY_INSUFFICIENT")
 
+    @_port_io
     def inspect(self, path):
         self._path(path)
         self.tree.check()
@@ -232,6 +332,7 @@ class UsbDestination:
                 return ObjectInfo("unknown", None, self._blocks(info))
             fd = self.tree.open(path, os.O_RDONLY | os.O_NONBLOCK)
         except FileNotFoundError:
+            self.tree.check()
             return None
         try:
             info = os.fstat(fd)
@@ -242,10 +343,10 @@ class UsbDestination:
 
     @staticmethod
     def _validate_token(token):
-        if (not isinstance(token, str) or len(token) != 32
-                or any(c not in "0123456789abcdef" for c in token)):
+        if not _valid_owner_token(token):
             raise TransferRefusal("OUTPUT_COLLISION", "invalid creation token")
 
+    @_port_io
     def create_directory(self, path, token):
         self._validate_token(token)
         with self._parent(path) as (parent, name):
@@ -255,7 +356,7 @@ class UsbDestination:
                 raise TransferRefusal("OUTPUT_COLLISION", "existing or uncertified directory: " + path) from exc
             fd = self.tree.open(path, os.O_RDONLY | os.O_DIRECTORY)
             try:
-                os.setxattr(fd, OWNER_XATTR, token.encode(), os.XATTR_CREATE)
+                os.setxattr(fd, OWNER_XATTR, owner_marker(token), os.XATTR_CREATE)
                 os.fsync(fd)
                 os.fsync(parent)
                 self._certify(fd, path, token, "directory")
@@ -268,15 +369,18 @@ class UsbDestination:
         if PurePosixPath(path).name != ".slice-" + token:
             raise TransferRefusal("OUTPUT_COLLISION", "not the operation's temporary name")
 
+    @_port_io
     def create_file(self, path, token):
         self._temporary(path, token)
         with self._parent(path) as (parent, name):
             try:
                 fd = os.open(".", os.O_TMPFILE | os.O_RDWR | os.O_CLOEXEC, 0o600, dir_fd=parent)
             except OSError as exc:
-                raise TransferRefusal("DESTINATION_UNPROVEN", "O_TMPFILE is required") from exc
+                if exc.errno in {errno.EOPNOTSUPP, errno.EINVAL, errno.EISDIR, errno.ENOSYS}:
+                    raise TransferRefusal("DESTINATION_UNPROVEN", "O_TMPFILE is required") from exc
+                raise
             try:
-                os.setxattr(fd, OWNER_XATTR, token.encode(), os.XATTR_CREATE)
+                os.setxattr(fd, OWNER_XATTR, owner_marker(token), os.XATTR_CREATE)
                 os.fsync(fd)
                 self._certify(fd, path, token, "file")
                 try:
@@ -287,6 +391,7 @@ class UsbDestination:
             finally:
                 os.close(fd)
 
+    @_port_io
     def append(self, path, token, data):
         self._temporary(path, token)
         with self._parent(path), self._owned(path, token, write=True) as fd:
@@ -301,6 +406,7 @@ class UsbDestination:
             # Settle delayed allocation before the next capacity/ownership boundary.
             os.fsync(fd)
 
+    @_port_io
     def discard_temporary(self, path, token):
         self._temporary(path, token)
         with self._parent(path) as (parent, name), self._owned(path, token) as fd:
@@ -317,13 +423,35 @@ class UsbDestination:
 
     @contextmanager
     def read(self, path):
-        with self._owned(path) as fd:
-            if not stat.S_ISREG(os.fstat(fd).st_mode):
-                raise TransferRefusal("OUTPUT_COLLISION", path)
-            with os.fdopen(os.dup(fd), "rb") as stream:
-                yield stream
-            self.tree.check()
+        stack = ExitStack()
+        try:
+            try:
+                fd = stack.enter_context(self._owned(path))
+                if not stat.S_ISREG(os.fstat(fd).st_mode):
+                    raise TransferRefusal("OUTPUT_COLLISION", path)
+                read_fd = os.dup(fd)
+                try:
+                    stream = os.fdopen(read_fd, "rb")
+                except BaseException:
+                    os.close(read_fd)
+                    raise
+                stream = stack.enter_context(stream)
+            except OSError as exc:
+                raise self._io_refusal(exc) from exc
+            # No exception catcher spans this yield: consumer/source failures must
+            # never be attributed to destination reads merely for using this context.
+            yield _DestinationRead(self, stream)
+            try:
+                self.tree.check()
+            except OSError as exc:
+                raise self._io_refusal(exc) from exc
+        finally:
+            try:
+                stack.close()
+            except OSError as exc:
+                raise self._io_refusal(exc) from exc
 
+    @_port_io
     def flush(self, path):
         self.tree.check()
         self._path(path, root=True)
@@ -333,6 +461,7 @@ class UsbDestination:
             with self._owned(path) as fd:
                 os.fsync(fd)
 
+    @_port_io
     def publish(self, temporary, path, token):
         self._temporary(temporary, token)
         with self._parent(temporary):
@@ -348,12 +477,14 @@ class UsbDestination:
                     raise TransferRefusal("OUTPUT_COLLISION", path) from exc
                 os.fsync(target_parent)
 
+    @_port_io
     def list_paths(self, root):
         self._path(root)
         self.tree.check()
         try:
             fd = self.tree.open(root, os.O_RDONLY | os.O_DIRECTORY)
         except FileNotFoundError:
+            self.tree.check()
             return ()
         result = []
         def visit(directory, prefix):

--- a/modelark/slice/destination.py
+++ b/modelark/slice/destination.py
@@ -481,25 +481,25 @@ class UsbDestination:
     def list_paths(self, root):
         self._path(root)
         self.tree.check()
-        try:
-            fd = self.tree.open(root, os.O_RDONLY | os.O_DIRECTORY)
-        except FileNotFoundError:
-            self.tree.check()
-            return ()
-        result = []
-        def visit(directory, prefix):
-            for name in sorted(os.listdir(directory)):
-                path = prefix + "/" + name
-                result.append(path)
-                info = os.stat(name, dir_fd=directory, follow_symlinks=False)
-                if stat.S_ISDIR(info.st_mode):
-                    child = self.tree.open(path, os.O_RDONLY | os.O_DIRECTORY)
-                    try:
-                        visit(child, path)
-                    finally:
-                        os.close(child)
-        try:
-            visit(fd, root)
-        finally:
-            os.close(fd)
+        result, pending = [], [root]
+        while pending:
+            prefix = pending.pop()
+            try:
+                directory = self.tree.open(prefix, os.O_RDONLY | os.O_DIRECTORY)
+            except FileNotFoundError:
+                self.tree.check()
+                if prefix == root:
+                    return ()
+                raise
+            try:
+                for name in sorted(os.listdir(directory)):
+                    path = prefix + "/" + name
+                    result.append(path)
+                    info = os.stat(name, dir_fd=directory, follow_symlinks=False)
+                    if stat.S_ISDIR(info.st_mode):
+                        pending.append(path)
+            finally:
+                # Reopen queued directories through BoundTree's confined resolver.
+                # Neither Python stack depth nor retained descriptors scale with depth.
+                os.close(directory)
         return tuple(sorted(result))

--- a/modelark/slice/fat32_destination.py
+++ b/modelark/slice/fat32_destination.py
@@ -1,0 +1,295 @@
+"""INTERNAL session-only port; actual kernel-vfat qualification is a release gate.
+
+Ownership lives only in retained descriptors under one consumed host attempt.
+No xattrs, persistent inode certificates, unnamed temporaries, or hardlinks.
+Trust boundary remains the operator account; no defense against malicious same-UID
+mkdir/open or authenticated-name/rename races is claimed. No residue cleanup.
+"""
+from contextlib import contextmanager
+from dataclasses import dataclass
+import errno
+import os
+from pathlib import PurePosixPath
+import resource
+import stat
+import sys
+
+from .destination import _port_io, _valid_owner_token
+from .io_errors import classify_io
+from .linux import _openat2, rename_noreplace
+from .transaction import ObjectInfo, TransferRefusal
+
+
+@dataclass
+class _Object:
+    fd: int
+    token: str
+    kind: str
+
+
+class _Reader:
+    def __init__(self, destination, stream):
+        self.destination, self.stream = destination, stream
+
+    def read(self, size=-1):
+        try:
+            self.destination._live()
+            return self.stream.read(size)
+        except OSError as exc:
+            raise self.destination._io_refusal(exc) from exc
+
+
+class Fat32Destination:
+    def __init__(self, tree, binding, store, tx, *, recheck):
+        plan = store.load(tx)
+        if not getattr(plan, "session_only", False) or plan.destination != binding:
+            raise TransferRefusal("ADMISSION_CORRUPT", "FAT session plan required")
+        self.tree, self.binding, self.plan = tree, binding, plan
+        self._child = plan.destination.target.child_name
+        self._recheck = recheck
+        self._objects = {}
+        self._authority = None
+        self._spent = False
+        self.cleanup_errors = ()
+        # Retain one descriptor per payload/control/report/directory. Reserve
+        # substantial headroom for source readers, SQLite and transient opens.
+        paths = [PurePosixPath(self._child) / a.repo_id / a.rfilename for a in plan.proposal.closure]
+        directories = {str(p) for path in paths for p in path.parents if str(p) != "."}
+        needed = len(paths) + len(directories) + 2 + 64
+        current = len(os.listdir("/proc/self/fd"))
+        limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if limit != resource.RLIM_INFINITY and current + needed > limit:
+            raise TransferRefusal("DESTINATION_LAYOUT_UNSUPPORTED", "retained descriptor budget exceeded")
+
+    def begin_session(self, authority):
+        if self._spent or self._authority is not None:
+            raise TransferRefusal("FAT32_NEW_ROOT_REQUIRED", "live port cannot be rebound")
+        authority.lease.check()
+        self._authority = authority
+        self._spent = True
+
+    def end_session(self):
+        self._spent = True
+        self._authority = None
+        objects = tuple(self._objects.values())
+        self._objects.clear()
+        errors = []
+        for obj in objects:
+            try:
+                os.close(obj.fd)
+            except OSError as exc:
+                errors.append(exc)
+        # Never retry a close: even a failed close may have released that number.
+        # Preserve any primary transfer failure while retaining cleanup diagnostics.
+        if errors:
+            self.cleanup_errors = (*self.cleanup_errors, *errors)
+        if errors and sys.exc_info()[0] is None:
+            raise errors[0]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.end_session()
+
+    def _live(self):
+        if self._authority is None:
+            raise TransferRefusal("FAT32_NEW_ROOT_REQUIRED", "no retained live authority")
+        self._authority.lease.check()
+        self._recheck_attachment()
+
+    def _recheck_attachment(self):
+        """Read-only parent AND backing evidence, also usable at IO failure boundaries."""
+        self.tree.check()
+        self._recheck(self.tree)
+
+    def _io_refusal(self, exc):
+        code = ("DESTINATION_CAPACITY_WAIT" if exc.errno in {errno.ENOSPC, errno.EDQUOT}
+                else "OUTPUT_COLLISION" if exc.errno == errno.EEXIST else "DESTINATION_IO_FAILED")
+        return classify_io(exc, self._recheck_attachment, TransferRefusal(code, str(exc)))
+
+    def _path(self, path):
+        if (not isinstance(path, str) or not path or "\\" in path or "\0" in path
+                or any(p in {"", ".", ".."} for p in path.split("/"))
+                or path.split("/")[0] != self._child):
+            raise TransferRefusal("PATH_UNSAFE", "outside approved output child")
+        return path
+
+    def _open(self, path):
+        self._path(path)
+        return _openat2(self.tree.fd, path, os.O_RDONLY | os.O_NONBLOCK)
+
+    @staticmethod
+    def _identity(fd):
+        info = os.fstat(fd)
+        return info.st_dev, info.st_ino, stat.S_IFMT(info.st_mode)
+
+    def _owned(self, path, token=None):
+        obj = self._objects.get(path)
+        if obj is None or (token is not None and obj.token != token):
+            raise TransferRefusal("OUTPUT_COLLISION", "no retained ownership: " + path)
+        try:
+            fd = self._open(path)
+        except FileNotFoundError as exc:
+            raise TransferRefusal("DESTINATION_CHANGED", "owned object disappeared") from exc
+        try:
+            if self._identity(fd) != self._identity(obj.fd):
+                raise TransferRefusal("DESTINATION_CHANGED", "owned object replaced")
+        finally:
+            os.close(fd)
+        return obj
+
+    @contextmanager
+    def _parent(self, path):
+        self._path(path)
+        self._live()
+        parent = str(PurePosixPath(path).parent)
+        fd = self.tree.fd if parent == "." else self._owned(parent).fd
+        yield fd, PurePosixPath(path).name
+
+    @_port_io
+    def check(self, binding, allocated, required_bytes):
+        self._live()
+        if binding != self.binding:
+            raise TransferRefusal("DESTINATION_CHANGED")
+        if any(type(n) is not int or n < 0 for n in (allocated, required_bytes)):
+            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN")
+        actual = sum(os.fstat(self._owned(path).fd).st_blocks * 512 for path in self._objects)
+        if actual != allocated:
+            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN", "live owned allocation differs")
+        space = os.fstatvfs(self.tree.fd)
+        if space.f_bavail * space.f_frsize < max(0, required_bytes - actual):
+            raise TransferRefusal("DESTINATION_CAPACITY_WAIT")
+
+    @_port_io
+    def inspect(self, path):
+        self._live()
+        if path in self._objects:
+            obj = self._owned(path)
+            return ObjectInfo(obj.kind, obj.token, os.fstat(obj.fd).st_blocks * 512)
+        try:
+            fd = self._open(path)
+        except FileNotFoundError:
+            return None
+        try:
+            info = os.fstat(fd)
+            return ObjectInfo("directory" if stat.S_ISDIR(info.st_mode) else "file", None,
+                              info.st_blocks * 512)
+        finally:
+            os.close(fd)
+
+    def _create(self, path, token, directory):
+        if not _valid_owner_token(token) or path in self._objects:
+            raise TransferRefusal("OUTPUT_COLLISION")
+        if not directory and PurePosixPath(path).name != ".slice-" + token:
+            raise TransferRefusal("PATH_UNSAFE", "files must begin as live named staging")
+        with self._parent(path) as (parent, name):
+            if directory:
+                os.mkdir(name, 0o700, dir_fd=parent)
+                fd = _openat2(parent, name, os.O_RDONLY | os.O_DIRECTORY)
+            else:
+                fd = _openat2(parent, name, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+            self._objects[path] = _Object(fd, token, "directory" if directory else "file")
+
+    @_port_io
+    def create_directory(self, path, token):
+        self._create(path, token, True)
+
+    @_port_io
+    def create_file(self, path, token):
+        self._create(path, token, False)
+
+    @_port_io
+    def append(self, path, token, data):
+        self._live()
+        if PurePosixPath(path).name != ".slice-" + token:
+            raise TransferRefusal("PATH_UNSAFE", "published output is immutable")
+        obj = self._owned(path, token)
+        if obj.kind != "file":
+            raise TransferRefusal("OUTPUT_COLLISION")
+        os.lseek(obj.fd, 0, os.SEEK_END)
+        view = memoryview(data)
+        while view:
+            written = os.write(obj.fd, view)
+            if written <= 0:
+                raise OSError(errno.EIO, "short FAT write")
+            view = view[written:]
+        os.fsync(obj.fd)  # Settle allocation before the next engine accounting check.
+
+    @contextmanager
+    def read(self, path):
+        try:
+            self._live()
+            obj = self._owned(path)
+            if obj.kind != "file":
+                raise TransferRefusal("OUTPUT_COLLISION")
+        except OSError as exc:
+            raise self._io_refusal(exc) from exc
+        fd, stream = -1, None
+        try:
+            try:
+                fd = os.dup(obj.fd)
+                stream = os.fdopen(fd, "rb")
+                fd = -1
+                stream.seek(0)
+            except OSError as exc:
+                raise self._io_refusal(exc) from exc
+            yield _Reader(self, stream)  # Never classify exceptions raised by the consumer.
+        finally:
+            primary = sys.exc_info()[1]
+            try:
+                if stream is not None:
+                    stream.close()
+                elif fd >= 0:
+                    os.close(fd)
+            except OSError as exc:
+                if primary is None:
+                    raise self._io_refusal(exc) from exc
+                self.cleanup_errors = (*self.cleanup_errors, exc)
+
+    @_port_io
+    def flush(self, path):
+        self._live()
+        fd = self.tree.fd if path == "." else self._owned(path).fd
+        os.fsync(fd)
+
+    @_port_io
+    def publish(self, temporary, path, token):
+        self._live()
+        if (PurePosixPath(temporary).name != ".slice-" + token
+                or PurePosixPath(path).name.lower().startswith(".slice-")):
+            raise TransferRefusal("PATH_UNSAFE", "publication requires staging to final")
+        obj = self._owned(temporary, token)
+        if obj.kind != "file" or path in self._objects:
+            raise TransferRefusal("OUTPUT_COLLISION")
+        with self._parent(temporary) as (src, old), self._parent(path) as (dst, new):
+            rename_noreplace(src, old, dst, new)
+        self._objects[path] = self._objects.pop(temporary)
+
+    @_port_io
+    def discard_temporary(self, path, token):
+        self._live()
+        self._owned(path, token)
+        if PurePosixPath(path).name != ".slice-" + token:
+            raise TransferRefusal("PATH_UNSAFE", "only live staging can be discarded")
+        with self._parent(path) as (fd, name):
+            os.unlink(name, dir_fd=fd)
+        os.close(self._objects.pop(path).fd)
+
+    @_port_io
+    def list_paths(self, root):
+        self._live()
+        if self.inspect(root) is None:
+            return ()
+        self._owned(root)
+        pending, result = [root], []
+        while pending:
+            current = pending.pop()
+            obj = self._owned(current)
+            for name in sorted(os.listdir(obj.fd)):
+                path = current + "/" + name
+                result.append(path)
+                child = self._objects.get(path)
+                if child is not None and child.kind == "directory":
+                    pending.append(path)
+        return tuple(result)

--- a/modelark/slice/fat32_layout.py
+++ b/modelark/slice/fat32_layout.py
@@ -1,0 +1,125 @@
+"""Non-executable FAT32 candidate layout preflight (DEC-130, Gate C).
+
+This deliberately restricted ASCII grammar is not driver/alias qualification.
+In particular, rejecting requested '~' names is insufficient on a mount using
+nonumtail. No result is a plan, live parent binding, lease, or ownership proof.
+Control/report sizes must be computed from the eventual exact sealed protocol.
+"""
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+import re
+
+from .folder_plan import _absolute
+from .transaction import TransferRefusal
+
+
+MAX_FILE_BYTES = (1 << 32) - 1
+MAX_COMPONENT = 255
+MAX_PATH_BYTES = 4096
+_ASCII_NAME = re.compile(r"[A-Za-z0-9_. -]+\Z")
+_DEVICES = {"CON", "PRN", "AUX", "NUL", "CLOCK$",
+            *("COM" + str(n) for n in range(1, 10)),
+            *("LPT" + str(n) for n in range(1, 10))}
+_TEMPORARY = ".slice-" + "0" * 32
+
+
+def _refuse(detail):
+    raise TransferRefusal("DESTINATION_LAYOUT_UNSUPPORTED", detail)
+
+
+def _name(value, *, generated=False):
+    if (not isinstance(value, str) or not _ASCII_NAME.fullmatch(value)
+            or value in {".", ".."} or value != value.strip()
+            or value.endswith(".") or len(value) > MAX_COMPONENT):
+        _refuse("unsupported FAT32 component")
+    if value.split(".", 1)[0].upper() in _DEVICES:
+        _refuse("reserved DOS device name")
+    if value.lower().startswith(".slice-") and not generated:
+        _refuse("reserved temporary namespace")
+
+
+def _size(value):
+    if type(value) is not int or not 0 <= value <= MAX_FILE_BYTES:
+        _refuse("FAT32 requires each file, control and report to fit 32-bit size")
+
+
+@dataclass(frozen=True)
+class Fat32Layout:
+    """Candidate paths only; never interpreted by the private execution store."""
+
+    files: tuple[tuple[str, int], ...]
+    directories: tuple[str, ...]
+    temporary_paths: tuple[str, ...]
+
+    @property
+    def execution_ready(self):
+        return False
+
+
+def admit_layout(files, *, output_root, parent_path, control_size, receipt_size):
+    """Check the whole proposed tree without IO, adoption, renaming or splitting.
+
+    Input payload paths are relative to the intended output child. Directory
+    spellings must agree exactly even where FAT would collapse ASCII case.
+    Generated staging paths use fixed-length transaction tokens; repeated paths
+    in temporary_paths are templates, not an allocation or uniqueness claim.
+    Parent is a host attachment spelling, not a newly generated FAT pathname;
+    parent alias/case eligibility belongs to the future live observer.
+    """
+    _name(output_root)
+    try:
+        _absolute(parent_path)
+    except TransferRefusal as exc:
+        _refuse(str(exc))
+    _size(control_size)
+    _size(receipt_size)
+    if isinstance(files, (str, bytes, dict)):
+        _refuse("payload path/size pairs required")
+    try:
+        records = tuple(files)
+    except TypeError:
+        _refuse("payload path/size pairs required")
+    if not records:
+        _refuse("nonempty payload layout required")
+
+    def path_length(path):
+        full = parent_path.rstrip("/") + "/" + path
+        if len(path.encode("utf-8")) >= MAX_PATH_BYTES or len(full.encode("utf-8")) >= MAX_PATH_BYTES:
+            _refuse("FAT32 output or intermediate path exceeds qualified path bound")
+
+    paths = []
+    for record in records:
+        if not isinstance(record, (tuple, list)) or len(record) != 2:
+            _refuse("payload path/size pair required")
+        path, size = record
+        if not isinstance(path, str):
+            _refuse("relative payload path required")
+        for part in path.split("/"):
+            _name(part)
+        _size(size)
+        paths.append((output_root + "/" + path, size))
+    paths += [(output_root + "/.modelark-slice-owner", control_size),
+              (output_root + "/.modelark-slice-receipt.json", receipt_size)]
+
+    namespace = {}
+    directories = set()
+    temporary_paths = []
+    for path, _ in paths:
+        parts = PurePosixPath(path).parts
+        for index, part in enumerate(parts):
+            _name(part)
+            current = "/".join(parts[:index + 1])
+            kind = "file" if index == len(parts) - 1 else "directory"
+            key = current.lower()
+            prior = namespace.get(key)
+            if prior is not None and (prior != (current, kind) or kind == "file"):
+                _refuse("duplicate, case-equivalent or file/directory collision")
+            namespace[key] = (current, kind)
+            if kind == "directory":
+                directories.add(current)
+        path_length(path)
+        temporary = str(PurePosixPath(path).parent / _TEMPORARY)
+        _name(_TEMPORARY, generated=True)
+        path_length(temporary)
+        temporary_paths.append(temporary)
+    return Fat32Layout(tuple(paths), tuple(sorted(directories)), tuple(temporary_paths))

--- a/modelark/slice/fat32_observation.py
+++ b/modelark/slice/fat32_observation.py
@@ -101,6 +101,10 @@ def _mount_policy(mount):
             _refuse('explicit FAT directory/file permission masks required', 'DESTINATION_NOT_WRITABLE')
         if int(value, 8) & 0o022 != 0o022:
             _refuse('FAT masks must exclude group/other writes', 'DESTINATION_NOT_WRITABLE')
+        required = 0o700 if key == 'dmask' else 0o600
+        if int(value, 8) & required:
+            _refuse('FAT masks must preserve owner directory rwx and file rw',
+                    'DESTINATION_NOT_WRITABLE')
     if 'rw' not in mount.options:
         _refuse('writable FAT mount required', 'DESTINATION_NOT_WRITABLE')
 

--- a/modelark/slice/fat32_observation.py
+++ b/modelark/slice/fat32_observation.py
@@ -1,0 +1,273 @@
+"""Read-only FAT32 admission; observations alone confer no writer authority.
+
+FSVER is lsblk/udev evidence corroborated by the kernel's vfat mount, not raw
+on-media forensic proof. The disposable kernel-driver test is not USB admission.
+Durable intent contains path/backing only. Only a retained Fat32Tree holds live
+parent identity; an inspection inode or saved observation cannot authorize resume.
+"""
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+
+from .fat32_layout import _name
+from .folder_contract import CapacityObservation
+from .folder_observation import NativeFolderObserver, _within
+from .hardware import _Inventory, _nonempty
+from .host_observation import parse_mounts
+from .io_errors import classify_io, probe_io
+from .linux import BoundTree, _openat2, _statx, require_create_access
+from .paths import canonical_attachment
+from .transaction import TransferRefusal
+
+
+def _refuse(detail, code='DESTINATION_UNPROVEN'):
+    raise TransferRefusal(code, detail)
+
+
+class Fat32Tree(BoundTree):
+    """Confinement for one retained live descriptor, never durable FAT ownership."""
+
+    @staticmethod
+    def _statx(fd):
+        return _statx(fd, require_birth=False)
+
+    @staticmethod
+    def identity(fd):
+        value = _statx(fd, require_birth=False)
+        return os.makedev(value.dev_major, value.dev_minor), value.ino
+
+
+def _inventory():
+    result = subprocess.run(
+        ['lsblk', '--json', '--bytes', '--paths', '--output',
+         'NAME,KNAME,PATH,TYPE,PKNAME,MAJ:MIN,SIZE,FSTYPE,FSVER,UUID,SERIAL,WWN,TRAN,RO'],
+        check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+@dataclass(frozen=True)
+class Fat32FolderEvidence:
+    parent_path: str
+    destination_path: str
+    filesystem_id: str
+    filesystem_scope: str
+    parent_parts: tuple[str, ...]
+    child_name: str
+    backing_ids: tuple[str, ...]
+    mount_id: int
+    major_minor: str
+    capacity: CapacityObservation
+    name_max: int
+    block_size: int
+
+
+def _stable(evidence):
+    return (evidence.parent_path, evidence.destination_path, evidence.filesystem_id,
+            evidence.filesystem_scope, evidence.parent_parts, evidence.child_name,
+            evidence.backing_ids, evidence.mount_id, evidence.major_minor,
+            evidence.name_max, evidence.block_size)
+
+
+def _mount_policy(mount):
+    """Closed ASCII/numbered-shortname candidate, no mount-option modification."""
+    plain = {'rw', 'nosuid', 'nodev', 'noexec', 'relatime', 'noatime', 'nodiratime',
+             'sync', 'dirsync', 'flush', 'utf8'}
+    values = {}
+    for option in mount.options:
+        if option in plain:
+            continue
+        key, separator, value = option.partition('=')
+        if not separator or key in values:
+            _refuse('unqualified FAT mount option: ' + option, 'FILESYSTEM_UNSUPPORTED')
+        values[key] = value
+    allowed = {'uid', 'gid', 'fmask', 'dmask', 'codepage', 'iocharset', 'shortname', 'errors'}
+    if set(values) - allowed:
+        _refuse('unqualified FAT name or permission options', 'FILESYSTEM_UNSUPPORTED')
+    # Admit only the name-codec combination exercised by the kernel-vfat
+    # qualification; ASCII-only output does not qualify other mount codecs.
+    if (values.get('codepage') != '437' or values.get('iocharset') != 'iso8859-1'
+            or 'utf8' not in mount.options
+            or values.get('shortname') != 'mixed' or values.get('errors') not in {None, 'remount-ro'}):
+        _refuse('qualified codepage=437, iocharset=iso8859-1, utf8 and shortname=mixed required',
+                'FILESYSTEM_UNSUPPORTED')
+    if values.get('uid') != str(os.geteuid()):
+        _refuse('FAT mount must assign ownership to the current user', 'DESTINATION_NOT_WRITABLE')
+    for key in ('dmask', 'fmask'):
+        value = values.get(key, '')
+        if not value or len(value) > 4 or any(character not in '01234567' for character in value):
+            _refuse('explicit FAT directory/file permission masks required', 'DESTINATION_NOT_WRITABLE')
+        if int(value, 8) & 0o022 != 0o022:
+            _refuse('FAT masks must exclude group/other writes', 'DESTINATION_NOT_WRITABLE')
+    if 'rw' not in mount.options:
+        _refuse('writable FAT mount required', 'DESTINATION_NOT_WRITABLE')
+
+
+@probe_io('DESTINATION_NOT_WRITABLE', 'FAT effective parent permissions unavailable')
+def check_directory(fd):
+    """FAT mode arguments do not enforce per-root protection; check mount semantics."""
+    require_create_access(fd)
+    info = os.fstat(fd)
+    if info.st_uid != os.geteuid() or info.st_mode & 0o022:
+        _refuse('FAT parent must be current-user-owned without nonowner write',
+                'DESTINATION_NOT_WRITABLE')
+
+
+@probe_io('DESTINATION_CAPACITY_UNPROVEN', 'FAT shared capacity unavailable')
+def _capacity(fd):
+    value = os.fstatvfs(fd)
+    if value.f_frsize <= 0 or value.f_bavail < 0 or value.f_bavail > value.f_blocks:
+        _refuse('invalid FAT shared-space observation', 'DESTINATION_CAPACITY_UNPROVEN')
+    # vfat does not expose a meaningful reservable inode count.
+    return CapacityObservation(value.f_bavail * value.f_frsize, None), value.f_frsize
+
+
+class Fat32FolderObserver(NativeFolderObserver):
+    """Read-only, exact spelling/direct USB candidate; does not adopt output roots."""
+
+    def __init__(self, *, inventory=None, mounts=None, tree_factory=Fat32Tree, backing=None, resolver=None):
+        super().__init__(inventory=inventory or _inventory, mounts=mounts, tree_factory=tree_factory,
+                         backing=backing, resolver=resolver)
+
+    def _canonical_parent(self, tree, mount):
+        parts = Path(tree.path).relative_to(mount.path).parts
+        with self._tree_factory(mount.path) as root:
+            fd = os.dup(root.fd)
+            try:
+                for part in parts:
+                    _name(part)
+                    names = os.listdir(fd)
+                    if [name for name in names if name.lower() == part.lower()] != [part]:
+                        _refuse('FAT parent spelling is an alias or ambiguous case', 'PATH_UNSAFE')
+                    child = _openat2(fd, part, os.O_RDONLY | os.O_DIRECTORY)
+                    os.close(fd)
+                    fd = child
+                if (Fat32Tree.identity(fd) != Fat32Tree.identity(tree.fd)
+                        or Fat32Tree._statx(fd).mount_id != tree.mount_id):
+                    _refuse('FAT canonical parent changed', 'DESTINATION_CHANGED')
+                root.check()
+            finally:
+                os.close(fd)
+        return parts
+
+    def _read_fat(self, tree, destination, inventory, mounts, archives, protected_paths):
+        tree.check()
+        info = os.fstat(tree.fd)
+        key = f'{os.major(info.st_dev)}:{os.minor(info.st_dev)}'
+        covering = [mount for mount in mounts if _within(str(tree.path), mount.path)]
+        if not covering:
+            _refuse('FAT parent has no covering mount')
+        longest = max(len(mount.path) for mount in covering)
+        matching = [mount for mount in covering if len(mount.path) == longest]
+        if len(matching) != 1:
+            _refuse('FAT parent has ambiguous covering mounts')
+        mount = matching[0]
+        if mount.mount_id != tree.mount_id or mount.major_minor != key:
+            _refuse('FAT parent descriptor differs from mount inventory', 'DESTINATION_CHANGED')
+        if mount.root != '/' or sum(m.major_minor == key for m in mounts) != 1:
+            _refuse('FAT mount aliases are not qualified')
+        if any(_within(m.path, destination) for m in mounts if m != mount):
+            _refuse('nested output mount is not qualified')
+        if key not in inventory.nodes:
+            _refuse('FAT backing is unavailable', 'WAITING_DESTINATION')
+        node = inventory.nodes[key]
+        if mount.fs_type != 'vfat' or node.get('fstype') != 'vfat' or node.get('fsver') != 'FAT32':
+            _refuse('kernel vfat plus explicit FAT32 version evidence required', 'FILESYSTEM_UNSUPPORTED')
+        disk = inventory.nodes[inventory.disk(key, direct=True)]
+        if disk.get('tran') != 'usb':
+            _refuse('FAT candidate requires a direct USB disk', 'FILESYSTEM_UNSUPPORTED')
+        backing_ids = self._roles(inventory, key, archives)
+        uuid = _nonempty(node.get('uuid'))
+        if not uuid:
+            _refuse('stable FAT filesystem identity required')
+        _mount_policy(mount)
+        check_directory(tree.fd)
+        protected = self._protected(destination, mounts, protected_paths)
+        parts = self._canonical_parent(tree, mount)
+        capacity, block_size = _capacity(tree.fd)
+        name_max = os.fpathconf(tree.fd, 'PC_NAME_MAX')
+        if name_max < 1 or len(Path(destination).name) > name_max:
+            _refuse('FAT child exceeds mounted name limit', 'DESTINATION_LAYOUT_UNSUPPORTED')
+        scope = 'fat32-fs-v1:' + hashlib.sha256(json.dumps(
+            {'uuid': uuid.casefold(), 'backing': backing_ids}, sort_keys=True).encode()).hexdigest()
+        backing_ids = tuple(sorted(set((*backing_ids, 'filesystem:' + uuid, scope))))
+        value = Fat32FolderEvidence(str(tree.path), destination, uuid, scope, parts,
+                                     Path(destination).name, backing_ids, tree.mount_id, key,
+                                     capacity, name_max, block_size)
+        tree.check()
+        return value, protected
+
+    def observe(self, destination_path, *, archives, protected_paths=(), allow_existing=False):
+        """Observe intent only; an existing child never becomes authorized by this API."""
+        destination = canonical_attachment(destination_path)
+        if destination == Path('/'):
+            _refuse('FAT output must name a new child', 'PATH_UNSAFE')
+        for component in destination.parts[1:]:
+            _name(component)
+        if len(os.fsencode(destination)) >= 4096:
+            _refuse('FAT output path exceeds qualified bound', 'DESTINATION_LAYOUT_UNSUPPORTED')
+        archives, protected_paths = tuple(archives), tuple(protected_paths)
+        try:
+            payload = json.dumps(self._inventory(), sort_keys=True)
+            inventory = _Inventory(json.loads(payload))
+            mounts = parse_mounts(self._mounts())
+            with self._tree_factory(destination.parent) as tree:
+                value, protected = self._read_fat(tree, str(destination), inventory, mounts,
+                                                  archives, protected_paths)
+                if not allow_existing:
+                    if any(name.lower() == destination.name.lower() for name in os.listdir(tree.fd)):
+                        _refuse('FAT output already exists or is case-equivalent', 'DESTINATION_COLLISION')
+                    try:
+                        os.stat(destination.name, dir_fd=tree.fd, follow_symlinks=False)
+                    except FileNotFoundError:
+                        pass
+                    else:
+                        _refuse('FAT output already exists or is an alias', 'DESTINATION_COLLISION')
+                backing = self._backing(value.major_minor)
+                if (json.dumps(self._inventory(), sort_keys=True) != payload
+                        or parse_mounts(self._mounts()) != mounts
+                        or self._protected(str(destination), mounts, protected_paths) != protected
+                        or self._backing(value.major_minor) != backing):
+                    _refuse('FAT observation changed during admission', 'DESTINATION_CHANGED')
+                tree.check()
+                self._observed[value.destination_path] = (value, inventory, mounts, backing,
+                                                          archives, protected_paths)
+                return value
+        except TransferRefusal:
+            raise
+        except OSError as exc:
+            raise classify_io(exc, None, TransferRefusal('DESTINATION_UNPROVEN', str(exc))) from exc
+        except (subprocess.SubprocessError, ValueError) as exc:
+            raise TransferRefusal('DESTINATION_UNPROVEN', str(exc)) from exc
+
+    def recheck(self, tree, evidence, *, archives=None):
+        """Check one live parent and stable intent; not persistent inode authentication."""
+        proof = self._observed.get(evidence.destination_path)
+        if (not isinstance(tree, Fat32Tree) or proof is None or _stable(proof[0]) != _stable(evidence)
+                or str(tree.path) != evidence.parent_path):
+            _refuse('no matching FAT candidate observation/live tree', 'DESTINATION_CHANGED')
+        original, inventory, mounts, backing, prior_archives, protected_paths = proof
+        try:
+            tree.check()
+            try:
+                current_backing = self._backing(evidence.major_minor)
+            except FileNotFoundError:
+                _refuse('FAT backing disappeared', 'WAITING_DESTINATION')
+            if current_backing != backing:
+                _refuse('FAT backing changed', 'DESTINATION_CHANGED')
+            roles = prior_archives if archives is None else tuple(archives)
+            current_mounts = parse_mounts(self._mounts())
+            if current_mounts != mounts or roles != prior_archives:
+                value = self.observe(evidence.destination_path, archives=roles,
+                                     protected_paths=protected_paths, allow_existing=True)
+            else:
+                value, _ = self._read_fat(tree, evidence.destination_path, inventory, mounts,
+                                         roles, protected_paths)
+            if _stable(value) != _stable(original):
+                _refuse('FAT path or backing intent changed', 'DESTINATION_CHANGED')
+            tree.check()
+            return value
+        except OSError as exc:
+            raise classify_io(exc, tree.check, TransferRefusal('DESTINATION_UNPROVEN', str(exc))) from exc

--- a/modelark/slice/fat32_operator.py
+++ b/modelark/slice/fat32_operator.py
@@ -1,0 +1,126 @@
+"""Attended FAT32 folder assembly: approved intent, one live Start, no resume.
+
+Kernel-vfat port qualification passed on the operator's disposable image. Every
+actual destination still requires closed mount/backing/role/capability admission.
+"""
+from dataclasses import asdict, replace
+import os
+from pathlib import Path
+
+from . import domain as d, state as private_state, transaction as t
+from .catalog import read_catalog
+from .fat32_destination import Fat32Destination
+from .fat32_observation import Fat32FolderObserver, Fat32Tree
+from .fat32_plan import Fat32Intent, Fat32Plan, binding_for, estimate_metadata
+from .folder_contract import FolderProfile
+from .folder_operator import _protected
+from .hardware import LinuxObserver
+from .io_errors import io_boundary
+from .local_source import LocalArchiveReader
+from .paths import canonical_attachment
+from .sources import FencedSources
+
+
+def _intent(evidence):
+    return Fat32Intent(FolderProfile.FAT32_SESSION, evidence.filesystem_scope,
+                       evidence.parent_parts, evidence.child_name)
+
+
+def _request_stop_once(store, tx):
+    # An interrupt inside the engine has already requested/acknowledged Stop
+    # under its retained lease. Do not append a new unacknowledged request.
+    if not store.stop_requested(tx):
+        store.request_stop(tx)
+
+
+def preview(catalog_path, destination_path, repo_ids):
+    from .operator import _archives, _store
+    catalog = str(Path(catalog_path).expanduser().resolve())
+    destination = canonical_attachment(destination_path)
+    spec = d.SliceSpec(tuple(repo_ids), "pending-fat32-intent", destination.name)
+    snapshot = read_catalog(catalog, spec)
+    proposal = d.preview(spec, snapshot)
+    if not proposal.source_ready:
+        return {"ok": False, "state": "blocked", "executable": False,
+                "gaps": [asdict(gap) for gap in proposal.gaps], "preview": asdict(proposal)}
+    observer = Fat32FolderObserver()
+    evidence = observer.observe(destination, archives=_archives(catalog), protected_paths=_protected(catalog))
+    target = _intent(evidence)
+    proposal = d.preview(replace(spec, destination_id=target.target_id), snapshot)
+    binding = binding_for(target, catalog, evidence.parent_path, evidence.backing_ids)
+    reserve = estimate_metadata(proposal, binding, catalog, evidence.parent_path, evidence.backing_ids,
+                                evidence.capacity, private_state.HOST_STATE_DIR)
+    plan = Fat32Plan(proposal, binding, catalog, evidence.parent_path, evidence.backing_ids,
+                     evidence.capacity, reserve)
+    with io_boundary(None, "DESTINATION_UNPROVEN", "FAT32 preview setup/teardown failed"), \
+            Fat32Tree(evidence.parent_path, writable=True) as tree:
+        fresh = observer.recheck(tree, evidence, archives=_archives(catalog))
+        if fresh.capacity.available_bytes < plan.required_bytes(private_state.HOST_STATE_DIR):
+            raise t.TransferRefusal("DESTINATION_CAPACITY_WAIT", "shared capacity insufficient at preview")
+        try:
+            os.stat(destination.name, dir_fd=tree.fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise t.TransferRefusal("OUTPUT_COLLISION", "output appeared during preview")
+    approval = d.approve(proposal, expected_seal=proposal.seal, current_snapshot=snapshot)
+    tx = _store().create(plan, approval)
+    return {"ok": True, "state": "ready", "executable": False, "transaction_id": tx,
+            "seal": plan.seal, "plan": asdict(plan), "ownership": "new-output-folder-only",
+            "parent_continuity": "fresh-at-start-not-persistently-identified",
+            "resume_policy": "new-root-after-any-ended-attempt",
+            "capacity_policy": "advisory-shared-space-not-reserved"}
+
+
+def start(store, tx, plan, destination_path, attachments):
+    from .operator import _archives, _result
+    if store.attempt_consumed(tx):
+        raise t.TransferRefusal("FAT32_NEW_ROOT_REQUIRED", "this intent has spent its only attempt")
+    path = canonical_attachment(destination_path)
+    if str(path.parent) != plan.parent_path or path.name != plan.destination.target.child_name:
+        raise t.TransferRefusal("DESTINATION_CHANGED", "Start must name the approved output path")
+    allowed = {source.drive.drive_label for artifact in plan.proposal.closure for source in artifact.sources}
+    if not isinstance(attachments, dict) or set(attachments) - allowed:
+        raise t.TransferRefusal("SOURCE_ATTACHMENT_UNSEALED")
+    observer = Fat32FolderObserver()
+    evidence = observer.observe(path, archives=_archives(plan.catalog), protected_paths=_protected(plan.catalog))
+    if _intent(evidence) != plan.destination.target or evidence.backing_ids != plan.backing_ids:
+        raise t.TransferRefusal("DESTINATION_CHANGED", "FAT path/backing differs from approved intent")
+    with io_boundary(None, "DESTINATION_IO_FAILED", "FAT32 setup/teardown failed"), \
+            Fat32Tree(plan.parent_path, writable=True) as tree:
+        def recheck(parent):
+            return observer.recheck(parent, evidence, archives=_archives(plan.catalog))
+
+        fresh = recheck(tree)
+        if fresh.capacity.available_bytes < plan.required_bytes(store.root):
+            raise t.TransferRefusal("DESTINATION_CAPACITY_WAIT", "shared capacity insufficient before claim")
+        with Fat32Destination(tree, plan.destination, store, tx, recheck=recheck) as destination:
+            sources = FencedSources(plan.catalog, LocalArchiveReader(attachments, observer=LinuxObserver()))
+            try:
+                session = t.start(store, tx, destination, sources)
+            except KeyboardInterrupt:
+                _request_stop_once(store, tx)
+                # Never use native's fresh-Start interrupt acknowledgment path:
+                # consumed FAT authority cannot be reacquired even to acknowledge.
+                return {**_result(store.status(tx), stop_requested=True), "ok": False,
+                        "new_root_required": store.attempt_consumed(tx)}
+            except t.TransferRefusal as exc:
+                if exc.code not in {"DESTINATION_CAPACITY_WAIT", "WAITING_DESTINATION", "STOPPED"}:
+                    raise
+                return {**_result(store.status(tx)), "new_root_required": store.attempt_consumed(tx)}
+            if isinstance(session, t.Status):
+                return _result(session)
+            with session:
+                try:
+                    result = session.run()
+                except KeyboardInterrupt:
+                    _request_stop_once(store, tx)
+                    # step() has already revoked the port on an interrupted run.
+                    # close() may acknowledge Stop with host authority if retained.
+                    interrupted = True
+                else:
+                    interrupted = False
+            if interrupted:
+                return {**_result(store.status(tx), stop_requested=True), "ok": False,
+                        "new_root_required": store.attempt_consumed(tx)}
+            return {**_result(result), "new_root_required": result.state != "complete"}

--- a/modelark/slice/fat32_plan.py
+++ b/modelark/slice/fat32_plan.py
@@ -1,0 +1,222 @@
+"""FAT32 durable path/backing intent, distinct from live Start authority.
+
+No saved parent token, inode, marker, plan or receipt authorizes FAT32 resume.
+The execution layer must consume a single attempt before creating the absent
+output root and must retain its fresh parent/object capabilities for that attempt.
+"""
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+from pathlib import PurePosixPath
+import re
+
+from . import domain as d
+from . import fat32_layout as layout
+from .folder_contract import CapacityObservation, FolderProfile, _decode, _fields, _text
+from .folder_plan import _absolute, _backing, _proposal_record
+from .transaction import TransferRefusal
+
+
+VERSION = "modelark.slice.fat32-transaction.v1"
+_INTENT_VERSION = "modelark.slice.fat32-intent.v1"
+_ADMISSION_PREFIX = "fat32-folder-v1:"
+_SHA = re.compile(r"[0-9a-f]{64}\Z")
+
+
+@dataclass(frozen=True)
+class Fat32Intent:
+    """Reviewed namespace intent, not proof of parent continuity or ownership."""
+
+    profile: FolderProfile
+    filesystem_scope: str
+    parent_parts: tuple[str, ...]
+    child_name: str
+
+    def __post_init__(self):
+        try:
+            profile = FolderProfile(self.profile)
+        except (TypeError, ValueError) as exc:
+            raise TransferRefusal("FAT32_PLAN_INVALID", "FAT32 session profile required") from exc
+        if (profile is not FolderProfile.FAT32_SESSION or not _text(self.filesystem_scope)
+                or not isinstance(self.parent_parts, (tuple, list))):
+            raise TransferRefusal("FAT32_PLAN_INVALID", "FAT32 path/backing intent required")
+        for part in (*self.parent_parts, self.child_name):
+            layout._name(part)
+        object.__setattr__(self, "profile", profile)
+        object.__setattr__(self, "parent_parts", tuple(self.parent_parts))
+
+    @property
+    def parts(self):
+        return (*self.parent_parts, self.child_name)
+
+    def to_json(self):
+        return d._json({"version": _INTENT_VERSION, **asdict(self)}).decode()
+
+    @property
+    def target_id(self):
+        return "fat32-intent-v1:" + hashlib.sha256(self.to_json().encode()).hexdigest()
+
+    @classmethod
+    def from_json(cls, payload):
+        try:
+            record = _decode(payload)
+            _fields(record, {"version", "profile", "filesystem_scope", "parent_parts", "child_name"})
+            if record["version"] != _INTENT_VERSION:
+                raise ValueError("unknown FAT32 intent version")
+            return cls(**{key: value for key, value in record.items() if key != "version"})
+        except (KeyError, TypeError, ValueError, RecursionError) as exc:
+            raise TransferRefusal("STATE_CORRUPT", "invalid FAT32 intent: " + str(exc)) from exc
+
+
+@dataclass(frozen=True)
+class Fat32Binding:
+    target: Fat32Intent
+    admission_id: str
+
+    def __post_init__(self):
+        if (not isinstance(self.target, Fat32Intent) or not isinstance(self.admission_id, str)
+                or not self.admission_id.startswith(_ADMISSION_PREFIX)
+                or not _SHA.fullmatch(self.admission_id[len(_ADMISSION_PREFIX):])):
+            raise TransferRefusal("FAT32_PLAN_INVALID", "FAT32 intent binding required")
+
+    @property
+    def device_id(self):
+        return self.target.target_id
+
+    @property
+    def filesystem_id(self):
+        return self.target.filesystem_scope
+
+    @property
+    def mount_id(self):
+        return self.admission_id
+
+
+def binding_for(target, catalog, parent_path, backing_ids):
+    """Seal stable path/backing policy, never a live descriptor or capacity claim."""
+    if not isinstance(target, Fat32Intent):
+        raise TransferRefusal("FAT32_PLAN_INVALID", "FAT32 intent required")
+    payload = {"version": VERSION, "target": json.loads(target.to_json()),
+               "catalog": _absolute(catalog), "parent_path": _absolute(parent_path),
+               "backing_ids": _backing(backing_ids)}
+    return Fat32Binding(target, _ADMISSION_PREFIX + hashlib.sha256(d._json(payload)).hexdigest())
+
+
+@dataclass(frozen=True)
+class Fat32Plan:
+    proposal: d.SlicePreview
+    destination: Fat32Binding
+    catalog: str
+    parent_path: str
+    backing_ids: tuple[str, ...]
+    capacity: CapacityObservation
+    metadata_reserve_bytes: int
+    version: str = VERSION
+
+    def __post_init__(self):
+        if (self.version != VERSION or not isinstance(self.proposal, d.SlicePreview)
+                or not isinstance(self.destination, Fat32Binding)
+                or not isinstance(self.capacity, CapacityObservation)
+                or not d._integer(self.metadata_reserve_bytes)):
+            raise TransferRefusal("FAT32_PLAN_INVALID", "typed FAT32 plan required")
+        d._verify(self.proposal)
+        if not self.proposal.source_ready:
+            raise TransferRefusal("PREVIEW_BLOCKED")
+        object.__setattr__(self, "backing_ids", _backing(self.backing_ids))
+        expected = binding_for(self.destination.target, self.catalog, self.parent_path, self.backing_ids)
+        if self.destination != expected:
+            raise TransferRefusal("ADMISSION_CORRUPT", "FAT32 admission differs from binding")
+        if (self.proposal.spec.destination_id != expected.device_id
+                or self.proposal.spec.destination_root != expected.target.child_name):
+            raise TransferRefusal("DESTINATION_CHANGED", "closure differs from reviewed FAT32 intent")
+        self.required_bytes("")
+
+    @property
+    def is_folder(self):
+        return True
+
+    @property
+    def session_only(self):
+        return True
+
+    @property
+    def control_path(self):
+        return self.destination.target.child_name + "/.modelark-slice-owner"
+
+    def to_json(self):
+        return d._json(asdict(self)).decode()
+
+    @property
+    def seal(self):
+        return hashlib.sha256(self.to_json().encode()).hexdigest()
+
+    def receipt(self, tx, files):
+        # Published before the host's final commit. This report must not assert
+        # that a later host commit or its own subsequent flush has succeeded.
+        return {"version": self.version, "transaction": tx, "seal": self.seal,
+                "destination": asdict(self.destination), "files": files,
+                "plan": json.loads(self.to_json()), "topology": "folder", "status": "export-verified",
+                "profile": self.destination.target.profile.value, "resume_policy": "new-root",
+                "host_transaction_completion": "not-claimed",
+                "receipt_persistence": "not-self-certified",
+                "capacity_evidence": "advisory-shared-space-not-reserved",
+                "verification": {"content": "sha256-original-bytes", "layout": "live-session-authenticated",
+                                 "result": "verified", "file_count": len(files)}}
+
+    def _metadata_sizes(self, store_root):
+        tx = "0" * 32
+        root = PurePosixPath(self.proposal.spec.destination_root)
+        files = [{"path": str(root / artifact.repo_id / artifact.rfilename),
+                  "size": artifact.size_bytes, "sha256": artifact.sha256,
+                  "source": asdict(max(artifact.sources, key=lambda source: len(d._json(asdict(source)))))}
+                 for artifact in self.proposal.closure]
+        control = {"transaction": tx, "seal": self.seal, "store": str(store_root),
+                   "destination": asdict(self.destination)}
+        return len(d._json(control)), len(d._json(self.receipt(tx, files)))
+
+    def required_bytes(self, store_root):
+        control_size, receipt_size = self._metadata_sizes(store_root)
+        layout.admit_layout(((artifact.repo_id + "/" + artifact.rfilename, artifact.size_bytes)
+                             for artifact in self.proposal.closure),
+                            output_root=self.destination.target.child_name, parent_path=self.parent_path,
+                            control_size=control_size, receipt_size=receipt_size)
+        if self.metadata_reserve_bytes < control_size + receipt_size:
+            raise TransferRefusal("DESTINATION_CAPACITY_UNPROVEN", "FAT32 metadata reserve is too small")
+        return self.proposal.total_bytes + self.metadata_reserve_bytes + self.capacity.headroom_bytes
+
+    @classmethod
+    def from_json(cls, payload):
+        from .transaction import decode_proposal
+        try:
+            obj = _decode(payload)
+            _fields(obj, {"proposal", "destination", "catalog", "parent_path", "backing_ids",
+                          "capacity", "metadata_reserve_bytes", "version"})
+            if obj["version"] != VERSION:
+                raise ValueError("unsupported FAT32 transaction version")
+            _fields(obj["destination"], {"target", "admission_id"})
+            _fields(obj["destination"]["target"], {"profile", "filesystem_scope", "parent_parts", "child_name"})
+            _fields(obj["capacity"], {"available_bytes", "free_inodes", "headroom_bytes"})
+            return cls(decode_proposal(_proposal_record(obj["proposal"])),
+                       Fat32Binding(Fat32Intent(**obj["destination"]["target"]), obj["destination"]["admission_id"]),
+                       obj["catalog"], obj["parent_path"], obj["backing_ids"],
+                       CapacityObservation(**obj["capacity"]), obj["metadata_reserve_bytes"], obj["version"])
+        except (KeyError, TypeError, ValueError, RecursionError) as exc:
+            raise TransferRefusal("STATE_CORRUPT", "invalid FAT32 plan: " + str(exc)) from exc
+
+
+def estimate_metadata(proposal, binding, catalog, parent_path, backing_ids, capacity, store_root):
+    """Conservative shared-space estimate; the live adapter still checks capacity."""
+    root = PurePosixPath(proposal.spec.destination_root)
+    directories = {str(parent) for artifact in proposal.closure
+                   for parent in (root / artifact.repo_id / artifact.rfilename).parents
+                   if str(parent) != "."}
+    objects = len(proposal.closure) + len(directories) + 2
+    record = {"proposal": asdict(proposal), "destination": asdict(binding), "catalog": catalog,
+              "parent_path": parent_path, "backing_ids": backing_ids, "capacity": asdict(capacity),
+              "store": str(store_root)}
+    allowance = 256 * 1024 + objects * 128 * 1024
+    reserve = allowance + 3 * len(d._json(record))
+    plan = Fat32Plan(proposal, binding, catalog, parent_path, backing_ids, capacity, reserve)
+    reserve = max(reserve, sum(plan._metadata_sizes(store_root)) + allowance)
+    plan.required_bytes(store_root)
+    return reserve

--- a/modelark/slice/folder_contract.py
+++ b/modelark/slice/folder_contract.py
@@ -1,0 +1,234 @@
+"""Non-executable folder contracts (DEC-130, Gate A).
+
+These are trusted-process observations, NOT ownership capabilities. A later qualified
+adapter must produce the unambiguous filesystem scope, filesystem-relative parent path,
+and parent identity from retained descriptors. Constructing/deserializing these values
+does not prove those facts and never authorizes a write or resume.
+
+Native execution consumes these contracts through its separately versioned plan
+and durable claim gate. These values alone remain non-executable; the FAT32 live
+binding and alias rules are still unqualified. Legacy seals retain their policy.
+"""
+from dataclasses import asdict, dataclass
+from enum import Enum
+import hashlib
+import json
+import re
+
+from .transaction import TransferRefusal
+
+
+_HEX32 = re.compile(r"[0-9a-f]{32}\Z")
+_HEX64 = re.compile(r"[0-9a-f]{64}\Z")
+_TARGET_VERSION = "modelark.slice.folder-target.v1"
+_REVIEW_VERSION = "modelark.slice.folder-review.v1"
+
+
+def _refuse(detail):
+    raise TransferRefusal("FOLDER_CONTRACT_INVALID", detail)
+
+
+def _integer(value):
+    return type(value) is int and value >= 0
+
+
+def _text(value):
+    return isinstance(value, str) and bool(value) and value == value.strip() and "\0" not in value
+
+
+def _component(value):
+    if not _text(value) or value in {".", ".."} or any(c in value for c in "/\\:"):
+        _refuse("canonical single path component required")
+    try:
+        value.encode("utf-8", errors="strict")
+    except UnicodeError:
+        _refuse("output path component must be strict UTF-8")
+
+
+def _encode(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False)
+
+
+def _fields(value, names):
+    if type(value) is not dict or set(value) != set(names):
+        _refuse("missing, extra or mixed-version fields")
+
+
+def _pairs(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            _refuse("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _decode(payload):
+    if not isinstance(payload, str):
+        _refuse("JSON text required")
+    try:
+        return json.loads(payload, object_pairs_hook=_pairs,
+                          parse_constant=lambda _: _refuse("non-finite JSON value"))
+    except (ValueError, RecursionError) as exc:
+        _refuse("invalid JSON: " + str(exc))
+
+
+class FolderProfile(str, Enum):
+    """Planned policies, not filesystem qualification.
+
+    Native v1 requires case-sensitive directories (no ext4 casefold). FAT32 name
+    equivalence/short-name aliases must be qualified before proving disjointness.
+    """
+
+    NATIVE_EXT4 = "native-ext4-folder.v1"
+    FAT32_SESSION = "fat32-folder-session.v1"
+
+    @property
+    def resume_policy(self):
+        return "authenticated" if self is FolderProfile.NATIVE_EXT4 else "new-root"
+
+
+@dataclass(frozen=True)
+class FolderTarget:
+    """Pre-creation target; no created root or free-space value is identity.
+
+    Native identity is the observed parent (inode, birth_ns). FAT32 identity is a
+    host-generated token naming a *retained live parent binding*, never a token read
+    from media. It cannot be recreated from serialized state to authorize resume.
+    filesystem_scope/path must already disambiguate aliases/backing identity; a UUID
+    alone is not enough. Unknown topology must be refused by the future observer.
+    """
+
+    profile: FolderProfile
+    filesystem_scope: str
+    parent_parts: tuple[str, ...]
+    parent_identity: tuple[int, int] | str
+    child_name: str
+
+    def __post_init__(self):
+        try:
+            profile = FolderProfile(self.profile)
+        except (ValueError, TypeError):
+            _refuse("unsupported folder profile")
+        object.__setattr__(self, "profile", profile)
+        if not _text(self.filesystem_scope):
+            _refuse("unambiguous filesystem scope required")
+        if not isinstance(self.parent_parts, (tuple, list)):
+            _refuse("filesystem-relative parent components required")
+        for part in self.parent_parts:
+            _component(part)
+        object.__setattr__(self, "parent_parts", tuple(self.parent_parts))
+        _component(self.child_name)
+        if profile is FolderProfile.NATIVE_EXT4:
+            identity = self.parent_identity
+            if (not isinstance(identity, (tuple, list)) or len(identity) != 2
+                    or any(not _integer(n) or n == 0 for n in identity)):
+                _refuse("native parent inode and birth identity required")
+            object.__setattr__(self, "parent_identity", tuple(identity))
+        elif not isinstance(self.parent_identity, str) or not _HEX32.fullmatch(self.parent_identity):
+            _refuse("retained-session parent token required; persistent FAT32 identity is unsupported")
+
+    @property
+    def parts(self):
+        return (*self.parent_parts, self.child_name)
+
+    def _record(self):
+        return {"version": _TARGET_VERSION, **asdict(self)}
+
+    def to_json(self):
+        return _encode(self._record())
+
+    @property
+    def target_id(self):
+        return "folder-target-v1:" + hashlib.sha256(self.to_json().encode("utf-8")).hexdigest()
+
+    @classmethod
+    def _from_record(cls, value):
+        _fields(value, {"version", "profile", "filesystem_scope", "parent_parts", "parent_identity", "child_name"})
+        if value["version"] != _TARGET_VERSION:
+            _refuse("unsupported folder target version")
+        return cls(**{key: item for key, item in value.items() if key != "version"})
+
+    @classmethod
+    def from_json(cls, payload):
+        return cls._from_record(_decode(payload))
+
+
+def overlaps(first: FolderTarget, second: FolderTarget):
+    """Namespace conflict, not ownership proof or a cross-version reservation gate.
+
+    Compare components rather than textual prefixes. Even replaced parents or
+    distinct FAT32 session tokens do not erase a claim on the same target path.
+    Inputs must use the same canonical scope for recognized filesystem aliases.
+    """
+    if not isinstance(first, FolderTarget) or not isinstance(second, FolderTarget):
+        _refuse("folder targets required for overlap comparison")
+    if first.filesystem_scope != second.filesystem_scope:
+        return False
+    if first.profile is not second.profile:
+        _refuse("inconsistent profiles for one filesystem scope")
+    common = min(len(first.parts), len(second.parts))
+    if first.parts[:common] == second.parts[:common]:
+        return True
+    if first.profile is FolderProfile.FAT32_SESSION:
+        _refuse("FAT32 disjointness requires qualified driver name/alias semantics")
+    return False
+
+
+@dataclass(frozen=True)
+class CapacityObservation:
+    """Shared-space snapshot, not a reservation, guarantee or destination identity."""
+
+    available_bytes: int
+    free_inodes: int | None
+    headroom_bytes: int = 0
+
+    def __post_init__(self):
+        if (not _integer(self.available_bytes) or not _integer(self.headroom_bytes)
+                or (self.free_inodes is not None and not _integer(self.free_inodes))):
+            _refuse("nonnegative integer capacity observations required")
+
+
+@dataclass(frozen=True)
+class FolderReview:
+    """Review record only: cannot be approved/stored/started by the legacy engine.
+
+    The full record seal includes advisory observations so the reviewed text is
+    immutable. Its target ID does not. closure_seal references the unchanged domain
+    closure; this record is not a TransferPlan and provides no execution authority.
+    """
+
+    target: FolderTarget
+    closure_seal: str
+    capacity: CapacityObservation
+
+    def __post_init__(self):
+        if (not isinstance(self.target, FolderTarget) or not isinstance(self.capacity, CapacityObservation)
+                or not isinstance(self.closure_seal, str) or not _HEX64.fullmatch(self.closure_seal)):
+            _refuse("folder target, domain closure seal and capacity observation required")
+
+    @property
+    def version(self):
+        return _REVIEW_VERSION
+
+    @property
+    def execution_ready(self):
+        return False
+
+    def to_json(self):
+        return _encode({"version": self.version, "target": self.target._record(),
+                        "closure_seal": self.closure_seal, "capacity": asdict(self.capacity)})
+
+    @property
+    def seal(self):
+        return hashlib.sha256(self.to_json().encode("utf-8")).hexdigest()
+
+    @classmethod
+    def from_json(cls, payload):
+        value = _decode(payload)
+        _fields(value, {"version", "target", "closure_seal", "capacity"})
+        if value["version"] != _REVIEW_VERSION:
+            _refuse("unsupported folder review version")
+        _fields(value["capacity"], {"available_bytes", "free_inodes", "headroom_bytes"})
+        return cls(FolderTarget._from_record(value["target"]), value["closure_seal"],
+                   CapacityObservation(**value["capacity"]))

--- a/modelark/slice/folder_destination.py
+++ b/modelark/slice/folder_destination.py
@@ -1,0 +1,85 @@
+"""Native folder port: shared filesystem space, certified child-tree ownership.
+
+The retained tree is the existing parent, not an owned filesystem. The engine's
+first directory operation creates/certifies the only child this port may mutate.
+Assembly must supply a qualified observer recheck and hold launch/attempt authority.
+"""
+import errno
+import os
+import stat
+from contextlib import contextmanager
+from pathlib import PurePosixPath
+
+from .destination import UsbDestination, _port_io
+from .io_errors import classify_io
+from .folder_observation import check_directory
+from .transaction import TransferRefusal
+
+
+class NativeFolderDestination(UsbDestination):
+    def __init__(self, tree, binding, store, tx, *, recheck):
+        plan = store.load(tx)
+        if not plan.is_folder:
+            raise TransferRefusal("ADMISSION_CORRUPT", "native adapter requires a native plan")
+        self._child = plan.destination.target.child_name
+        self._required_inodes = plan.required_inodes
+        self._native_recheck = recheck
+        super().__init__(tree, binding, store, tx)
+
+    def _path(self, path, *, root=False):
+        UsbDestination._path(path, root=root)
+        if root and path == ".":
+            return path  # Only flush uses this exception to persist child creation.
+        if PurePosixPath(path).parts[0] != self._child:
+            raise TransferRefusal("OUTPUT_COLLISION", "path is outside the approved output folder")
+        return path
+
+    def _recheck_attachment(self):
+        self.tree.check()
+        self._native_recheck(self.tree)
+
+    @contextmanager
+    def _parent(self, path):
+        with super()._parent(path) as (fd, name):
+            check_directory(fd)
+            yield fd, name
+
+    @contextmanager
+    def _owned(self, path, token=None, *, write=False):
+        with super()._owned(path, token, write=write) as fd:
+            if stat.S_ISDIR(os.fstat(fd).st_mode):
+                check_directory(fd)
+            yield fd
+
+    def _io_refusal(self, exc):
+        if exc.errno in {errno.ENOSPC, errno.EDQUOT}:
+            # A partial append may already have allocated blocks. End this attempt;
+            # the next Start rebuilds actual allocation from authenticated objects.
+            return classify_io(exc, self._recheck_attachment,
+                               TransferRefusal("DESTINATION_CAPACITY_WAIT", str(exc)))
+        return super()._io_refusal(exc)
+
+    @_port_io
+    def check(self, binding, allocated, required_bytes):
+        self._recheck_attachment()
+        if binding != self.binding:
+            raise TransferRefusal("DESTINATION_CHANGED", "folder binding changed")
+        if any(type(value) is not int or value < 0 for value in (allocated, required_bytes)):
+            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN")
+        actual, owned_inodes = self._audit_allocation()
+        if actual != allocated:
+            raise TransferRefusal("DESTINATION_ALLOCATION_UNPROVEN", "owned allocation differs")
+        # Parent growth and sibling bytes/inodes are not part of this transaction.
+        # An existing certified root disappearing is not a new-root opportunity.
+        with self._connection() as con:
+            certified = con.execute("SELECT 1 FROM certificates WHERE tx=? AND seal=? AND device=? "
+                                    "AND filesystem=? AND mount=? AND path=? AND kind='directory' LIMIT 1",
+                                    (*self._scope, self._child)).fetchone()
+        if certified and self.inspect(self._child) is None:
+            raise TransferRefusal("DESTINATION_CHANGED", "certified output root disappeared")
+        free = os.fstatvfs(self.tree.fd)
+        available = free.f_bavail * free.f_frsize
+        remaining_inodes = max(0, self._required_inodes - owned_inodes)
+        if (available < max(0, required_bytes - actual)
+                or min(free.f_favail, free.f_ffree) < remaining_inodes):
+            raise TransferRefusal("DESTINATION_CAPACITY_WAIT", "shared filesystem space/inodes insufficient")

--- a/modelark/slice/folder_observation.py
+++ b/modelark/slice/folder_observation.py
@@ -4,8 +4,9 @@ The writer must exclusively create a 0700 root, authenticate any resumed child,
 and retain/recheck the observed parent. No probe creates files, reads raw block
 devices, or changes permissions. Non-owner-writable parents need sticky protection;
 root/current-user ownership prevents another directory owner removing the child.
-Ordinary default ACLs are allowed only when their owner entry preserves rwx:
-the required 0700 creation mode masks all inherited non-owner permissions.
+Ordinary default ACLs are allowed only when their owner entry preserves rwx and
+both inherited ACLs leave room for the ownership marker in one xattr block. The
+required 0700 creation mode masks all inherited non-owner permissions.
 """
 from dataclasses import dataclass
 import errno
@@ -19,6 +20,7 @@ import struct
 import subprocess
 
 from .folder_contract import CapacityObservation, FolderProfile, FolderTarget
+from .destination import owner_marker
 from .hardware import _Inventory, _backing_identity, _inventory, _nonempty
 from .host_observation import parse_mounts, read_fs_text, resolve_protected
 from .io_errors import classify_io, probe_io
@@ -64,6 +66,20 @@ def _directory_flags(fd):
     return struct.unpack('=L', fcntl.ioctl(fd, 0x80086601, bytes(8))[:4])[0]
 
 
+def _marker_space(fd, acl_size):
+    # A new directory inherits access AND default ACLs. Charge their full Linux
+    # xattr sizes (larger than ext4's compact format), the padded owner marker,
+    # and 256 bytes for the block header, entries/names, alignment and slack.
+    # Do not credit in-inode storage, ACL sharing or EA-inode support. This is
+    # an ACL/marker compatibility bound, not a reservation against quota, other
+    # security xattrs or concurrent allocation. Rechecked before every mkdir.
+    value = os.fstatvfs(fd)
+    block_size = min(value.f_bsize, value.f_frsize)
+    if block_size < len(owner_marker('0' * 32)) + 2 * acl_size + 256:
+        _refuse('inherited ACL and ownership marker exceed the native xattr budget',
+                'DESTINATION_NOT_WRITABLE')
+
+
 @probe_io('DESTINATION_NOT_WRITABLE', 'native parent permissions or xattrs unavailable')
 def _permissions(fd):
     require_create_access(fd)
@@ -81,6 +97,7 @@ def _permissions(fd):
         acl = os.getxattr(fd, 'system.posix_acl_default')
     except OSError as exc:
         if exc.errno == errno.ENODATA:
+            _marker_space(fd, 0)
             return
         raise
     if len(acl) < 4 or (len(acl) - 4) % 8 or struct.unpack('<I', acl[:4])[0] != 2:
@@ -90,6 +107,7 @@ def _permissions(fd):
     if owners != [7] or any(permissions & ~7 for _, permissions, _ in entries):
         _refuse('inherited ACL must preserve owner rwx for a 0700 output root',
                 'DESTINATION_NOT_WRITABLE')
+    _marker_space(fd, len(acl))
 
 
 @probe_io('DESTINATION_CAPACITY_UNPROVEN', 'shared-space observation unavailable')

--- a/modelark/slice/folder_observation.py
+++ b/modelark/slice/folder_observation.py
@@ -1,0 +1,316 @@
+"""Native ext4 folder admission; read-only evidence, never execution authority.
+
+The writer must exclusively create a 0700 root, authenticate any resumed child,
+and retain/recheck the observed parent. No probe creates files, reads raw block
+devices, or changes permissions. Non-owner-writable parents need sticky protection;
+root/current-user ownership prevents another directory owner removing the child.
+Ordinary default ACLs are allowed only when their owner entry preserves rwx:
+the required 0700 creation mode masks all inherited non-owner permissions.
+"""
+from dataclasses import dataclass
+import errno
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import struct
+import subprocess
+
+from .folder_contract import CapacityObservation, FolderProfile, FolderTarget
+from .hardware import _Inventory, _backing_identity, _inventory, _nonempty
+from .host_observation import parse_mounts, read_fs_text, resolve_protected
+from .io_errors import classify_io, probe_io
+from .linux import BoundTree, require_create_access
+from .paths import canonical_attachment
+from .transaction import TransferRefusal
+
+
+_OS_SUBTREES = ('/boot', '/usr', '/etc', '/var', '/bin', '/sbin', '/lib', '/lib64',
+                '/dev', '/proc', '/sys', '/run', '/root')
+
+
+def _refuse(detail, code='DESTINATION_UNPROVEN'):
+    raise TransferRefusal(code, detail)
+
+
+def _within(path, parent):
+    return path == parent or path.startswith(parent.rstrip('/') + '/')
+
+
+@dataclass(frozen=True)
+class NativeFolderEvidence:
+    target: FolderTarget
+    parent_path: str
+    destination_path: str
+    filesystem_id: str
+    backing_ids: tuple[str, ...]
+    mount_id: int
+    major_minor: str
+    capacity: CapacityObservation
+    name_max: int
+    block_size: int
+
+
+def _stable(value):
+    return (value.target, value.parent_path, value.destination_path, value.filesystem_id,
+            value.backing_ids, value.mount_id, value.major_minor, value.name_max, value.block_size)
+
+
+@probe_io('FILESYSTEM_UNSUPPORTED', 'native directory flags unavailable')
+def _directory_flags(fd):
+    # FS_IOC_GETFLAGS uses long in its ioctl number; supported Linux ABIs are 64-bit.
+    return struct.unpack('=L', fcntl.ioctl(fd, 0x80086601, bytes(8))[:4])[0]
+
+
+@probe_io('DESTINATION_NOT_WRITABLE', 'native parent permissions or xattrs unavailable')
+def _permissions(fd):
+    require_create_access(fd)
+    info = os.fstat(fd)
+    if info.st_uid not in {0, os.geteuid()}:
+        _refuse('parent must be owned by the current user or root', 'DESTINATION_NOT_WRITABLE')
+    if info.st_mode & 0o022 and not info.st_mode & stat.S_ISVTX:
+        _refuse('non-owner-writable parent requires sticky protection', 'DESTINATION_NOT_WRITABLE')
+    try:
+        os.getxattr(fd, 'user.modelark.slice-capability-probe')
+    except OSError as exc:
+        if exc.errno != errno.ENODATA:
+            raise
+    try:
+        acl = os.getxattr(fd, 'system.posix_acl_default')
+    except OSError as exc:
+        if exc.errno == errno.ENODATA:
+            return
+        raise
+    if len(acl) < 4 or (len(acl) - 4) % 8 or struct.unpack('<I', acl[:4])[0] != 2:
+        _refuse('unrecognized inherited ACL', 'DESTINATION_NOT_WRITABLE')
+    entries = tuple(struct.iter_unpack('<HHI', acl[4:]))
+    owners = [permissions for tag, permissions, _ in entries if tag == 1]
+    if owners != [7] or any(permissions & ~7 for _, permissions, _ in entries):
+        _refuse('inherited ACL must preserve owner rwx for a 0700 output root',
+                'DESTINATION_NOT_WRITABLE')
+
+
+@probe_io('DESTINATION_CAPACITY_UNPROVEN', 'shared-space observation unavailable')
+def _capacity(fd):
+    value = os.fstatvfs(fd)
+    if (value.f_frsize <= 0 or value.f_bavail < 0 or value.f_bavail > value.f_blocks
+            or min(value.f_favail, value.f_ffree) < 0):
+        _refuse('invalid shared-space observation', 'DESTINATION_CAPACITY_UNPROVEN')
+    return CapacityObservation(value.f_bavail * value.f_frsize,
+                               min(value.f_favail, value.f_ffree)), value.f_frsize
+
+
+def check_directory(fd, *, flags=None):
+    """Read-only flag/permission admission for retained parent or owned directories."""
+    # fscrypt, casefold, verity, immutable, append-only and inline-data directory
+    # semantics are not qualified. Ordinary indexed/multiblock directories are.
+    if (flags or _directory_flags)(fd) & (0x800 | 0x40000000 | 0x100000 | 0x10 | 0x20 | 0x10000000):
+        _refuse('unqualified native directory flags', 'FILESYSTEM_UNSUPPORTED')
+    _permissions(fd)
+
+
+class NativeFolderObserver:
+    """Strict ext4 folder observations with injectable read-only host providers.
+
+    One unambiguous mount and a single-parent block chain are required. Bind mount
+    aliases and multi-parent mappings fail closed; ordinary single-parent LVM/crypt
+    chains do not require raw-device access. System backing is permitted, OS-managed
+    subtrees are not. Callers MUST supply catalog/runtime/private paths in addition
+    to the standard private state paths below. Missing paths remain lexically protected.
+    """
+
+    def __init__(self, *, inventory=None, mounts=None, tree_factory=BoundTree,
+                 backing=None, resolver=None, flags=None):
+        self._inventory = inventory or _inventory
+        self._mounts = mounts or (lambda: read_fs_text('/proc/self/mountinfo'))
+        self._tree_factory = tree_factory
+        self._backing = backing or _backing_identity
+        self._resolver = resolver or resolve_protected
+        self._flags = flags or _directory_flags
+        self._observed = {}
+
+    def _protected(self, destination, mounts, extra):
+        private = (Path.home() / '.local/state/modelark', Path.home() / '.local/share/modelark',
+                   Path.home() / '.config/modelark', Path.home() / '.cache/modelark')
+        result = []
+        for role in (*_OS_SUBTREES, *private, *extra):
+            requested = str(canonical_attachment(role))
+            if requested == '/':
+                _refuse('root cannot be supplied as an unrestricted protected role')
+            # Protect exact file roles and whole directory roles, not the parent of
+            # a catalog file: ~/catalog.sqlite must not ban every ~/exports child.
+            try:
+                directory = not Path(requested).is_file()
+                target = self._resolver(requested, directory=directory, optional=True)
+            except FileNotFoundError:
+                # resolve_protected distinguishes genuinely missing from dangling links.
+                raise
+            paths = [requested]
+            if target is not None:
+                matching = [m for m in mounts if m.mount_id == target.mount_id]
+                if (len(matching) != 1 or matching[0].major_minor != target.major_minor
+                        or not _within(target.path, matching[0].path)):
+                    _refuse('protected role differs from mount inventory')
+                paths.append(target.path)
+            if any(_within(destination, path) or _within(path, destination) for path in paths):
+                _refuse('output intersects a protected OS, catalog, runtime or private subtree')
+            result.append((directory, requested, target))
+        return tuple(result)
+
+    def _roles(self, inventory, key, archives):
+        disk_key = inventory.disk(key)
+        disk = inventory.nodes[disk_key]
+        serial, wwn = _nonempty(disk.get('serial')), _nonempty(disk.get('wwn'))
+        if not (serial or wwn):
+            _refuse('stable backing disk identity required')
+        # Refuse unknown mappings, cycles and read-only members. _Inventory already
+        # refuses ambiguous duplicate identities and multiple-parent lsblk trees.
+        current = key
+        while True:
+            node = inventory.nodes[current]
+            if node.get('type') not in {'disk', 'part', 'crypt', 'lvm'}:
+                _refuse('unqualified block mapping')
+            if node.get('ro') not in (False, 0, '0'):
+                _refuse('read-only or unknown backing member', 'DESTINATION_NOT_WRITABLE')
+            if current == disk_key:
+                break
+            current = inventory.parents[current]
+        for archive in archives:
+            uuid = _nonempty(getattr(archive, 'fs_uuid', None))
+            archive_serial = _nonempty(getattr(archive, 'serial', None))
+            if not uuid and not archive_serial:
+                _refuse('registered archive lacks comparable backing identity')
+            if archive_serial and archive_serial in {serial, wwn}:
+                _refuse('registered archive backing disk is excluded')
+            for candidate, value in inventory.nodes.items():
+                candidate_uuid = _nonempty(value.get('uuid'))
+                if uuid and candidate_uuid and uuid.casefold() == candidate_uuid.casefold():
+                    if inventory.disk(candidate) == disk_key:
+                        _refuse('registered archive filesystem or sibling backing disk is excluded')
+        return tuple(sorted(key for key in (('wwn:' + wwn) if wwn else None,
+                                            ('serial:' + serial) if serial else None) if key))
+
+    def _read(self, tree, destination, inventory, mounts, archives, protected_paths):
+        tree.check()
+        info = os.fstat(tree.fd)
+        key = f'{os.major(info.st_dev)}:{os.minor(info.st_dev)}'
+        covering = [m for m in mounts if _within(str(tree.path), m.path)]
+        if not covering:
+            _refuse('parent has no covering mount')
+        longest = max(len(m.path) for m in covering)
+        matching = [m for m in covering if len(m.path) == longest]
+        if len(matching) != 1:
+            _refuse('parent has ambiguous covering mounts')
+        mount = matching[0]
+        if mount.mount_id != tree.mount_id or mount.major_minor != key:
+            _refuse('parent descriptor differs from mount inventory', 'DESTINATION_CHANGED')
+        if mount.root != '/' or sum(m.major_minor == key for m in mounts) != 1:
+            _refuse('filesystem mount aliases are not qualified')
+        if any(_within(m.path, destination) for m in mounts if m != mount):
+            _refuse('nested output mount is not qualified')
+        if key not in inventory.nodes:
+            _refuse('mounted block backing unavailable', 'WAITING_DESTINATION')
+        node = inventory.nodes[key]
+        if mount.fs_type != 'ext4' or node.get('fstype') != 'ext4':
+            _refuse('native folder profile requires ext4', 'FILESYSTEM_UNSUPPORTED')
+        if 'rw' not in mount.options or {'ro', 'nouser_xattr'} & mount.options:
+            _refuse('writable user-xattr mount required', 'DESTINATION_NOT_WRITABLE')
+        uuid = _nonempty(node.get('uuid'))
+        if not uuid:
+            _refuse('stable filesystem identity required')
+        backing_ids = self._roles(inventory, key, archives)
+        protected = self._protected(destination, mounts, protected_paths)
+        check_directory(tree.fd, flags=self._flags)
+        capacity, block_size = _capacity(tree.fd)
+        name_max = os.fpathconf(tree.fd, 'PC_NAME_MAX')
+        if name_max <= 0 or len(os.fsencode(Path(destination).name)) > name_max:
+            _refuse('output name exceeds filesystem capability', 'DESTINATION_LAYOUT_UNSUPPORTED')
+        filesystem_scope = 'native-fs-v1:' + hashlib.sha256(json.dumps(
+            {'uuid': uuid.casefold(), 'backing': backing_ids}, sort_keys=True).encode()).hexdigest()
+        parts = Path(tree.path).relative_to(mount.path).parts
+        identity = tree.identity(tree.fd)
+        target = FolderTarget(FolderProfile.NATIVE_EXT4, filesystem_scope, parts,
+                              identity[1:], Path(destination).name)
+        # One canonical representation must cross observation/admission/state; do
+        # not append aliases after sorting only the physical-disk subset.
+        backing_ids = tuple(sorted(set((*backing_ids, 'filesystem:' + uuid, filesystem_scope))))
+        evidence = NativeFolderEvidence(target, str(tree.path), destination, uuid,
+                                        backing_ids, tree.mount_id, key,
+                                        capacity, name_max, block_size)
+        tree.check()
+        return evidence, protected
+
+    def observe(self, destination_path, *, archives, protected_paths=(), allow_existing=False):
+        """Observe only. allow_existing is NOT ownership proof or resume permission."""
+        destination = canonical_attachment(destination_path)
+        archives, protected_paths = tuple(archives), tuple(protected_paths)
+        if destination == Path('/'):
+            _refuse('output must be a child of an existing parent', 'PATH_UNSAFE')
+        try:
+            payload = json.dumps(self._inventory(), sort_keys=True)
+            inventory = _Inventory(json.loads(payload))
+            mounts = parse_mounts(self._mounts())
+            with self._tree_factory(destination.parent) as tree:
+                value, protected = self._read(tree, str(destination), inventory, mounts,
+                                              tuple(archives), tuple(protected_paths))
+                if not allow_existing:
+                    try:
+                        os.stat(destination.name, dir_fd=tree.fd, follow_symlinks=False)
+                    except FileNotFoundError:
+                        pass
+                    else:
+                        _refuse('output already exists; exclusive creation required', 'DESTINATION_COLLISION')
+                backing = self._backing(value.major_minor)
+                if (json.dumps(self._inventory(), sort_keys=True) != payload
+                        or parse_mounts(self._mounts()) != mounts
+                        or self._protected(str(destination), mounts, protected_paths) != protected
+                        or self._backing(value.major_minor) != backing):
+                    _refuse('folder observation changed during admission', 'DESTINATION_CHANGED')
+                tree.check()
+                self._observed[value.target.target_id] = (value, inventory, mounts, backing,
+                                                          tuple(archives), tuple(protected_paths))
+                return value
+        except TransferRefusal:
+            raise
+        except (OSError, subprocess.SubprocessError, ValueError) as exc:
+            if isinstance(exc, OSError):
+                raise classify_io(exc, None, TransferRefusal('DESTINATION_UNPROVEN', str(exc))) from exc
+            raise TransferRefusal('DESTINATION_UNPROVEN', str(exc)) from exc
+
+    def recheck(self, tree, evidence, *, archives=None):
+        """Revalidate retained parent, permitting an owned child; capacity is advisory."""
+        proof = self._observed.get(evidence.target.target_id)
+        if proof is None or _stable(proof[0]) != _stable(evidence) or str(tree.path) != evidence.parent_path:
+            _refuse('no matching parent observation', 'DESTINATION_CHANGED')
+        original, inventory, mounts, backing, prior_archives, protected_paths = proof
+        try:
+            tree.check()
+            try:
+                current_backing = self._backing(evidence.major_minor)
+            except FileNotFoundError:
+                _refuse('observed backing disappeared', 'WAITING_DESTINATION')
+            if current_backing != backing:
+                _refuse('observed backing changed', 'DESTINATION_CHANGED')
+            roles = prior_archives if archives is None else tuple(archives)
+            current_mounts = parse_mounts(self._mounts())
+            current = evidence.major_minor
+            mapped = False
+            while current is not None:
+                mapped |= inventory.nodes[current].get('type') in {'crypt', 'lvm'}
+                current = inventory.parents[current]
+            # A dm table reload need not change mountinfo or the dm sysfs inode.
+            # Re-observe mapped ancestry until a cheaper retained topology proof is
+            # qualified; a stale disk-role cache cannot authorize archive writes.
+            if current_mounts != mounts or roles != prior_archives or mapped:
+                value = self.observe(evidence.destination_path, archives=roles,
+                                     protected_paths=protected_paths, allow_existing=True)
+            else:
+                value, _ = self._read(tree, evidence.destination_path, inventory, mounts, roles, protected_paths)
+            if _stable(value) != _stable(original):
+                _refuse('folder binding changed', 'DESTINATION_CHANGED')
+            tree.check()
+            return value
+        except OSError as exc:
+            raise classify_io(exc, tree.check, TransferRefusal('DESTINATION_UNPROVEN', str(exc))) from exc

--- a/modelark/slice/folder_operator.py
+++ b/modelark/slice/folder_operator.py
@@ -1,0 +1,154 @@
+"""Launch-guarded native folder assembly. No Fill/catalog mutation or retrieval."""
+from dataclasses import asdict, replace
+import os
+from pathlib import Path, PurePosixPath
+
+from . import domain as d
+from . import transaction as t
+from . import state as private_state
+from .catalog import read_catalog
+from .folder_contract import _component
+from .folder_destination import NativeFolderDestination
+from .folder_observation import NativeFolderObserver
+from .folder_plan import NativePlan, binding_for, estimate_metadata
+from .hardware import LinuxObserver
+from .host_observation import parse_mounts, read_fs_text
+from .io_errors import io_boundary
+from .linux import BoundTree
+from .local_source import LocalArchiveReader
+from .paths import canonical_attachment, utf8_size
+from .sources import FencedSources
+
+
+def _protected(catalog):
+    # Actual runtime code, catalog and private state are roles, not whole disks.
+    return (str(private_state.HOST_STATE_DIR), str(catalog), str(Path(__file__).resolve().parents[1]))
+
+
+def _filesystem_type(parent):
+    """Read-only routing hint, never filesystem or destination admission.
+
+    The selected observer must still prove the actual retained parent, complete
+    mount/backing/role evidence and capabilities. No fallback after an admission
+    refusal is permitted, including a topology change after this hint was read.
+    """
+    with io_boundary(None, "DESTINATION_UNPROVEN", "folder profile routing inventory unavailable"):
+        mounts = parse_mounts(read_fs_text("/proc/self/mountinfo"))
+    covering = [mount for mount in mounts if parent.is_relative_to(mount.path)]
+    if not covering:
+        raise t.TransferRefusal("DESTINATION_UNPROVEN", "parent has no covering mount")
+    longest = max(len(mount.path) for mount in covering)
+    selected = [mount for mount in covering if len(mount.path) == longest]
+    if len(selected) != 1:
+        raise t.TransferRefusal("DESTINATION_UNPROVEN", "ambiguous folder profile routing")
+    return selected[0].fs_type
+
+
+def _layout(proposal, evidence):
+    root = proposal.spec.destination_root
+    paths = [str(PurePosixPath(root) / item.repo_id / item.rfilename) for item in proposal.closure]
+    paths += [root + "/.modelark-slice-owner", root + "/.modelark-slice-receipt.json"]
+    names = set(paths)
+    for path in paths:
+        value = PurePosixPath(path)
+        if any(str(parent) in names for parent in value.parents):
+            raise t.TransferRefusal("DESTINATION_LAYOUT_UNSUPPORTED", "file/directory layout collision")
+        for part in value.parts:
+            _component(part)
+            if utf8_size(part) > evidence.name_max or part.startswith(".slice-"):
+                raise t.TransferRefusal("DESTINATION_LAYOUT_UNSUPPORTED", "unsupported or reserved output name")
+        temporary = str(value.parent / (".slice-" + "0" * 32))
+        for name in (path, temporary):
+            if utf8_size(name) >= 4096 or utf8_size(evidence.parent_path + "/" + name) >= 4096:
+                raise t.TransferRefusal("DESTINATION_LAYOUT_UNSUPPORTED", "output or temporary path too long")
+
+
+def preview(catalog_path, destination_path, repo_ids):
+    from .operator import _archives, _store
+    catalog = str(Path(catalog_path).expanduser().resolve())
+    destination = canonical_attachment(destination_path)
+    spec = d.SliceSpec(tuple(repo_ids), "pending-folder-observation", destination.name)
+    snapshot = read_catalog(catalog, spec)
+    proposal = d.preview(spec, snapshot)
+    if not proposal.source_ready:
+        return {"ok": False, "state": "blocked", "executable": False,
+                "gaps": [asdict(gap) for gap in proposal.gaps], "preview": asdict(proposal)}
+    if _filesystem_type(destination.parent) == "vfat":
+        from .fat32_operator import preview as fat32_preview
+        return fat32_preview(catalog, destination, repo_ids)
+    observer = NativeFolderObserver()
+    archives = _archives(catalog)
+    evidence = observer.observe(destination, archives=archives, protected_paths=_protected(catalog))
+    proposal = d.preview(replace(spec, destination_id=evidence.target.target_id), snapshot)
+    _layout(proposal, evidence)
+    binding = binding_for(evidence.target, catalog, evidence.parent_path, evidence.backing_ids)
+    reserve = estimate_metadata(proposal, binding, catalog, evidence.parent_path, evidence.backing_ids,
+                                evidence.capacity, private_state.HOST_STATE_DIR)
+    plan = NativePlan(proposal, binding, catalog, evidence.parent_path, evidence.backing_ids,
+                      evidence.capacity, reserve)
+    with io_boundary(None, "DESTINATION_UNPROVEN", "native folder preview setup/teardown failed"), \
+            BoundTree(evidence.parent_path, writable=True) as tree:
+        fresh = observer.recheck(tree, evidence, archives=_archives(catalog))
+        if fresh.capacity.available_bytes < plan.required_bytes(private_state.HOST_STATE_DIR):
+            raise t.TransferRefusal("DESTINATION_CAPACITY_WAIT", "shared capacity insufficient at preview")
+        if fresh.capacity.free_inodes is None:
+            raise t.TransferRefusal("DESTINATION_CAPACITY_UNPROVEN", "native free inode observation required")
+        if fresh.capacity.free_inodes < plan.required_inodes:
+            raise t.TransferRefusal("DESTINATION_CAPACITY_WAIT", "shared inode capacity insufficient at preview")
+        # A caller may have occupied the name since the initial read-only observation.
+        with tree.parent(destination.name) as (parent, name):
+            try:
+                os.stat(name, dir_fd=parent, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                raise t.TransferRefusal("OUTPUT_COLLISION", "output folder already exists")
+    approval = d.approve(proposal, expected_seal=proposal.seal, current_snapshot=snapshot)
+    tx = _store().create(plan, approval)
+    return {"ok": True, "state": "ready", "executable": False, "transaction_id": tx,
+            "seal": plan.seal, "plan": asdict(plan), "ownership": "new-output-folder-only",
+            "capacity_policy": "advisory-shared-space-not-reserved", "resume_policy": "authenticated"}
+
+
+def start(store, tx, plan, destination_path, attachments):
+    from .operator import _archives, _result, _acknowledge_interrupt
+    path = canonical_attachment(destination_path)
+    if str(path.parent) != plan.parent_path or path.name != plan.destination.target.child_name:
+        raise t.TransferRefusal("DESTINATION_CHANGED", "Start must name the approved output folder")
+    allowed = {source.drive.drive_label for artifact in plan.proposal.closure for source in artifact.sources}
+    if not isinstance(attachments, dict) or set(attachments) - allowed:
+        raise t.TransferRefusal("SOURCE_ATTACHMENT_UNSEALED")
+    observer = NativeFolderObserver()
+    evidence = observer.observe(path, archives=_archives(plan.catalog),
+                                protected_paths=_protected(plan.catalog), allow_existing=True)
+    if (evidence.target != plan.destination.target or evidence.backing_ids != plan.backing_ids):
+        raise t.TransferRefusal("DESTINATION_CHANGED", "folder parent or backing differs from approval")
+    _layout(plan.proposal, evidence)
+    with io_boundary(None, "DESTINATION_IO_FAILED", "native folder setup/teardown failed"), \
+            BoundTree(plan.parent_path, writable=True) as tree:
+        def recheck(parent):
+            return observer.recheck(parent, evidence, archives=_archives(plan.catalog))
+
+        with io_boundary(lambda: recheck(tree), "DESTINATION_IO_FAILED", "native folder execution failed"):
+            recheck(tree)
+            destination = NativeFolderDestination(tree, plan.destination, store, tx, recheck=recheck)
+            # Destination folder eligibility does not replace archive source proof.
+            sources = FencedSources(plan.catalog, LocalArchiveReader(attachments, observer=LinuxObserver()))
+            try:
+                session = t.start(store, tx, destination, sources)
+            except KeyboardInterrupt:
+                return _result(_acknowledge_interrupt(store, tx, destination, sources),
+                               stop_requested=True)
+            except t.TransferRefusal as exc:
+                if exc.code == "DESTINATION_CAPACITY_WAIT":
+                    return _result(store.status(tx))
+                raise
+            if isinstance(session, t.Status):
+                return _result(session)
+            with session:
+                try:
+                    return _result(session.run())
+                except KeyboardInterrupt:
+                    # Acknowledge while this attempt's lease is still retained.
+                    return _result(_acknowledge_interrupt(store, tx, destination, sources, session),
+                                   stop_requested=True)

--- a/modelark/slice/folder_plan.py
+++ b/modelark/slice/folder_plan.py
@@ -1,0 +1,214 @@
+"""Versioned native-folder plans; observations and seals are not writer authority.
+
+Capacity is immutable review evidence, never attachment identity or a reservation.
+The admitted adapter must authenticate the parent/output objects and recheck shared
+space at runtime. This envelope cannot be decoded as a legacy USB transaction.
+"""
+from dataclasses import asdict, dataclass, fields
+import hashlib
+import json
+from pathlib import PurePosixPath
+import re
+
+from . import domain as d
+from .folder_contract import CapacityObservation, FolderProfile, FolderTarget, _decode, _fields
+from .transaction import TransferRefusal
+
+
+VERSION = "modelark.slice.native-transaction.v1"
+_ADMISSION_PREFIX = "native-folder-v1:"
+_SHA = re.compile(r"[0-9a-f]{64}\Z")
+
+
+def _absolute(value):
+    if (not isinstance(value, str) or not value or "\0" in value
+            or not value.startswith("/") or value.startswith("//")
+            or str(PurePosixPath(value)) != value or ".." in PurePosixPath(value).parts):
+        raise TransferRefusal("FOLDER_PLAN_INVALID", "canonical absolute path required")
+    try:
+        value.encode("utf-8", errors="strict")
+    except UnicodeError as exc:
+        raise TransferRefusal("FOLDER_PLAN_INVALID", "strict UTF-8 path required") from exc
+    return value
+
+
+def _backing(values):
+    if (not isinstance(values, (tuple, list)) or not values
+            or any(not isinstance(value, str) or not value or value != value.strip()
+                   or "\0" in value for value in values)):
+        raise TransferRefusal("FOLDER_PLAN_INVALID", "backing identities required")
+    if tuple(values) != tuple(sorted(set(values))):
+        raise TransferRefusal("FOLDER_PLAN_INVALID", "backing identities must be sorted and unique")
+    return tuple(values)
+
+
+def _proposal_record(record):
+    """Reject unknown fields even where the shared legacy decoder selects keys."""
+    _fields(record, {field.name for field in fields(d.SlicePreview)})
+    _fields(record["spec"], {field.name for field in fields(d.SliceSpec)})
+    for artifact in record["closure"]:
+        _fields(artifact, {field.name for field in fields(d.Artifact)})
+        for source in artifact["sources"]:
+            _fields(source, {field.name for field in fields(d.SourceEvidence)})
+            for key, record_type in (("copy", d.CopyFact), ("drive", d.DriveFact), ("anchor", d.AnchorFact)):
+                _fields(source[key], {field.name for field in fields(record_type)})
+    for gap in record["gaps"]:
+        _fields(gap, {field.name for field in fields(d.Gap)})
+    return record
+
+
+@dataclass(frozen=True)
+class NativeBinding:
+    target: FolderTarget
+    admission_id: str
+
+    def __post_init__(self):
+        if (not isinstance(self.target, FolderTarget)
+                or self.target.profile is not FolderProfile.NATIVE_EXT4
+                or not isinstance(self.admission_id, str)
+                or not self.admission_id.startswith(_ADMISSION_PREFIX)
+                or not _SHA.fullmatch(self.admission_id[len(_ADMISSION_PREFIX):])):
+            raise TransferRefusal("FOLDER_PLAN_INVALID", "native binding required")
+
+    @property
+    def device_id(self):
+        return self.target.target_id
+
+    @property
+    def filesystem_id(self):
+        return self.target.filesystem_scope
+
+    @property
+    def mount_id(self):
+        return self.admission_id
+
+
+def binding_for(target, catalog, parent_path, backing_ids):
+    """Bind stable admission policy, excluding mutable free-space observations."""
+    if not isinstance(target, FolderTarget) or target.profile is not FolderProfile.NATIVE_EXT4:
+        raise TransferRefusal("FOLDER_PLAN_INVALID", "native target required")
+    payload = {"version": VERSION, "target": json.loads(target.to_json()),
+               "catalog": _absolute(catalog), "parent_path": _absolute(parent_path),
+               "backing_ids": _backing(backing_ids)}
+    return NativeBinding(target, _ADMISSION_PREFIX + hashlib.sha256(d._json(payload)).hexdigest())
+
+
+@dataclass(frozen=True)
+class NativePlan:
+    proposal: d.SlicePreview
+    destination: NativeBinding
+    catalog: str
+    parent_path: str
+    backing_ids: tuple[str, ...]
+    capacity: CapacityObservation
+    metadata_reserve_bytes: int
+    version: str = VERSION
+
+    def __post_init__(self):
+        if (self.version != VERSION or not isinstance(self.proposal, d.SlicePreview)
+                or not isinstance(self.destination, NativeBinding)
+                or not isinstance(self.capacity, CapacityObservation)
+                or not d._integer(self.metadata_reserve_bytes)):
+            raise TransferRefusal("FOLDER_PLAN_INVALID", "typed native plan required")
+        d._verify(self.proposal)
+        if not self.proposal.source_ready:
+            raise TransferRefusal("PREVIEW_BLOCKED")
+        object.__setattr__(self, "backing_ids", _backing(self.backing_ids))
+        expected = binding_for(self.destination.target, self.catalog, self.parent_path, self.backing_ids)
+        if self.destination != expected:
+            raise TransferRefusal("ADMISSION_CORRUPT", "native admission differs from binding")
+        if (self.proposal.spec.destination_id != expected.device_id
+                or self.proposal.spec.destination_root != expected.target.child_name):
+            raise TransferRefusal("DESTINATION_CHANGED", "closure differs from reviewed folder intent")
+        self.required_bytes("")
+
+    @property
+    def is_folder(self):
+        return True
+
+    @property
+    def control_path(self):
+        return self.destination.target.child_name + "/.modelark-slice-owner"
+
+    @property
+    def required_inodes(self):
+        root = PurePosixPath(self.proposal.spec.destination_root)
+        directories = {parent for artifact in self.proposal.closure
+                       for parent in (root / artifact.repo_id / artifact.rfilename).parents
+                       if str(parent) != "."}
+        # Staging and final names share one inode, including during publication.
+        return len(directories) + len(self.proposal.closure) + 2  # control + receipt
+
+    def to_json(self):
+        return d._json(asdict(self)).decode()
+
+    @property
+    def seal(self):
+        return hashlib.sha256(self.to_json().encode()).hexdigest()
+
+    def receipt(self, tx, files):
+        return {"version": self.version, "transaction": tx, "seal": self.seal,
+                "destination": asdict(self.destination), "files": files,
+                "plan": json.loads(self.to_json()), "topology": "folder", "status": "complete",
+                "profile": self.destination.target.profile.value, "resume_policy": "authenticated",
+                "capacity_evidence": "advisory-shared-space-not-reserved",
+                "verification": {"content": "sha256-original-bytes", "layout": "authenticated",
+                                 "result": "verified", "file_count": len(files)}}
+
+    def _metadata_minimum(self, store_root):
+        tx = "0" * 32
+        root = PurePosixPath(self.proposal.spec.destination_root)
+        files = [{"path": str(root / artifact.repo_id / artifact.rfilename),
+                  "size": artifact.size_bytes, "sha256": artifact.sha256,
+                  "source": asdict(max(artifact.sources, key=lambda source: len(d._json(asdict(source)))))}
+                 for artifact in self.proposal.closure]
+        control = {"transaction": tx, "seal": self.seal, "store": str(store_root),
+                   "destination": asdict(self.destination)}
+        return len(d._json(control)) + len(d._json(self.receipt(tx, files)))
+
+    def required_bytes(self, store_root):
+        if self.metadata_reserve_bytes < self._metadata_minimum(store_root):
+            raise TransferRefusal("DESTINATION_CAPACITY_UNPROVEN", "native metadata reserve is too small")
+        # No comparison with reviewed available_bytes: shared free space can change.
+        return self.proposal.total_bytes + self.metadata_reserve_bytes + self.capacity.headroom_bytes
+
+    @classmethod
+    def from_json(cls, payload):
+        from .transaction import decode_proposal
+        try:
+            obj = _decode(payload)
+            _fields(obj, {"proposal", "destination", "catalog", "parent_path", "backing_ids",
+                          "capacity", "metadata_reserve_bytes", "version"})
+            if obj["version"] != VERSION:
+                raise ValueError("unsupported native transaction version")
+            _fields(obj["destination"], {"target", "admission_id"})
+            target = obj["destination"]["target"]
+            _fields(target, {"profile", "filesystem_scope", "parent_parts", "parent_identity", "child_name"})
+            _fields(obj["capacity"], {"available_bytes", "free_inodes", "headroom_bytes"})
+            return cls(decode_proposal(_proposal_record(obj["proposal"])),
+                       NativeBinding(FolderTarget(**target), obj["destination"]["admission_id"]),
+                       obj["catalog"], obj["parent_path"], obj["backing_ids"],
+                       CapacityObservation(**obj["capacity"]), obj["metadata_reserve_bytes"], obj["version"])
+        except (KeyError, TypeError, ValueError, RecursionError) as exc:
+            raise TransferRefusal("STATE_CORRUPT", "invalid native plan: " + str(exc)) from exc
+
+
+def estimate_metadata(proposal, binding, catalog, parent_path, backing_ids, capacity, store_root):
+    """Conservative advisory metadata budget, not proof of filesystem allocation.
+
+    Include serialized evidence and per-inode/directory overhead. Runtime space and
+    inode checks remain mandatory; external writers and quota limits can still win.
+    """
+    root = PurePosixPath(proposal.spec.destination_root)
+    directories = {str(parent) for artifact in proposal.closure
+                   for parent in (root / artifact.repo_id / artifact.rfilename).parents
+                   if str(parent) != "."}
+    objects = len(proposal.closure) + len(directories) + 2
+    record = {"proposal": asdict(proposal), "destination": asdict(binding), "catalog": catalog,
+              "parent_path": parent_path, "backing_ids": backing_ids, "capacity": asdict(capacity),
+              "store": str(store_root)}
+    allowance = 256 * 1024 + objects * 16 * 1024
+    reserve = allowance + 3 * len(d._json(record))
+    plan = NativePlan(proposal, binding, catalog, parent_path, backing_ids, capacity, reserve)
+    reserve = max(reserve, plan._metadata_minimum(store_root) + allowance)
+    return reserve

--- a/modelark/slice/hardware.py
+++ b/modelark/slice/hardware.py
@@ -16,6 +16,9 @@ import subprocess
 
 from .linux import BoundTree, require_create_access, require_no_default_acl
 from .paths import canonical_attachment
+from .io_errors import attachment_refusal, classify_io, probe_io
+from .host_observation import (ProtectedTarget, decode_proc_path, parse_mounts, proc_fields,
+                               proc_lines, read_fs_text, resolve_protected)
 from .transaction import DestinationBinding, TransferRefusal
 
 
@@ -44,48 +47,34 @@ class DeviceEvidence:
         return DestinationBinding(self.device_id, self.fs_uuid, self.profile, self.available_bytes)
 
 
-@dataclass(frozen=True)
-class Mount:
-    mount_id: int
-    major_minor: str
-    root: str
-    path: str
-    options: frozenset[str]
-    fs_type: str
-    source: str
-
-
 def _refuse(detail, code="DESTINATION_UNPROVEN"):
     raise TransferRefusal(code, detail)
 
 
 def _decode(value):
-    # proc mountinfo and swaps encode whitespace/backslash using octal escapes.
-    if re.search(r"\\(?![0-7]{3})", value):
-        _refuse("invalid procfs path encoding")
-    return re.sub(r"\\([0-7]{3})", lambda match: chr(int(match[1], 8)), value)
+    return decode_proc_path(value)
 
 
 def _mounts(text):
+    return parse_mounts(text)
+
+
+_SYSTEM_PATHS = ('/', '/boot', '/home', '/var', '/usr', '/etc', '/bin', '/sbin', '/lib', '/lib64')
+
+
+def _swap_records(swaps):
+    rows = proc_lines(swaps)
+    if not rows or not proc_fields(rows[0]) or proc_fields(rows[0])[0] != 'Filename':
+        _refuse('active swap inventory unavailable')
     result = []
-    try:
-        for line in text.splitlines():
-            if not line:
-                continue
-            left, right = line.split(" - ", 1)
-            fields, filesystem = left.split(), right.split()
-            if len(fields) < 6 or len(filesystem) < 3:
-                raise ValueError("short mountinfo row")
-            path, root = _decode(fields[4]), _decode(fields[3])
-            if not path.startswith("/") or not root.startswith("/"):
-                raise ValueError("nonabsolute mountinfo path")
-            result.append(Mount(int(fields[0]), fields[2], root, path,
-                                frozenset(fields[5].split(",") + filesystem[2].split(",")),
-                                filesystem[0], _decode(filesystem[1])))
-    except (ValueError, TypeError) as exc:
-        _refuse("invalid mount inventory: " + str(exc))
-    if not result or len({m.mount_id for m in result}) != len(result):
-        _refuse("missing or ambiguous mount inventory")
+    for row in rows[1:]:
+        fields = proc_fields(row)
+        if len(fields) != 5 or fields[1] not in {'file', 'partition'}:
+            _refuse('invalid active swap inventory')
+        name = _decode(fields[0])
+        if not name.startswith('/'):
+            _refuse('nonabsolute active swap path')
+        result.append((name, fields[1]))
     return tuple(result)
 
 
@@ -116,21 +105,18 @@ def _backing_identity(major_minor):
     return info.st_dev, info.st_ino
 
 
+@probe_io('DESTINATION_NOT_WRITABLE', 'effective creation permission/user xattrs unavailable')
 def _writable_root(tree, mount):
     if 'rw' not in mount.options or {'ro', 'nouser_xattr'} & mount.options:
         _refuse('writable mount and user xattrs required', 'DESTINATION_NOT_WRITABLE')
     if any('quota' in option or option.startswith('jqfmt=') for option in mount.options):
         _refuse('quota-enabled mounts are unsupported', 'FILESYSTEM_UNSUPPORTED')
+    require_create_access(tree.fd)
     try:
-        require_create_access(tree.fd)
-        try:
-            os.getxattr(tree.fd, 'user.modelark.slice-capability-probe')
-        except OSError as exc:
-            if exc.errno != errno.ENODATA:
-                raise
+        os.getxattr(tree.fd, 'user.modelark.slice-capability-probe')
     except OSError as exc:
-        _refuse('effective creation permission/user xattrs unavailable: ' + str(exc),
-                'DESTINATION_NOT_WRITABLE')
+        if exc.errno != errno.ENODATA:
+            raise
     require_no_default_acl(tree.fd)
 
 
@@ -208,13 +194,33 @@ class _Inventory:
 class LinuxObserver:
     """Read-only observer with injectable inventory providers; no implicit live discovery."""
 
-    def __init__(self, *, inventory=None, mounts=None, swaps=None, tree_factory=BoundTree, backing=None):
+    def __init__(self, *, inventory=None, mounts=None, swaps=None, tree_factory=BoundTree, backing=None, resolver=None):
         self._inventory = inventory or _inventory
-        self._mounts = mounts or (lambda: Path("/proc/self/mountinfo").read_text())
-        self._swaps = swaps or (lambda: Path("/proc/swaps").read_text())
+        self._mounts = mounts or (lambda: read_fs_text('/proc/self/mountinfo'))
+        self._swaps = swaps or (lambda: read_fs_text('/proc/swaps'))
         self._tree_factory = tree_factory
         self._backing = backing or _backing_identity
+        self._resolver = resolver or resolve_protected
         self._observed = {}
+
+    def _protected_snapshot(self, mounts, swaps):
+        requests = [(path, True, path != '/') for path in _SYSTEM_PATHS]
+        requests.extend((name, False, False) for name, kind in _swap_records(swaps) if kind == 'file')
+        snapshot = []
+        for requested, directory, optional in requests:
+            target = self._resolver(requested, directory=directory, optional=optional)
+            if target is None:
+                if not optional:
+                    _refuse('required protected role is unavailable')
+            else:
+                target = ProtectedTarget(str(requested), target.path, target.major_minor, target.mount_id, target.inode)
+                matching = [mount for mount in mounts if mount.mount_id == target.mount_id]
+                if (len(matching) != 1 or matching[0].major_minor != target.major_minor
+                        or not (target.path == matching[0].path
+                                or target.path.startswith(matching[0].path.rstrip('/') + '/'))):
+                    _refuse('protected descriptor differs from mount inventory')
+            snapshot.append((directory, requested, target))
+        return tuple(snapshot)
 
     def check_attachment(self, tree, evidence, *, archives=None):
         """No subprocess on unchanged topology; cached proof belongs to this attachment only."""
@@ -228,7 +234,10 @@ class LinuxObserver:
             self._check_backing(tree, proof)
             tree.check()
             roles = proof['archives'] if archives is None else tuple(archives)
-            if (_mounts(self._mounts()) != proof['mounts'] or self._swaps() != proof['swaps']
+            current_mounts, current_swaps = _mounts(self._mounts()), self._swaps()
+            current_protected = self._protected_snapshot(current_mounts, current_swaps)
+            if (current_mounts != proof['mounts'] or current_swaps != proof['swaps']
+                    or current_protected != proof['protected']
                     or _archive_roles(roles) != _archive_roles(proof['archives'])):
                 fresh = self.observe(tree.path, writable=proof['writable'], archives=roles)
                 if _stable_attachment(fresh) != _stable_attachment(evidence):
@@ -237,14 +246,24 @@ class LinuxObserver:
                 _writable_root(tree, proof['mount'])
             tree.check()
             self._check_backing(tree, proof)
+        except OSError as exc:
+            raise classify_io(exc, lambda: self.recheck_attachment(tree, evidence), TransferRefusal(
+                'DESTINATION_UNPROVEN', 'attachment check failed: ' + str(exc))) from exc
+
+    def recheck_attachment(self, tree, evidence):
+        """Raw failure-time proof; no discovery, policy admission or recursive classifier."""
+        proof = self._observed.get((str(tree.path), tree.mount_id))
+        if proof is None or _stable_attachment(proof['evidence']) != _stable_attachment(evidence):
+            _refuse('no matching retained attachment evidence')
+        self._check_backing(tree, proof)
+        try:
+            tree.check()
         except (OSError, TransferRefusal) as exc:
-            try:
-                self._check_backing(tree, proof)
-            except OSError:
-                pass  # Unknown probe failure is not disappearance evidence.
-            if isinstance(exc, TransferRefusal):
-                raise
-            raise TransferRefusal('DESTINATION_UNPROVEN', 'attachment check failed: ' + str(exc)) from exc
+            refusal = attachment_refusal(lambda: self._check_backing(tree, proof))
+            if refusal is not None:
+                raise refusal from exc
+            raise
+        self._check_backing(tree, proof)
 
     def _check_backing(self, tree, proof):
         if tree._attachment_lost:
@@ -261,19 +280,24 @@ class LinuxObserver:
         path = canonical_attachment(path)
         try:
             return self._observe(path, writable, tuple(archives))
-        except (OSError, subprocess.SubprocessError, json.JSONDecodeError, TransferRefusal) as exc:
-            target = str(path)
-            for (observed_path, _), proof in self._observed.items():
-                if observed_path == target:
-                    try:
-                        self._backing(proof['device'])
-                    except FileNotFoundError:
-                        _refuse('previously observed block backing disappeared', 'WAITING_DESTINATION')
-                    except OSError:
-                        pass
-            if isinstance(exc, TransferRefusal):
-                raise
-            raise TransferRefusal("DESTINATION_UNPROVEN", "device observation failed: " + str(exc)) from exc
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+            fallback = TransferRefusal("DESTINATION_UNPROVEN", "device observation failed: " + str(exc))
+            if isinstance(exc, OSError):
+                raise classify_io(exc, lambda: self._recheck_observed(path), fallback) from exc
+            raise fallback from exc
+
+    def _recheck_observed(self, path):
+        # Only the latest full proof for this spelling is relevant. This callback
+        # is raw evidence, never policy evaluation or another IO classifier.
+        for (observed_path, _), proof in reversed(tuple(self._observed.items())):
+            if observed_path == str(path):
+                try:
+                    backing = self._backing(proof['device'])
+                except FileNotFoundError:
+                    _refuse('previously observed block backing disappeared', 'WAITING_DESTINATION')
+                if backing != proof['backing']:
+                    _refuse('previously observed block backing was replaced', 'DESTINATION_CHANGED')
+                return
 
     def _observe(self, path, writable, archives):
         inventory_snapshot = json.dumps(self._inventory(), sort_keys=True)
@@ -324,41 +348,26 @@ class LinuxObserver:
             if writable:
                 _writable_root(tree, mount)
 
-            def covering(value):
-                candidates = [m for m in mounts if value == m.path or value.startswith(m.path.rstrip("/") + "/")]
-                if not candidates:
-                    _refuse("cannot determine protected path backing device")
-                longest = max(len(m.path) for m in candidates)
-                result = [m for m in candidates if len(m.path) == longest]
-                if len(result) != 1:
-                    _refuse("ambiguous protected mount")
-                return result[0]
-
+            protected_snapshot = self._protected_snapshot(mounts, swaps)
             protected = set()
-            system_paths = ("/boot", "/home", "/var", "/usr", "/etc", "/bin", "/sbin", "/lib", "/lib64")
-            for value in ("/", *system_paths):
-                protected.add(inventory.disk(covering(value).major_minor))
-            for other in mounts:
-                if any(other.path.startswith(value + "/") for value in system_paths):
-                    # Pseudo mounts (e.g. /var/lib/docker/.../proc) cannot hide a block
-                    # device, but every listed block-backed nested system mount counts.
-                    if other.major_minor in inventory.nodes:
-                        protected.add(inventory.disk(other.major_minor))
-            swap_rows = swaps.splitlines()
-            if not swap_rows or not swap_rows[0].split() or swap_rows[0].split()[0] != "Filename":
-                _refuse("active swap inventory unavailable")
-            for row in swap_rows[1:]:
-                fields = row.split()
-                if len(fields) < 5:
-                    _refuse("invalid active swap inventory")
-                name = _decode(fields[0])
-                if name in inventory.paths:
-                    key = inventory.paths[name]
-                elif fields[1] == "file" and name.startswith("/"):
-                    key = covering(name).major_minor
-                else:
+            for directory, requested, protected_target in protected_snapshot:
+                if protected_target is None:
+                    continue
+                protected.add(inventory.disk(protected_target.major_minor))
+                if directory and requested != '/':
+                    for other in mounts:
+                        if (other.path.startswith(protected_target.path.rstrip('/') + '/')
+                                or other.path.startswith(requested.rstrip('/') + '/')):
+                            if other.major_minor in inventory.nodes:
+                                protected.add(inventory.disk(other.major_minor))
+                            elif other.source.startswith('/dev/'):
+                                _refuse('nested protected block mount has unknown ancestry')
+            for name, kind in _swap_records(swaps):
+                if kind == 'file':
+                    continue  # Descriptor-backed target was included in the snapshot.
+                if name not in inventory.paths:
                     _refuse("cannot resolve active swap parent disk")
-                protected.add(inventory.disk(key))
+                protected.add(inventory.disk(inventory.paths[name]))
             if disk_key in protected:
                 _refuse("system or swap disk and all siblings are excluded")
             if writable:
@@ -400,7 +409,8 @@ class LinuxObserver:
                 profile_fields, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
             tree.check()
             if (json.dumps(self._inventory(), sort_keys=True) != inventory_snapshot
-                    or _mounts(self._mounts()) != mounts or self._swaps() != swaps):
+                    or _mounts(self._mounts()) != mounts or self._swaps() != swaps
+                    or self._protected_snapshot(mounts, swaps) != protected_snapshot):
                 _refuse("hardware inventory changed during descriptor observation")
             try:
                 final_backing = self._backing(major_minor)
@@ -412,5 +422,6 @@ class LinuxObserver:
                                       available, block_size, name_max, device_size, profile)
             self._observed[(target, tree.mount_id)] = {
                 'evidence': evidence, 'device': major_minor, 'backing': backing, 'mounts': mounts,
-                'mount': mount, 'swaps': swaps, 'writable': writable, 'archives': archives}
+                'mount': mount, 'swaps': swaps, 'writable': writable, 'archives': archives,
+                'protected': protected_snapshot}
             return evidence

--- a/modelark/slice/hardware.py
+++ b/modelark/slice/hardware.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import re
 import subprocess
 
-from .linux import BoundTree, require_create_access
+from .linux import BoundTree, require_create_access, require_no_default_acl
 from .transaction import DestinationBinding, TransferRefusal
 
 
@@ -130,6 +130,7 @@ def _writable_root(tree, mount):
     except OSError as exc:
         _refuse('effective creation permission/user xattrs unavailable: ' + str(exc),
                 'DESTINATION_NOT_WRITABLE')
+    require_no_default_acl(tree.fd)
 
 
 def _stable_attachment(evidence):

--- a/modelark/slice/hardware.py
+++ b/modelark/slice/hardware.py
@@ -1,0 +1,306 @@
+"""Explicit, read-only Linux device eligibility observations for direct Slice delivery.
+
+No discovery is performed at import or construction. Production observation reads lsblk,
+mountinfo and active swap inventory only when observe() is explicitly called. Tests inject
+those inventories and bind disposable directories. Evidence is an observation, not a lease:
+writers must retain BoundTree and re-observe identity under the shared execution authority.
+"""
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+
+from .linux import BoundTree
+from .transaction import DestinationBinding, TransferRefusal
+
+
+@dataclass(frozen=True)
+class DeviceEvidence:
+    device_id: str
+    fs_uuid: str
+    serial: str | None
+    total_bytes: int
+    mount_path: str
+    mount_id: int
+    fs_type: str
+    available_bytes: int
+    block_size: int
+    name_max: int
+    device_size: int
+    profile: str
+
+    def binding(self):
+        """Legacy mount_id slot seals the stable capability profile, NOT an attachment ID.
+
+        Linux mount IDs change on reattachment and are separately checked against retained
+        descriptors. The stable profile includes capacity/filesystem/device capabilities,
+        allowing a later explicit Start to re-observe the same device after remounting.
+        """
+        return DestinationBinding(self.device_id, self.fs_uuid, self.profile, self.available_bytes)
+
+
+@dataclass(frozen=True)
+class Mount:
+    mount_id: int
+    major_minor: str
+    root: str
+    path: str
+    options: frozenset[str]
+    fs_type: str
+    source: str
+
+
+def _refuse(detail, code="DESTINATION_UNPROVEN"):
+    raise TransferRefusal(code, detail)
+
+
+def _decode(value):
+    # proc mountinfo and swaps encode whitespace/backslash using octal escapes.
+    if re.search(r"\\(?![0-7]{3})", value):
+        _refuse("invalid procfs path encoding")
+    return re.sub(r"\\([0-7]{3})", lambda match: chr(int(match[1], 8)), value)
+
+
+def _mounts(text):
+    result = []
+    try:
+        for line in text.splitlines():
+            if not line:
+                continue
+            left, right = line.split(" - ", 1)
+            fields, filesystem = left.split(), right.split()
+            if len(fields) < 6 or len(filesystem) < 3:
+                raise ValueError("short mountinfo row")
+            path, root = _decode(fields[4]), _decode(fields[3])
+            if not path.startswith("/") or not root.startswith("/"):
+                raise ValueError("nonabsolute mountinfo path")
+            result.append(Mount(int(fields[0]), fields[2], root, path,
+                                frozenset(fields[5].split(",")), filesystem[0], _decode(filesystem[1])))
+    except (ValueError, TypeError) as exc:
+        _refuse("invalid mount inventory: " + str(exc))
+    if not result or len({m.mount_id for m in result}) != len(result):
+        _refuse("missing or ambiguous mount inventory")
+    return tuple(result)
+
+
+def _inventory():
+    result = subprocess.run(
+        ["lsblk", "--json", "--bytes", "--paths", "--output",
+         "NAME,PATH,TYPE,PKNAME,MAJ:MIN,SIZE,FSTYPE,UUID,SERIAL,WWN,TRAN,RO"],
+        check=True, capture_output=True, text=True)
+    return json.loads(result.stdout)
+
+
+def _nonempty(value):
+    return value if isinstance(value, str) and value.strip() == value and value else None
+
+
+def _integer(value):
+    if isinstance(value, bool):
+        return None
+    try:
+        result = int(value)
+    except (ValueError, TypeError):
+        return None
+    return result if result > 0 and str(result) == str(value) else None
+
+
+class _Inventory:
+    def __init__(self, payload):
+        self.nodes, self.parents, self.paths = {}, {}, {}
+        def visit(node, parent=None):
+            if not isinstance(node, dict):
+                _refuse("invalid block-device inventory")
+            key = node.get("maj:min")
+            path = _nonempty(node.get("path")) or _nonempty(node.get("name"))
+            if (not isinstance(key, str) or not re.fullmatch(r"\d+:\d+", key)
+                    or not path or not path.startswith("/dev/") or key in self.nodes or path in self.paths):
+                _refuse("ambiguous block-device inventory")
+            self.nodes[key], self.parents[key], self.paths[path] = node, parent, key
+            for child in node.get("children") or ():
+                visit(child, key)
+        if not isinstance(payload, dict) or not isinstance(payload.get("blockdevices"), list):
+            _refuse("invalid lsblk JSON")
+        for node in payload["blockdevices"]:
+            visit(node)
+        # --json trees are expected, but resolve explicit PKNAME on a flat inventory too.
+        for key, node in self.nodes.items():
+            parent_path = _nonempty(node.get("pkname"))
+            if parent_path and not parent_path.startswith("/"):
+                parent_path = "/dev/" + parent_path
+            if parent_path:
+                parent = self.paths.get(parent_path)
+                if parent is None or self.parents[key] not in {None, parent}:
+                    _refuse("ambiguous parent disk")
+                self.parents[key] = parent
+        uuids, disk_ids = set(), set()
+        for node in self.nodes.values():
+            uuid = _nonempty(node.get("uuid"))
+            if uuid:
+                if uuid.casefold() in uuids:
+                    _refuse("duplicate filesystem UUID")
+                uuids.add(uuid.casefold())
+            if node.get("type") == "disk":
+                for field in ("serial", "wwn"):
+                    value = _nonempty(node.get(field))
+                    if value:
+                        key = (field, value)
+                        if key in disk_ids:
+                            _refuse("duplicate whole-disk identity")
+                        disk_ids.add(key)
+
+    def disk(self, key, *, direct=False):
+        """Follow ancestry for exclusion, requiring a direct disk/partition for delivery."""
+        seen = set()
+        while key in self.nodes and key not in seen:
+            seen.add(key)
+            node = self.nodes[key]
+            kind, parent = node.get("type"), self.parents[key]
+            if kind == "disk" and parent is None:
+                return key
+            if direct and (kind != "part" or parent is None
+                           or self.nodes[parent].get("type") != "disk"):
+                _refuse("stacked or unknown delivery device")
+            if parent is None:
+                break
+            key = parent
+        _refuse("cannot prove whole parent disk")
+
+
+class LinuxObserver:
+    """Read-only observer with injectable inventory providers; no implicit live discovery."""
+
+    def __init__(self, *, inventory=None, mounts=None, swaps=None, tree_factory=BoundTree):
+        self._inventory = inventory or _inventory
+        self._mounts = mounts or (lambda: Path("/proc/self/mountinfo").read_text())
+        self._swaps = swaps or (lambda: Path("/proc/swaps").read_text())
+        self._tree_factory = tree_factory
+
+    def observe(self, path, writable=False, archives=()):
+        try:
+            return self._observe(path, writable, tuple(archives))
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+            raise TransferRefusal("DESTINATION_UNPROVEN", "device observation failed: " + str(exc)) from exc
+
+    def _observe(self, path, writable, archives):
+        inventory_snapshot = json.dumps(self._inventory(), sort_keys=True)
+        inventory = _Inventory(json.loads(inventory_snapshot))
+        mounts = _mounts(self._mounts())
+        swaps = self._swaps()
+        with self._tree_factory(path, writable=writable) as tree:
+            target = str(tree.path)
+            if target == "/":
+                _refuse("host root is not a delivery device")
+            matching = [m for m in mounts if m.path == target or (
+                not writable and target.startswith(m.path.rstrip("/") + "/"))]
+            if matching and not writable:
+                longest = max(len(m.path) for m in matching)
+                matching = [m for m in matching if len(m.path) == longest]
+            if len(matching) != 1:
+                _refuse("path must have a unique covering mount; writable paths require its exact root")
+            mount = matching[0]
+            actual = os.fstat(tree.fd)
+            major_minor = f"{os.major(actual.st_dev)}:{os.minor(actual.st_dev)}"
+            if mount.root != "/" or mount.mount_id != tree.mount_id or mount.major_minor != major_minor:
+                _refuse("mount inventory differs from retained descriptor")
+            if mount.major_minor not in inventory.nodes:
+                _refuse("mounted filesystem has no unambiguous block device")
+            if sum(m.major_minor == mount.major_minor for m in mounts) != 1:
+                _refuse("filesystem has multiple mount aliases")
+            if any(m.path.startswith(mount.path.rstrip("/") + "/") and m != mount for m in mounts):
+                _refuse("nested mounts within delivery filesystem")
+            node = inventory.nodes[mount.major_minor]
+            disk_key = inventory.disk(mount.major_minor, direct=True)
+            disk = inventory.nodes[disk_key]
+            uuid = _nonempty(node.get("uuid"))
+            serial, wwn = _nonempty(disk.get("serial")), _nonempty(disk.get("wwn"))
+            device_size = _integer(node.get("size"))
+            disk_size = _integer(disk.get("size"))
+            if not uuid or not (serial or wwn) or not device_size or not disk_size or device_size > disk_size:
+                _refuse("stable filesystem and parent disk identity/capacity required")
+            permitted = {"ext4"} if writable else {"ext4", "xfs"}
+            if node.get("fstype") != mount.fs_type or mount.fs_type not in permitted:
+                _refuse("unsupported or inconsistent filesystem", "FILESYSTEM_UNSUPPORTED")
+            if writable and (disk.get("tran") != "usb" or "rw" not in mount.options or "ro" in mount.options
+                             or node.get("ro") not in (False, 0, "0") or disk.get("ro") not in (False, 0, "0")):
+                _refuse("destination must be a writable direct USB disk")
+
+            def covering(value):
+                candidates = [m for m in mounts if value == m.path or value.startswith(m.path.rstrip("/") + "/")]
+                if not candidates:
+                    _refuse("cannot determine protected path backing device")
+                longest = max(len(m.path) for m in candidates)
+                result = [m for m in candidates if len(m.path) == longest]
+                if len(result) != 1:
+                    _refuse("ambiguous protected mount")
+                return result[0]
+
+            protected = set()
+            system_paths = ("/boot", "/home", "/var", "/usr", "/etc", "/bin", "/sbin", "/lib", "/lib64")
+            for value in ("/", *system_paths):
+                protected.add(inventory.disk(covering(value).major_minor))
+            for other in mounts:
+                if any(other.path.startswith(value + "/") for value in system_paths):
+                    # Pseudo mounts (e.g. /var/lib/docker/.../proc) cannot hide a block
+                    # device, but every listed block-backed nested system mount counts.
+                    if other.major_minor in inventory.nodes:
+                        protected.add(inventory.disk(other.major_minor))
+            swap_rows = swaps.splitlines()
+            if not swap_rows or not swap_rows[0].split() or swap_rows[0].split()[0] != "Filename":
+                _refuse("active swap inventory unavailable")
+            for row in swap_rows[1:]:
+                fields = row.split()
+                if len(fields) < 5:
+                    _refuse("invalid active swap inventory")
+                name = _decode(fields[0])
+                if name in inventory.paths:
+                    key = inventory.paths[name]
+                elif fields[1] == "file" and name.startswith("/"):
+                    key = covering(name).major_minor
+                else:
+                    _refuse("cannot resolve active swap parent disk")
+                protected.add(inventory.disk(key))
+            if disk_key in protected:
+                _refuse("system or swap disk and all siblings are excluded")
+            if writable:
+                for other in mounts:
+                    if other.major_minor in inventory.nodes and other.major_minor != mount.major_minor:
+                        if inventory.disk(other.major_minor) == disk_key:
+                            _refuse("destination disk has another mounted partition")
+                for archive in archives:
+                    archive_uuid = _nonempty(getattr(archive, "fs_uuid", None))
+                    archive_serial = _nonempty(getattr(archive, "serial", None))
+                    if not archive_uuid and not archive_serial:
+                        _refuse("registered archive lacks comparable physical identity")
+                    if archive_serial and archive_serial in {serial, wwn}:
+                        _refuse("registered archive parent disk is excluded")
+                    for key, candidate in inventory.nodes.items():
+                        candidate_uuid = _nonempty(candidate.get("uuid"))
+                        if (archive_uuid and candidate_uuid and candidate_uuid.casefold() == archive_uuid.casefold()
+                                and inventory.disk(key) == disk_key):
+                            _refuse("registered archive filesystem or sibling disk is excluded")
+
+            capacity = os.fstatvfs(tree.fd)
+            total = capacity.f_blocks * capacity.f_frsize
+            available = capacity.f_bavail * capacity.f_frsize
+            block_size = capacity.f_frsize
+            name_max = os.fpathconf(tree.fd, "PC_NAME_MAX")
+            if (total <= 0 or total > device_size or not 0 <= available <= total
+                    or block_size <= 0 or name_max <= 0):
+                _refuse("filesystem capacity/capability cannot be proven")
+            device_id = ("wwn:" + wwn) if wwn else ("serial:" + serial)
+            profile_fields = {"version": "modelark.linux.direct.v1", "device_id": device_id,
+                              "disk_size": disk_size, "device_size": device_size, "filesystem_id": uuid,
+                              "filesystem": mount.fs_type, "total_bytes": total,
+                              "block_size": block_size, "name_max": name_max}
+            profile = "linux-direct-v1:" + hashlib.sha256(json.dumps(
+                profile_fields, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+            tree.check()
+            if (json.dumps(self._inventory(), sort_keys=True) != inventory_snapshot
+                    or _mounts(self._mounts()) != mounts or self._swaps() != swaps):
+                _refuse("hardware inventory changed during descriptor observation")
+            return DeviceEvidence(device_id, uuid, serial, total, mount.path, mount.mount_id, mount.fs_type,
+                                  available, block_size, name_max, device_size, profile)

--- a/modelark/slice/hardware.py
+++ b/modelark/slice/hardware.py
@@ -81,7 +81,7 @@ def _swap_records(swaps):
 def _inventory():
     result = subprocess.run(
         ["lsblk", "--json", "--bytes", "--paths", "--output",
-         "NAME,PATH,TYPE,PKNAME,MAJ:MIN,SIZE,FSTYPE,UUID,SERIAL,WWN,TRAN,RO"],
+         "NAME,PATH,KNAME,TYPE,PKNAME,MAJ:MIN,SIZE,FSTYPE,UUID,SERIAL,WWN,TRAN,RO"],
         check=True, capture_output=True, text=True)
     return json.loads(result.stdout)
 
@@ -141,6 +141,16 @@ class _Inventory:
                     or not path or not path.startswith("/dev/") or key in self.nodes or path in self.paths):
                 _refuse("ambiguous block-device inventory")
             self.nodes[key], self.parents[key], self.paths[path] = node, parent, key
+            # lsblk may spell a mapper node as /dev/mapper/name while a child's
+            # PKNAME uses /dev/dm-N. KNAME is explicit inventory evidence for that
+            # alias; do not infer ancestry from names or ignore a disagreement.
+            kernel_path = _nonempty(node.get("kname"))
+            if kernel_path:
+                if not kernel_path.startswith("/"):
+                    kernel_path = "/dev/" + kernel_path
+                if not kernel_path.startswith("/dev/") or self.paths.get(kernel_path, key) != key:
+                    _refuse("ambiguous kernel block-device alias")
+                self.paths[kernel_path] = key
             for child in node.get("children") or ():
                 visit(child, key)
         if not isinstance(payload, dict) or not isinstance(payload.get("blockdevices"), list):

--- a/modelark/slice/hardware.py
+++ b/modelark/slice/hardware.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 
 from .linux import BoundTree, require_create_access, require_no_default_acl
+from .paths import canonical_attachment
 from .transaction import DestinationBinding, TransferRefusal
 
 
@@ -257,10 +258,11 @@ class LinuxObserver:
             _refuse('block backing was replaced', 'DESTINATION_CHANGED')
 
     def observe(self, path, writable=False, archives=()):
+        path = canonical_attachment(path)
         try:
             return self._observe(path, writable, tuple(archives))
         except (OSError, subprocess.SubprocessError, json.JSONDecodeError, TransferRefusal) as exc:
-            target = str(Path(path).expanduser().absolute())
+            target = str(path)
             for (observed_path, _), proof in self._observed.items():
                 if observed_path == target:
                     try:

--- a/modelark/slice/hardware.py
+++ b/modelark/slice/hardware.py
@@ -6,6 +6,7 @@ those inventories and bind disposable directories. Evidence is an observation, n
 writers must retain BoundTree and re-observe identity under the shared execution authority.
 """
 from dataclasses import dataclass
+import errno
 import hashlib
 import json
 import os
@@ -13,7 +14,7 @@ from pathlib import Path
 import re
 import subprocess
 
-from .linux import BoundTree
+from .linux import BoundTree, require_create_access
 from .transaction import DestinationBinding, TransferRefusal
 
 
@@ -78,7 +79,8 @@ def _mounts(text):
             if not path.startswith("/") or not root.startswith("/"):
                 raise ValueError("nonabsolute mountinfo path")
             result.append(Mount(int(fields[0]), fields[2], root, path,
-                                frozenset(fields[5].split(",")), filesystem[0], _decode(filesystem[1])))
+                                frozenset(fields[5].split(",") + filesystem[2].split(",")),
+                                filesystem[0], _decode(filesystem[1])))
     except (ValueError, TypeError) as exc:
         _refuse("invalid mount inventory: " + str(exc))
     if not result or len({m.mount_id for m in result}) != len(result):
@@ -106,6 +108,37 @@ def _integer(value):
     except (ValueError, TypeError):
         return None
     return result if result > 0 and str(result) == str(value) else None
+
+
+def _backing_identity(major_minor):
+    info = Path('/sys/dev/block', major_minor).stat()
+    return info.st_dev, info.st_ino
+
+
+def _writable_root(tree, mount):
+    if 'rw' not in mount.options or {'ro', 'nouser_xattr'} & mount.options:
+        _refuse('writable mount and user xattrs required', 'DESTINATION_NOT_WRITABLE')
+    if any('quota' in option or option.startswith('jqfmt=') for option in mount.options):
+        _refuse('quota-enabled mounts are unsupported', 'FILESYSTEM_UNSUPPORTED')
+    try:
+        require_create_access(tree.fd)
+        try:
+            os.getxattr(tree.fd, 'user.modelark.slice-capability-probe')
+        except OSError as exc:
+            if exc.errno != errno.ENODATA:
+                raise
+    except OSError as exc:
+        _refuse('effective creation permission/user xattrs unavailable: ' + str(exc),
+                'DESTINATION_NOT_WRITABLE')
+
+
+def _stable_attachment(evidence):
+    return (evidence.device_id, evidence.fs_uuid, evidence.profile, evidence.total_bytes,
+            evidence.mount_id, evidence.mount_path)
+
+
+def _archive_roles(archives):
+    return tuple((getattr(a, 'fs_uuid', None), getattr(a, 'serial', None)) for a in archives)
 
 
 class _Inventory:
@@ -173,16 +206,70 @@ class _Inventory:
 class LinuxObserver:
     """Read-only observer with injectable inventory providers; no implicit live discovery."""
 
-    def __init__(self, *, inventory=None, mounts=None, swaps=None, tree_factory=BoundTree):
+    def __init__(self, *, inventory=None, mounts=None, swaps=None, tree_factory=BoundTree, backing=None):
         self._inventory = inventory or _inventory
         self._mounts = mounts or (lambda: Path("/proc/self/mountinfo").read_text())
         self._swaps = swaps or (lambda: Path("/proc/swaps").read_text())
         self._tree_factory = tree_factory
+        self._backing = backing or _backing_identity
+        self._observed = {}
+
+    def check_attachment(self, tree, evidence, *, archives=None):
+        """No subprocess on unchanged topology; cached proof belongs to this attachment only."""
+        key = (str(tree.path), tree.mount_id)
+        proof = self._observed.get(key)
+        if proof is None or _stable_attachment(proof['evidence']) != _stable_attachment(evidence):
+            _refuse('no full observation for retained attachment', 'DESTINATION_CHANGED')
+        try:
+            # Check backing before path/stat IO: a disconnected filesystem may return EIO
+            # while its mount ID is still present. A lost tree never silently reacquires.
+            self._check_backing(tree, proof)
+            tree.check()
+            roles = proof['archives'] if archives is None else tuple(archives)
+            if (_mounts(self._mounts()) != proof['mounts'] or self._swaps() != proof['swaps']
+                    or _archive_roles(roles) != _archive_roles(proof['archives'])):
+                fresh = self.observe(tree.path, writable=proof['writable'], archives=roles)
+                if _stable_attachment(fresh) != _stable_attachment(evidence):
+                    _refuse('attachment changed during revalidation', 'DESTINATION_CHANGED')
+            elif proof['writable']:
+                _writable_root(tree, proof['mount'])
+            tree.check()
+            self._check_backing(tree, proof)
+        except (OSError, TransferRefusal) as exc:
+            try:
+                self._check_backing(tree, proof)
+            except OSError:
+                pass  # Unknown probe failure is not disappearance evidence.
+            if isinstance(exc, TransferRefusal):
+                raise
+            raise TransferRefusal('DESTINATION_UNPROVEN', 'attachment check failed: ' + str(exc)) from exc
+
+    def _check_backing(self, tree, proof):
+        if tree._attachment_lost:
+            _refuse('attachment lost; fresh Start required', 'WAITING_DESTINATION')
+        try:
+            backing = self._backing(proof['device'])
+        except FileNotFoundError:
+            tree._attachment_lost = True
+            _refuse('mounted block backing disappeared', 'WAITING_DESTINATION')
+        if backing != proof['backing']:
+            _refuse('block backing was replaced', 'DESTINATION_CHANGED')
 
     def observe(self, path, writable=False, archives=()):
         try:
             return self._observe(path, writable, tuple(archives))
-        except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        except (OSError, subprocess.SubprocessError, json.JSONDecodeError, TransferRefusal) as exc:
+            target = str(Path(path).expanduser().absolute())
+            for (observed_path, _), proof in self._observed.items():
+                if observed_path == target:
+                    try:
+                        self._backing(proof['device'])
+                    except FileNotFoundError:
+                        _refuse('previously observed block backing disappeared', 'WAITING_DESTINATION')
+                    except OSError:
+                        pass
+            if isinstance(exc, TransferRefusal):
+                raise
             raise TransferRefusal("DESTINATION_UNPROVEN", "device observation failed: " + str(exc)) from exc
 
     def _observe(self, path, writable, archives):
@@ -207,7 +294,11 @@ class LinuxObserver:
             if mount.root != "/" or mount.mount_id != tree.mount_id or mount.major_minor != major_minor:
                 _refuse("mount inventory differs from retained descriptor")
             if mount.major_minor not in inventory.nodes:
-                _refuse("mounted filesystem has no unambiguous block device")
+                _refuse("mounted block backing is absent", "WAITING_DESTINATION")
+            try:
+                backing = self._backing(major_minor)
+            except FileNotFoundError:
+                _refuse('mounted block backing disappeared', 'WAITING_DESTINATION')
             if sum(m.major_minor == mount.major_minor for m in mounts) != 1:
                 _refuse("filesystem has multiple mount aliases")
             if any(m.path.startswith(mount.path.rstrip("/") + "/") and m != mount for m in mounts):
@@ -227,6 +318,8 @@ class LinuxObserver:
             if writable and (disk.get("tran") != "usb" or "rw" not in mount.options or "ro" in mount.options
                              or node.get("ro") not in (False, 0, "0") or disk.get("ro") not in (False, 0, "0")):
                 _refuse("destination must be a writable direct USB disk")
+            if writable:
+                _writable_root(tree, mount)
 
             def covering(value):
                 candidates = [m for m in mounts if value == m.path or value.startswith(m.path.rstrip("/") + "/")]
@@ -268,6 +361,10 @@ class LinuxObserver:
             if writable:
                 for other in mounts:
                     if other.major_minor in inventory.nodes and other.major_minor != mount.major_minor:
+                        # Loop mounts are not sibling partitions. Protected/system/swap
+                        # ancestry above remains strict, as do unknown mapped devices here.
+                        if inventory.nodes[other.major_minor].get('type') == 'loop':
+                            continue
                         if inventory.disk(other.major_minor) == disk_key:
                             _refuse("destination disk has another mounted partition")
                 for archive in archives:
@@ -302,5 +399,15 @@ class LinuxObserver:
             if (json.dumps(self._inventory(), sort_keys=True) != inventory_snapshot
                     or _mounts(self._mounts()) != mounts or self._swaps() != swaps):
                 _refuse("hardware inventory changed during descriptor observation")
-            return DeviceEvidence(device_id, uuid, serial, total, mount.path, mount.mount_id, mount.fs_type,
-                                  available, block_size, name_max, device_size, profile)
+            try:
+                final_backing = self._backing(major_minor)
+            except FileNotFoundError:
+                _refuse('mounted block backing disappeared', 'WAITING_DESTINATION')
+            if final_backing != backing:
+                _refuse('block backing changed during observation', 'DESTINATION_CHANGED')
+            evidence = DeviceEvidence(device_id, uuid, serial, total, mount.path, mount.mount_id, mount.fs_type,
+                                      available, block_size, name_max, device_size, profile)
+            self._observed[(target, tree.mount_id)] = {
+                'evidence': evidence, 'device': major_minor, 'backing': backing, 'mounts': mounts,
+                'mount': mount, 'swaps': swaps, 'writable': writable, 'archives': archives}
+            return evidence

--- a/modelark/slice/host_observation.py
+++ b/modelark/slice/host_observation.py
@@ -121,14 +121,16 @@ def resolve_protected(path, *, directory=True, optional=False):
         info = os.fstat(fd)
         if not (stat.S_ISDIR(info.st_mode) if directory else stat.S_ISREG(info.st_mode)):
             raise TransferRefusal('DESTINATION_UNPROVEN', 'protected role has unexpected file type')
-        mount_id = _statx(fd).mount_id
+        # Host-role classification needs current inode/mount equality, not durable
+        # owned-object birth identity (procfs/sysfs do not provide the latter).
+        mount_id = _statx(fd, require_birth=False).mount_id
         identity = info.st_dev, info.st_ino, mount_id
         resolved = os.path.realpath(requested, strict=True)
         for current in (resolved, requested):
             other = os.open(current, os.O_PATH | os.O_CLOEXEC)
             try:
                 observed = os.fstat(other)
-                if (observed.st_dev, observed.st_ino, _statx(other).mount_id) != identity:
+                if (observed.st_dev, observed.st_ino, _statx(other, require_birth=False).mount_id) != identity:
                     raise TransferRefusal('DESTINATION_UNPROVEN', 'protected role changed while resolving')
             finally:
                 os.close(other)

--- a/modelark/slice/host_observation.py
+++ b/modelark/slice/host_observation.py
@@ -1,0 +1,140 @@
+"""Lossless procfs records and descriptor-backed host-role observations.
+
+Protected roles may deliberately follow host symlinks (e.g. /home -> /data/users).
+This is NOT attachment confinement: destination/archive BoundTree roots remain no-symlink.
+IO failures stay OSError for the caller's attachment-aware classification boundary.
+"""
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+import stat
+
+from .transaction import TransferRefusal
+
+
+def read_fs_text(path):
+    return os.fsdecode(Path(path).read_bytes())
+
+
+def proc_lines(text):
+    """Kernel records use LF, not Unicode's broader notion of a line boundary."""
+    return tuple(line for line in text.split('\n') if line)
+
+
+def proc_fields(line):
+    """Mountinfo/swaps fields use ASCII space/tab; filename characters are not separators."""
+    return tuple(re.split('[ \t]+', line.strip(' \t'))) if line.strip(' \t') else ()
+
+
+def decode_proc_path(value):
+    raw = os.fsencode(value)
+    if re.search(rb'\\(?![0-7]{3})', raw):
+        raise TransferRefusal('DESTINATION_UNPROVEN', 'invalid procfs path encoding')
+    def decode(match):
+        value = int(match[1], 8)
+        if value > 255 or value == 0:
+            raise TransferRefusal('DESTINATION_UNPROVEN', 'invalid procfs path byte')
+        return bytes([value])
+    return os.fsdecode(re.sub(rb'\\([0-7]{3})', decode, raw))
+
+
+@dataclass(frozen=True)
+class Mount:
+    mount_id: int
+    major_minor: str
+    root: str
+    path: str
+    options: frozenset[str]
+    fs_type: str
+    source: str
+
+
+def parse_mounts(text):
+    result = []
+    try:
+        for line in proc_lines(text):
+            left, right = line.split(' - ', 1)
+            fields, filesystem = proc_fields(left), proc_fields(right)
+            if len(fields) < 6 or len(filesystem) < 3:
+                raise ValueError('short mountinfo row')
+            path, root = decode_proc_path(fields[4]), decode_proc_path(fields[3])
+            mount_id = int(fields[0])
+            # Persistent namespace handles have kernel-generated opaque roots,
+            # unlike filesystem directories. Preserve them in the inventory;
+            # attachment admission still requires the selected root to be '/'.
+            namespace_root = (filesystem[0] == 'nsfs' and re.fullmatch(
+                r'(?:mnt|net|uts|ipc|pid|pid_for_children|user|cgroup|time|time_for_children):\[[0-9]+\]', root))
+            if (not path.startswith('/') or not (root.startswith('/') or namespace_root) or mount_id <= 0
+                    or not re.fullmatch('[0-9]+:[0-9]+', fields[2])):
+                raise ValueError('invalid mount identity/path')
+            result.append(Mount(mount_id, fields[2], root, path,
+                                frozenset(fields[5].split(',') + filesystem[2].split(',')),
+                                filesystem[0], decode_proc_path(filesystem[1])))
+    except (ValueError, TypeError) as exc:
+        raise TransferRefusal('DESTINATION_UNPROVEN', 'invalid mount inventory: ' + str(exc)) from exc
+    if not result or len({mount.mount_id for mount in result}) != len(result):
+        raise TransferRefusal('DESTINATION_UNPROVEN', 'missing or ambiguous mount inventory')
+    return tuple(result)
+
+
+@dataclass(frozen=True)
+class ProtectedTarget:
+    requested: str
+    path: str
+    major_minor: str
+    mount_id: int
+    inode: int
+
+
+def _optional_missing(path):
+    # A genuinely absent optional /home or /boot is normal. A symlink dangling
+    # anywhere in that path is not absence evidence and must still fail closed.
+    current = Path('/')
+    for component in Path(path).parts[1:]:
+        current /= component
+        try:
+            info = current.lstat()
+        except FileNotFoundError:
+            return True
+        if stat.S_ISLNK(info.st_mode):
+            current = Path(os.path.realpath(current, strict=True))
+    return False
+
+
+def resolve_protected(path, *, directory=True, optional=False):
+    """Resolve one host role to its actual filesystem using retained descriptors.
+
+    Return None only for a genuinely missing optional role. Bind the resolved name
+    and original request to the same current mount/inode; races cannot silently
+    turn lexical prefix classification into physical-storage evidence.
+    """
+    from .linux import _statx  # Lazy: linux imports this module's procfs helpers.
+    requested = os.path.abspath(path)
+    try:
+        fd = os.open(requested, os.O_PATH | os.O_CLOEXEC)
+    except FileNotFoundError:
+        if optional and _optional_missing(requested):
+            return None
+        raise
+    try:
+        info = os.fstat(fd)
+        if not (stat.S_ISDIR(info.st_mode) if directory else stat.S_ISREG(info.st_mode)):
+            raise TransferRefusal('DESTINATION_UNPROVEN', 'protected role has unexpected file type')
+        mount_id = _statx(fd).mount_id
+        identity = info.st_dev, info.st_ino, mount_id
+        resolved = os.path.realpath(requested, strict=True)
+        for current in (resolved, requested):
+            other = os.open(current, os.O_PATH | os.O_CLOEXEC)
+            try:
+                observed = os.fstat(other)
+                if (observed.st_dev, observed.st_ino, _statx(other).mount_id) != identity:
+                    raise TransferRefusal('DESTINATION_UNPROVEN', 'protected role changed while resolving')
+            finally:
+                os.close(other)
+        if os.path.realpath(requested, strict=True) != resolved:
+            raise TransferRefusal('DESTINATION_UNPROVEN', 'protected role target changed while resolving')
+        return ProtectedTarget(requested, resolved, f'{os.major(info.st_dev)}:{os.minor(info.st_dev)}',
+                               mount_id, info.st_ino)
+    finally:
+        os.close(fd)

--- a/modelark/slice/io_errors.py
+++ b/modelark/slice/io_errors.py
@@ -1,0 +1,66 @@
+"""Preserve probe evidence until an attachment-aware boundary chooses the outcome."""
+from functools import wraps
+from contextlib import contextmanager
+
+from .transaction import TransferRefusal
+
+
+class ProbeFailure(OSError):
+    """An IO failure plus its fallback meaning, not yet a transaction refusal."""
+
+    def __init__(self, original, code, detail):
+        super().__init__(original.errno, original.strerror, original.filename)
+        self.original = original
+        self.filename2 = original.filename2
+        self.code, self.detail = code, detail + ': ' + str(original)
+
+
+def probe_io(code, detail):
+    """Annotate IO failure without swallowing it or overriding a narrower probe."""
+    def decorate(method):
+        @wraps(method)
+        def call(*args, **kwargs):
+            try:
+                return method(*args, **kwargs)
+            except ProbeFailure:
+                raise
+            except OSError as exc:
+                raise ProbeFailure(exc, code, detail) from exc
+        return call
+    return decorate
+
+
+def attachment_refusal(check):
+    """Return only conclusive raw attachment evidence, never an unknown probe error."""
+    if check is not None:
+        try:
+            check()
+        except TransferRefusal as refusal:
+            if refusal.code in {'WAITING_DESTINATION', 'DESTINATION_CHANGED'}:
+                return refusal
+        except OSError:
+            pass
+    return None
+
+
+def classify_io(exc, check, fallback):
+    """Only proven attachment loss/replacement overrides the original IO meaning.
+
+    check is a raw, read-only proof, never another error classifier. An unavailable
+    re-probe is not absence evidence; neither errno nor a generic refusal proves loss.
+    """
+    refusal = attachment_refusal(check)
+    if refusal is not None:
+        return refusal
+    if isinstance(exc, ProbeFailure):
+        return TransferRefusal(exc.code, exc.detail)
+    return fallback
+
+
+@contextmanager
+def io_boundary(check, code, detail):
+    """Classify only IO executed inside this boundary, not a consumer's work."""
+    try:
+        yield
+    except OSError as exc:
+        raise classify_io(exc, check, TransferRefusal(code, detail + ': ' + str(exc))) from exc

--- a/modelark/slice/linux.py
+++ b/modelark/slice/linux.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import platform
 
 from .transaction import TransferRefusal
+from .paths import canonical_attachment
 
 
 class _Timestamp(ctypes.Structure):
@@ -164,7 +165,7 @@ class BoundTree:
     """Retained root fd; each descendant resolution rejects symlinks and mount crossings."""
 
     def __init__(self, path, verify=None, writable=False, *, mount_ids=None):
-        self.path = Path(os.path.abspath(path))
+        self.path = canonical_attachment(path)
         self.verify = verify
         self.writable = writable
         self._mount_ids = mount_ids or _mount_ids

--- a/modelark/slice/linux.py
+++ b/modelark/slice/linux.py
@@ -108,13 +108,35 @@ def rename_noreplace(src_dirfd, src, dst_dirfd, dst):
                           ctypes.c_uint(1)))
 
 
+def _mount_ids():
+    """Read attachment presence only; no device discovery or mount actions."""
+    try:
+        rows = Path("/proc/self/mountinfo").read_text().splitlines()
+        ids = []
+        for row in rows:
+            fields = row.split()
+            if len(fields) < 10 or " - " not in row:
+                raise ValueError("invalid mountinfo row")
+            value = int(fields[0])
+            if value <= 0:
+                raise ValueError("invalid mount ID")
+            ids.append(value)
+        if not ids or len(set(ids)) != len(ids):
+            raise ValueError("missing or ambiguous mountinfo")
+        return frozenset(ids)
+    except (OSError, ValueError) as exc:
+        raise TransferRefusal("DESTINATION_UNPROVEN", "attachment inventory unavailable") from exc
+
+
 class BoundTree:
     """Retained root fd; each descendant resolution rejects symlinks and mount crossings."""
 
-    def __init__(self, path, verify=None, writable=False):
+    def __init__(self, path, verify=None, writable=False, *, mount_ids=None):
         self.path = Path(os.path.abspath(path))
         self.verify = verify
         self.writable = writable
+        self._mount_ids = mount_ids or _mount_ids
+        self._attachment_lost = False
         self.fd = -1
         root = os.open("/", os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
         try:
@@ -139,6 +161,7 @@ class BoundTree:
     def check(self):
         if self.fd < 0:
             raise TransferRefusal("DESTINATION_CHANGED", "closed bound tree")
+        self._check_attachment()
         root = os.open("/", os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
         current = -1
         try:
@@ -146,13 +169,35 @@ class BoundTree:
                               os.O_RDONLY | os.O_DIRECTORY, resolve=0x0C)
             if (self.identity(current) != self._identity or
                     _statx(current).mount_id != self.mount_id):
+                # An unmount can expose a perfectly ordinary host directory at the
+                # same pathname. Never treat that directory as a replacement writer.
+                self._check_attachment()
                 raise TransferRefusal("DESTINATION_CHANGED", "bound root or attachment changed")
             if self.verify is not None:
                 self.verify()
+            self._check_attachment()
+        except (OSError, TransferRefusal) as exc:
+            # Re-probe after errors: disappearing media can race the initial presence
+            # check or the higher-level identity observer. Only absence proof is a wait.
+            self._check_attachment()
+            if isinstance(exc, FileNotFoundError):
+                raise TransferRefusal("DESTINATION_CHANGED", "bound root disappeared on attached filesystem") from exc
+            raise
         finally:
             if current >= 0:
                 os.close(current)
             os.close(root)
+
+    def _check_attachment(self):
+        if self._attachment_lost:
+            raise TransferRefusal("WAITING_DESTINATION", "attachment was lost; a fresh Start must bind it again")
+        ids = self._mount_ids()
+        if (not isinstance(ids, (set, frozenset, tuple, list))
+                or any(isinstance(value, bool) or not isinstance(value, int) or value <= 0 for value in ids)):
+            raise TransferRefusal("DESTINATION_UNPROVEN", "attachment inventory unavailable")
+        if self.mount_id not in ids:
+            self._attachment_lost = True
+            raise TransferRefusal("WAITING_DESTINATION", "bound attachment is no longer mounted")
 
     def open(self, relative, flags, mode=0o600):
         _relative(relative)

--- a/modelark/slice/linux.py
+++ b/modelark/slice/linux.py
@@ -80,6 +80,14 @@ def _relative(path):
     return parts
 
 
+def require_create_access(fd):
+    """Kernel effective-credential/ACL check on the retained directory, without writes."""
+    # faccessat2(AT_EMPTY_PATH | AT_EACCESS), syscall439 on both supported ABIs.
+    # Do not fall back to older glibc faccessat mode-bit emulation (which can ignore ACLs).
+    _result(_libc().syscall(ctypes.c_long(439), ctypes.c_int(fd), ctypes.c_char_p(b""),
+                          ctypes.c_int(os.W_OK | os.X_OK), ctypes.c_int(0x1200)))
+
+
 def link_fd(fd, parent_fd, name):
     """Publish the opened inode exclusively; never resolve a source pathname."""
     if len(_relative(name)) != 1:

--- a/modelark/slice/linux.py
+++ b/modelark/slice/linux.py
@@ -1,0 +1,184 @@
+"""Linux descriptor confinement primitives for direct delivery.
+
+These primitives prove path confinement, not device eligibility or exclusive namespace
+ownership. Callers must separately prove those preconditions. No fallback to path-based IO.
+"""
+from contextlib import contextmanager
+import ctypes
+import errno
+import os
+from pathlib import Path
+import platform
+
+from .transaction import TransferRefusal
+
+
+class _Timestamp(ctypes.Structure):
+    _fields_ = [("sec", ctypes.c_int64), ("nsec", ctypes.c_uint32),
+                ("reserved", ctypes.c_int32)]
+
+
+class _Statx(ctypes.Structure):
+    # Linux UAPI statx layout, including reserved tail (256 bytes).
+    _fields_ = [("mask", ctypes.c_uint32), ("blksize", ctypes.c_uint32),
+                ("attributes", ctypes.c_uint64), ("nlink", ctypes.c_uint32),
+                ("uid", ctypes.c_uint32), ("gid", ctypes.c_uint32),
+                ("mode", ctypes.c_uint16), ("spare0", ctypes.c_uint16),
+                ("ino", ctypes.c_uint64), ("size", ctypes.c_uint64),
+                ("blocks", ctypes.c_uint64), ("attributes_mask", ctypes.c_uint64),
+                ("atime", _Timestamp), ("btime", _Timestamp),
+                ("ctime", _Timestamp), ("mtime", _Timestamp),
+                ("rdev_major", ctypes.c_uint32), ("rdev_minor", ctypes.c_uint32),
+                ("dev_major", ctypes.c_uint32), ("dev_minor", ctypes.c_uint32),
+                ("mount_id", ctypes.c_uint64), ("tail", ctypes.c_uint64 * 13)]
+
+
+class _OpenHow(ctypes.Structure):
+    _fields_ = [("flags", ctypes.c_uint64), ("mode", ctypes.c_uint64),
+                ("resolve", ctypes.c_uint64)]
+
+
+def _libc():
+    if platform.system() != "Linux" or platform.machine() not in {"x86_64", "aarch64"}:
+        raise TransferRefusal("FILESYSTEM_UNSUPPORTED", "Linux x86_64/aarch64 required")
+    return ctypes.CDLL(None, use_errno=True)
+
+
+def _result(value):
+    if value < 0:
+        number = ctypes.get_errno()
+        raise OSError(number, os.strerror(number))
+    return value
+
+
+def _openat2(fd, path, flags, mode=0, *, resolve=0x0D):
+    # BENEATH | NO_SYMLINKS | NO_XDEV. Syscall 437 on both supported ABIs.
+    how = _OpenHow(flags | os.O_CLOEXEC, mode, resolve)
+    return _result(_libc().syscall(ctypes.c_long(437), ctypes.c_int(fd),
+                                 ctypes.c_char_p(os.fsencode(path)),
+                                 ctypes.byref(how), ctypes.c_size_t(ctypes.sizeof(how))))
+
+
+def _statx(fd):
+    result = _Statx()
+    libc = _libc()
+    if not hasattr(libc, "statx"):
+        raise TransferRefusal("FILESYSTEM_UNSUPPORTED", "statx unavailable")
+    _result(libc.statx(ctypes.c_int(fd), ctypes.c_char_p(b""), ctypes.c_int(0x1000),
+                       ctypes.c_uint(0x1900), ctypes.byref(result)))
+    if result.mask & 0x1900 != 0x1900:
+        raise TransferRefusal("FILESYSTEM_UNSUPPORTED", "inode birth time and mount identity required")
+    return result
+
+
+def _relative(path):
+    if not isinstance(path, str) or not path or "\\" in path or "\0" in path:
+        raise TransferRefusal("PATH_UNSAFE", "canonical relative path required")
+    parts = path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise TransferRefusal("PATH_UNSAFE", "canonical relative path required")
+    return parts
+
+
+def link_fd(fd, parent_fd, name):
+    """Publish the opened inode exclusively; never resolve a source pathname."""
+    if len(_relative(name)) != 1:
+        raise TransferRefusal("PATH_UNSAFE")
+    libc = _libc()
+    result = libc.linkat(ctypes.c_int(fd), ctypes.c_char_p(b""), ctypes.c_int(parent_fd),
+                         ctypes.c_char_p(os.fsencode(name)), ctypes.c_int(0x1000))
+    if result < 0 and ctypes.get_errno() in {errno.EPERM, errno.ENOENT}:
+        # Documented unprivileged O_TMPFILE publication. Only our retained fd can be
+        # selected; never accept a caller-supplied procfs path.
+        result = libc.linkat(ctypes.c_int(-100), ctypes.c_char_p(f"/proc/self/fd/{fd}".encode()),
+                             ctypes.c_int(parent_fd), ctypes.c_char_p(os.fsencode(name)),
+                             ctypes.c_int(0x400))
+    _result(result)
+
+
+def rename_noreplace(src_dirfd, src, dst_dirfd, dst):
+    """No-replace rename; callers must own the source directory namespace."""
+    if len(_relative(src)) != 1 or len(_relative(dst)) != 1:
+        raise TransferRefusal("PATH_UNSAFE")
+    libc = _libc()
+    if not hasattr(libc, "renameat2"):
+        raise TransferRefusal("FILESYSTEM_UNSUPPORTED", "renameat2 unavailable")
+    _result(libc.renameat2(ctypes.c_int(src_dirfd), ctypes.c_char_p(os.fsencode(src)),
+                          ctypes.c_int(dst_dirfd), ctypes.c_char_p(os.fsencode(dst)),
+                          ctypes.c_uint(1)))
+
+
+class BoundTree:
+    """Retained root fd; each descendant resolution rejects symlinks and mount crossings."""
+
+    def __init__(self, path, verify=None, writable=False):
+        self.path = Path(os.path.abspath(path))
+        self.verify = verify
+        self.writable = writable
+        self.fd = -1
+        root = os.open("/", os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        try:
+            # Mount crossing is allowed only while binding the explicitly supplied root.
+            self.fd = _openat2(root, str(self.path).lstrip("/") or ".",
+                               os.O_RDONLY | os.O_DIRECTORY, resolve=0x0C)
+            self._identity = self.identity(self.fd)
+            self.mount_id = _statx(self.fd).mount_id
+            self.check()
+        except BaseException:
+            self.close()
+            raise
+        finally:
+            os.close(root)
+
+    @staticmethod
+    def identity(fd):
+        value = _statx(fd)
+        return (os.makedev(value.dev_major, value.dev_minor), value.ino,
+                value.btime.sec * 1_000_000_000 + value.btime.nsec)
+
+    def check(self):
+        if self.fd < 0:
+            raise TransferRefusal("DESTINATION_CHANGED", "closed bound tree")
+        root = os.open("/", os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        current = -1
+        try:
+            current = _openat2(root, str(self.path).lstrip("/") or ".",
+                              os.O_RDONLY | os.O_DIRECTORY, resolve=0x0C)
+            if (self.identity(current) != self._identity or
+                    _statx(current).mount_id != self.mount_id):
+                raise TransferRefusal("DESTINATION_CHANGED", "bound root or attachment changed")
+            if self.verify is not None:
+                self.verify()
+        finally:
+            if current >= 0:
+                os.close(current)
+            os.close(root)
+
+    def open(self, relative, flags, mode=0o600):
+        _relative(relative)
+        self.check()
+        # openat2 rejects nonzero mode unless creation was requested.
+        creation = flags & os.O_CREAT or flags & os.O_TMPFILE == os.O_TMPFILE
+        return _openat2(self.fd, relative, flags, mode if creation else 0)
+
+    @contextmanager
+    def parent(self, relative):
+        parts = _relative(relative)
+        self.check()
+        fd = (self.open("/".join(parts[:-1]), os.O_RDONLY | os.O_DIRECTORY)
+              if len(parts) > 1 else os.dup(self.fd))
+        try:
+            yield fd, parts[-1]
+        finally:
+            os.close(fd)
+
+    def close(self):
+        if self.fd >= 0:
+            os.close(self.fd)
+            self.fd = -1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/modelark/slice/linux.py
+++ b/modelark/slice/linux.py
@@ -68,15 +68,17 @@ def _openat2(fd, path, flags, mode=0, *, resolve=0x0D):
                                           ctypes.byref(how), ctypes.c_size_t(ctypes.sizeof(how))), 'openat2')
 
 
-def _statx(fd):
+def _statx(fd, *, require_birth=True):
     result = _Statx()
     libc = _libc()
     if not hasattr(libc, "statx"):
         raise TransferRefusal("FILESYSTEM_UNSUPPORTED", "statx unavailable")
+    required = 0x1900 if require_birth else 0x1100
     _required_result(libc.statx(ctypes.c_int(fd), ctypes.c_char_p(b""), ctypes.c_int(0x1000),
-                              ctypes.c_uint(0x1900), ctypes.byref(result)), 'statx')
-    if result.mask & 0x1900 != 0x1900:
-        raise TransferRefusal("FILESYSTEM_UNSUPPORTED", "inode birth time and mount identity required")
+                              ctypes.c_uint(required), ctypes.byref(result)), 'statx')
+    if result.mask & required != required:
+        detail = "inode birth time and mount identity required" if require_birth else "inode and mount identity required"
+        raise TransferRefusal("FILESYSTEM_UNSUPPORTED", detail)
     return result
 
 
@@ -160,13 +162,19 @@ class BoundTree:
             self.fd = _openat2(root, str(self.path).lstrip("/") or ".",
                                os.O_RDONLY | os.O_DIRECTORY, resolve=0x0C)
             self._identity = self.identity(self.fd)
-            self.mount_id = _statx(self.fd).mount_id
+            self.mount_id = self._statx(self.fd).mount_id
             self.check()
         except BaseException:
             self.close()
             raise
         finally:
             os.close(root)
+
+    @staticmethod
+    def _statx(fd):
+        # Native/legacy callers keep the birth requirement. Live-only adapters may
+        # override observation without changing any existing default capability.
+        return _statx(fd)
 
     @staticmethod
     def identity(fd):
@@ -184,7 +192,7 @@ class BoundTree:
             current = _openat2(root, str(self.path).lstrip("/") or ".",
                               os.O_RDONLY | os.O_DIRECTORY, resolve=0x0C)
             if (self.identity(current) != self._identity or
-                    _statx(current).mount_id != self.mount_id):
+                    self._statx(current).mount_id != self.mount_id):
                 # An unmount can expose a perfectly ordinary host directory at the
                 # same pathname. Never treat that directory as a replacement writer.
                 self._check_attachment()

--- a/modelark/slice/linux.py
+++ b/modelark/slice/linux.py
@@ -7,11 +7,12 @@ from contextlib import contextmanager
 import ctypes
 import errno
 import os
-from pathlib import Path
 import platform
 
 from .transaction import TransferRefusal
 from .paths import canonical_attachment
+from .io_errors import attachment_refusal, probe_io
+from .host_observation import parse_mounts, read_fs_text
 
 
 class _Timestamp(ctypes.Structure):
@@ -96,6 +97,7 @@ def require_create_access(fd):
                                    ctypes.c_int(os.W_OK | os.X_OK), ctypes.c_int(0x1200)), 'faccessat2')
 
 
+@probe_io('DESTINATION_CAPACITY_UNPROVEN', 'cannot prove absence of default ACL')
 def require_no_default_acl(fd):
     """Keep inherited xattrs outside the bounded ownership-marker allocation profile."""
     try:
@@ -103,12 +105,7 @@ def require_no_default_acl(fd):
     except OSError as exc:
         if exc.errno == errno.ENODATA:
             return
-        if exc.errno in {errno.EIO, errno.ENODEV, errno.ENXIO}:
-            # Retain media errors for the observer/adapter's backing-loss re-probe.
-            # A typed capacity refusal here would bypass its attended-unplug path.
-            raise
-        raise TransferRefusal('DESTINATION_CAPACITY_UNPROVEN',
-                              'cannot prove absence of default ACL: ' + str(exc)) from exc
+        raise
     raise TransferRefusal('DESTINATION_CAPACITY_UNPROVEN',
                           'default ACL inheritance is unsupported by the ownership-marker profile')
 
@@ -141,24 +138,10 @@ def rename_noreplace(src_dirfd, src, dst_dirfd, dst):
                           ctypes.c_uint(1)))
 
 
+@probe_io('DESTINATION_UNPROVEN', 'attachment inventory unavailable')
 def _mount_ids():
     """Read attachment presence only; no device discovery or mount actions."""
-    try:
-        rows = Path("/proc/self/mountinfo").read_text().splitlines()
-        ids = []
-        for row in rows:
-            fields = row.split()
-            if len(fields) < 10 or " - " not in row:
-                raise ValueError("invalid mountinfo row")
-            value = int(fields[0])
-            if value <= 0:
-                raise ValueError("invalid mount ID")
-            ids.append(value)
-        if not ids or len(set(ids)) != len(ids):
-            raise ValueError("missing or ambiguous mountinfo")
-        return frozenset(ids)
-    except (OSError, ValueError) as exc:
-        raise TransferRefusal("DESTINATION_UNPROVEN", "attachment inventory unavailable") from exc
+    return frozenset(mount.mount_id for mount in parse_mounts(read_fs_text('/proc/self/mountinfo')))
 
 
 class BoundTree:
@@ -212,7 +195,9 @@ class BoundTree:
         except (OSError, TransferRefusal) as exc:
             # Re-probe after errors: disappearing media can race the initial presence
             # check or the higher-level identity observer. Only absence proof is a wait.
-            self._check_attachment()
+            refusal = attachment_refusal(self._check_attachment)
+            if refusal is not None:
+                raise refusal from exc
             if isinstance(exc, FileNotFoundError):
                 raise TransferRefusal("DESTINATION_CHANGED", "bound root disappeared on attached filesystem") from exc
             raise

--- a/modelark/slice/linux.py
+++ b/modelark/slice/linux.py
@@ -51,12 +51,19 @@ def _result(value):
     return value
 
 
+def _required_result(value, capability):
+    if value < 0 and ctypes.get_errno() == errno.ENOSYS:
+        raise TransferRefusal('FILESYSTEM_UNSUPPORTED',
+                              f'direct delivery requires {capability}; Linux 5.8+ capabilities required')
+    return _result(value)
+
+
 def _openat2(fd, path, flags, mode=0, *, resolve=0x0D):
     # BENEATH | NO_SYMLINKS | NO_XDEV. Syscall 437 on both supported ABIs.
     how = _OpenHow(flags | os.O_CLOEXEC, mode, resolve)
-    return _result(_libc().syscall(ctypes.c_long(437), ctypes.c_int(fd),
-                                 ctypes.c_char_p(os.fsencode(path)),
-                                 ctypes.byref(how), ctypes.c_size_t(ctypes.sizeof(how))))
+    return _required_result(_libc().syscall(ctypes.c_long(437), ctypes.c_int(fd),
+                                          ctypes.c_char_p(os.fsencode(path)),
+                                          ctypes.byref(how), ctypes.c_size_t(ctypes.sizeof(how))), 'openat2')
 
 
 def _statx(fd):
@@ -64,8 +71,8 @@ def _statx(fd):
     libc = _libc()
     if not hasattr(libc, "statx"):
         raise TransferRefusal("FILESYSTEM_UNSUPPORTED", "statx unavailable")
-    _result(libc.statx(ctypes.c_int(fd), ctypes.c_char_p(b""), ctypes.c_int(0x1000),
-                       ctypes.c_uint(0x1900), ctypes.byref(result)))
+    _required_result(libc.statx(ctypes.c_int(fd), ctypes.c_char_p(b""), ctypes.c_int(0x1000),
+                              ctypes.c_uint(0x1900), ctypes.byref(result)), 'statx')
     if result.mask & 0x1900 != 0x1900:
         raise TransferRefusal("FILESYSTEM_UNSUPPORTED", "inode birth time and mount identity required")
     return result
@@ -84,8 +91,25 @@ def require_create_access(fd):
     """Kernel effective-credential/ACL check on the retained directory, without writes."""
     # faccessat2(AT_EMPTY_PATH | AT_EACCESS), syscall439 on both supported ABIs.
     # Do not fall back to older glibc faccessat mode-bit emulation (which can ignore ACLs).
-    _result(_libc().syscall(ctypes.c_long(439), ctypes.c_int(fd), ctypes.c_char_p(b""),
-                          ctypes.c_int(os.W_OK | os.X_OK), ctypes.c_int(0x1200)))
+    _required_result(_libc().syscall(ctypes.c_long(439), ctypes.c_int(fd), ctypes.c_char_p(b""),
+                                   ctypes.c_int(os.W_OK | os.X_OK), ctypes.c_int(0x1200)), 'faccessat2')
+
+
+def require_no_default_acl(fd):
+    """Keep inherited xattrs outside the bounded ownership-marker allocation profile."""
+    try:
+        os.getxattr(fd, 'system.posix_acl_default')
+    except OSError as exc:
+        if exc.errno == errno.ENODATA:
+            return
+        if exc.errno in {errno.EIO, errno.ENODEV, errno.ENXIO}:
+            # Retain media errors for the observer/adapter's backing-loss re-probe.
+            # A typed capacity refusal here would bypass its attended-unplug path.
+            raise
+        raise TransferRefusal('DESTINATION_CAPACITY_UNPROVEN',
+                              'cannot prove absence of default ACL: ' + str(exc)) from exc
+    raise TransferRefusal('DESTINATION_CAPACITY_UNPROVEN',
+                          'default ACL inheritance is unsupported by the ownership-marker profile')
 
 
 def link_fd(fd, parent_fd, name):

--- a/modelark/slice/local_source.py
+++ b/modelark/slice/local_source.py
@@ -123,10 +123,12 @@ def _open_content(tree, candidate):
 
 
 class LocalArchiveReader:
-    """Internal reader; production assembly awaits an approved hardware observer."""
+    """Internal reader with full per-artifact and lightweight per-read attachment proofs."""
 
     def __init__(self, attachments, *, observer, max_decode_bytes=64 << 20):
-        self.attachments = {label: Path(path) for label, path in attachments.items()}
+        # Expand operator spelling before observation without following symlinks;
+        # BoundTree still performs the authoritative no-symlink path resolution.
+        self.attachments = {label: Path(path).expanduser().absolute() for label, path in attachments.items()}
         self.observer = observer
         self.max_decode_bytes = max_decode_bytes
 
@@ -144,27 +146,30 @@ class LocalArchiveReader:
                 if path != Path(observed.mount_path) / "modelark":
                     raise TransferRefusal("SOURCE_PATH_UNSAFE", "archive must be <mount>/modelark")
 
-                def attachment_check():
-                    if _identity(self.observer.observe(path)) != expected:
-                        raise TransferRefusal("SOURCE_CHANGED", label)
-
-                tree = stack.enter_context(BoundTree(path, verify=attachment_check))
+                tree = stack.enter_context(BoundTree(path))
                 if tree.mount_id != expected[4]:
                     raise TransferRefusal("SOURCE_CHANGED", "observer and source descriptor attachments differ")
                 drive = candidate.drive
+                annex = _annex_uuid(tree)
+                fingerprint = identity_fingerprint_v1(
+                    fs_uuid=expected[0], annex_uuid=annex, serial=expected[1],
+                    filesystem_capacity_bytes=expected[2])
+                if (expected[:3] != (drive.fs_uuid, drive.serial, drive.filesystem_capacity_bytes)
+                        or annex != drive.annex_uuid or fingerprint != drive.identity_fingerprint):
+                    raise TransferRefusal("SOURCE_CHANGED", label)
+                stream = stack.enter_context(os.fdopen(_open_content(tree, candidate), "rb"))
+                confirmed = self.observer.observe(path)
+                if _identity(confirmed) != expected:
+                    raise TransferRefusal("SOURCE_CHANGED", label)
 
                 def check():
-                    tree.check()
-                    annex = _annex_uuid(tree)
-                    fingerprint = identity_fingerprint_v1(
-                        fs_uuid=expected[0], annex_uuid=annex, serial=expected[1],
-                        filesystem_capacity_bytes=expected[2])
-                    if (expected[:3] != (drive.fs_uuid, drive.serial, drive.filesystem_capacity_bytes)
-                            or annex != drive.annex_uuid or fingerprint != drive.identity_fingerprint):
-                        raise TransferRefusal("SOURCE_CHANGED", label)
+                    # The archive fence spans this context. Full inventory and
+                    # annex identity are checked at artifact-open boundaries;
+                    # each read retains kernel attachment/backing-device proof
+                    # without spawning a complete inventory for every chunk.
+                    self.observer.check_attachment(tree, confirmed)
 
                 check()
-                stream = stack.enter_context(os.fdopen(_open_content(tree, candidate), "rb"))
                 decoded = original_stream(stream, compressed=candidate.copy.compressed,
                                           expected_bytes=candidate.copy.orig_bytes,
                                           max_decode_bytes=self.max_decode_bytes, check=check)

--- a/modelark/slice/local_source.py
+++ b/modelark/slice/local_source.py
@@ -19,6 +19,7 @@ import stat
 from modelark.capacity_evidence import identity_fingerprint_v1
 from . import domain as d
 from .decoding import original_stream
+from .paths import canonical_attachment
 from .transaction import TransferRefusal
 
 
@@ -126,10 +127,7 @@ class LocalArchiveReader:
     """Internal reader with full per-artifact and lightweight per-read attachment proofs."""
 
     def __init__(self, attachments, *, observer, max_decode_bytes=64 << 20):
-        # Normalize operator spelling, including lexical '..', before observation
-        # without following symlinks. BoundTree still performs the authoritative
-        # no-symlink path resolution; Path.absolute() alone retains parent segments.
-        self.attachments = {label: Path(os.path.abspath(Path(path).expanduser()))
+        self.attachments = {label: canonical_attachment(path)
                             for label, path in attachments.items()}
         self.observer = observer
         self.max_decode_bytes = max_decode_bytes

--- a/modelark/slice/local_source.py
+++ b/modelark/slice/local_source.py
@@ -20,6 +20,7 @@ from modelark.capacity_evidence import identity_fingerprint_v1
 from . import domain as d
 from .decoding import original_stream
 from .paths import canonical_attachment
+from .io_errors import classify_io
 from .transaction import TransferRefusal
 
 
@@ -51,19 +52,37 @@ def _translate_confinement(exc):
 
 
 class _SourceErrors:
-    def __init__(self, stream, label):
-        self.stream, self.label = stream, label
+    def __init__(self, stream, label, check=None):
+        self.stream, self.label, self.check = stream, label, check
 
     def read(self, size=-1):
         try:
             return self.stream.read(size)
         except OSError as exc:
-            raise _translate_io(exc, self.label) from exc
+            raise _translate_confinement(classify_io(
+                exc, self.check, _translate_io(exc, self.label))) from exc
         except TransferRefusal as exc:
             translated = _translate_confinement(exc)
             if translated is exc:
                 raise
             raise translated from exc
+
+
+class _SourceStack(ExitStack):
+    """Translate only source-owned cleanup, without masking a consumer exception."""
+    def __init__(self, label):
+        super().__init__()
+        self.label = label
+
+    def __exit__(self, exc_type, exc, traceback):
+        try:
+            return super().__exit__(exc_type, exc, traceback)
+        except OSError as cleanup:
+            if exc_type is not None:
+                return False  # Preserve the original failure already being unwound.
+            # The retained tree may already be closed: no fresh absence inference.
+            raise _translate_confinement(classify_io(
+                cleanup, None, _translate_io(cleanup, self.label))) from cleanup
 
 
 def _annex_uuid(tree):
@@ -139,7 +158,13 @@ class LocalArchiveReader:
         if label not in self.attachments:
             raise TransferRefusal("WAITING_SOURCE", f"attach archive {label}")
         path = self.attachments[label]
-        with ExitStack() as stack:
+        with _SourceStack(label) as stack:
+            tree = observed = None
+
+            def recheck():
+                if tree is not None and observed is not None:
+                    self.observer.recheck_attachment(tree, observed)
+
             try:
                 observed = self.observer.observe(path)
                 expected = _identity(observed)
@@ -174,7 +199,7 @@ class LocalArchiveReader:
                                           expected_bytes=candidate.copy.orig_bytes,
                                           max_decode_bytes=self.max_decode_bytes, check=check)
             except OSError as exc:
-                raise _translate_io(exc, label) from exc
+                raise _translate_confinement(classify_io(exc, recheck, _translate_io(exc, label))) from exc
             except TransferRefusal as exc:
                 translated = _translate_confinement(exc)
                 if translated is exc:
@@ -182,4 +207,4 @@ class LocalArchiveReader:
                 raise translated from exc
             # Consumer exceptions (particularly destination ENOSPC/EIO) must
             # never be attributed to the source by this context manager.
-            yield _SourceErrors(decoded, label)
+            yield _SourceErrors(decoded, label, recheck)

--- a/modelark/slice/local_source.py
+++ b/modelark/slice/local_source.py
@@ -35,6 +35,8 @@ def _translate_io(exc, label):
 
 
 def _translate_confinement(exc):
+    if exc.code == "WAITING_DESTINATION":
+        return TransferRefusal("SOURCE_MISSING", exc.detail)
     if exc.code == "DESTINATION_CHANGED":
         return TransferRefusal("SOURCE_CHANGED", exc.detail)
     # The shared hardware observer speaks destination-side eligibility codes.
@@ -147,6 +149,8 @@ class LocalArchiveReader:
                         raise TransferRefusal("SOURCE_CHANGED", label)
 
                 tree = stack.enter_context(BoundTree(path, verify=attachment_check))
+                if tree.mount_id != expected[4]:
+                    raise TransferRefusal("SOURCE_CHANGED", "observer and source descriptor attachments differ")
                 drive = candidate.drive
 
                 def check():

--- a/modelark/slice/local_source.py
+++ b/modelark/slice/local_source.py
@@ -126,9 +126,11 @@ class LocalArchiveReader:
     """Internal reader with full per-artifact and lightweight per-read attachment proofs."""
 
     def __init__(self, attachments, *, observer, max_decode_bytes=64 << 20):
-        # Expand operator spelling before observation without following symlinks;
-        # BoundTree still performs the authoritative no-symlink path resolution.
-        self.attachments = {label: Path(path).expanduser().absolute() for label, path in attachments.items()}
+        # Normalize operator spelling, including lexical '..', before observation
+        # without following symlinks. BoundTree still performs the authoritative
+        # no-symlink path resolution; Path.absolute() alone retains parent segments.
+        self.attachments = {label: Path(os.path.abspath(Path(path).expanduser()))
+                            for label, path in attachments.items()}
         self.observer = observer
         self.max_decode_bytes = max_decode_bytes
 

--- a/modelark/slice/local_source.py
+++ b/modelark/slice/local_source.py
@@ -1,0 +1,176 @@
+"""Explicit, read-only archive attachments yielding original bytes without retrieval.
+
+Compose with FencedSources: its archive fence must span this context manager.
+Only direct ``<mount>/modelark/.git`` archives are supported. The sole allowed
+symlink is a final annex pointer whose normalized target is a sealed key under
+the pinned archive's object directory; the target is then opened independently
+with the same no-symlink/no-mount-crossing confinement as ordinary files.
+"""
+from __future__ import annotations
+
+import configparser
+from contextlib import ExitStack, contextmanager
+import errno
+import os
+from pathlib import Path, PurePosixPath
+import posixpath
+import stat
+
+from modelark.capacity_evidence import identity_fingerprint_v1
+from . import domain as d
+from .decoding import original_stream
+from .transaction import TransferRefusal
+
+
+def _identity(evidence):
+    return tuple(getattr(evidence, key) for key in
+                 ("fs_uuid", "serial", "total_bytes", "device_id", "mount_id", "mount_path"))
+
+
+def _translate_io(exc, label):
+    if isinstance(exc, FileNotFoundError):
+        return TransferRefusal("SOURCE_MISSING", label)
+    code = "SOURCE_PATH_UNSAFE" if exc.errno in (errno.ELOOP, errno.EXDEV) else "SOURCE_READ_FAILED"
+    return TransferRefusal(code, f"{label}: {exc}")
+
+
+def _translate_confinement(exc):
+    if exc.code == "DESTINATION_CHANGED":
+        return TransferRefusal("SOURCE_CHANGED", exc.detail)
+    # The shared hardware observer speaks destination-side eligibility codes.
+    # Its inability to prove a source attachment must stay a source refusal so
+    # the engine can consider other sealed archive copies, never blame USB output.
+    if exc.code.startswith("DESTINATION_") or exc.code == "FILESYSTEM_UNSUPPORTED":
+        return TransferRefusal("SOURCE_IDENTITY_UNPROVEN", exc.detail)
+    if exc.code == "PATH_UNSAFE":
+        return TransferRefusal("SOURCE_PATH_UNSAFE", exc.detail)
+    return exc
+
+
+class _SourceErrors:
+    def __init__(self, stream, label):
+        self.stream, self.label = stream, label
+
+    def read(self, size=-1):
+        try:
+            return self.stream.read(size)
+        except OSError as exc:
+            raise _translate_io(exc, self.label) from exc
+        except TransferRefusal as exc:
+            translated = _translate_confinement(exc)
+            if translated is exc:
+                raise
+            raise translated from exc
+
+
+def _annex_uuid(tree):
+    fd = tree.open(".git/config", os.O_RDONLY | os.O_NONBLOCK)
+    with os.fdopen(fd, "rb") as config:
+        info = os.fstat(config.fileno())
+        if not stat.S_ISREG(info.st_mode) or info.st_size > 1 << 20:
+            raise TransferRefusal("SOURCE_IDENTITY_UNPROVEN", "invalid archive git config")
+        data = config.read((1 << 20) + 1)
+    if len(data) > 1 << 20:
+        raise TransferRefusal("SOURCE_IDENTITY_UNPROVEN", "oversize archive git config")
+    parser = configparser.RawConfigParser(strict=True)
+    try:
+        parser.read_string(data.decode("utf-8"))
+        value = parser.get("annex", "uuid").strip()
+    except (UnicodeError, configparser.Error) as exc:
+        raise TransferRefusal("SOURCE_IDENTITY_UNPROVEN", "missing unambiguous annex UUID") from exc
+    if not value:
+        raise TransferRefusal("SOURCE_IDENTITY_UNPROVEN", "missing annex UUID")
+    return value
+
+
+def _open_content(tree, candidate):
+    stored = candidate.copy.stored_relpath
+    repo = candidate.copy.repo_id
+    if not d._path(stored) or not d._path(repo) or len(PurePosixPath(repo).parts) != 2:
+        raise TransferRefusal("SOURCE_PATH_UNSAFE", f"{repo}/{stored}")
+    # Catalog stored_relpath is repository-relative, exactly as written by
+    # fetch and consumed by restore. Root-level names must never shadow it.
+    relative = f"{repo}/{stored}"
+    with tree.parent(relative) as (parent, name):
+        info = os.stat(name, dir_fd=parent, follow_symlinks=False)
+        if stat.S_ISLNK(info.st_mode):
+            target = os.readlink(name, dir_fd=parent)
+            if target.startswith("/") or "\\" in target or "\0" in target:
+                raise TransferRefusal("SOURCE_PATH_UNSAFE", "absolute or malformed annex link")
+            normalized = posixpath.normpath(posixpath.join(posixpath.dirname(relative), target))
+            key = candidate.copy.annex_key
+            parts = PurePosixPath(normalized).parts
+            if (not d._path(normalized) or not isinstance(key, str) or not d._ANNEX.fullmatch(key)
+                    or len(parts) != 7 or parts[:3] != (".git", "annex", "objects")
+                    or parts[-2:] != (key, key)):
+                raise TransferRefusal("SOURCE_PATH_UNSAFE", "annex target differs from sealed key")
+            relative = normalized
+        elif not stat.S_ISREG(info.st_mode):
+            raise TransferRefusal("SOURCE_PATH_UNSAFE", "source is not a regular file")
+    fd = tree.open(relative, os.O_RDONLY | os.O_NONBLOCK)
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            raise TransferRefusal("SOURCE_PATH_UNSAFE", "source is not a regular file")
+        if info.st_size != candidate.copy.stored_bytes:
+            raise TransferRefusal("SOURCE_CHANGED", "stored size differs from sealed evidence")
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+class LocalArchiveReader:
+    """Internal reader; production assembly awaits an approved hardware observer."""
+
+    def __init__(self, attachments, *, observer, max_decode_bytes=64 << 20):
+        self.attachments = {label: Path(path) for label, path in attachments.items()}
+        self.observer = observer
+        self.max_decode_bytes = max_decode_bytes
+
+    @contextmanager
+    def open(self, candidate):
+        from .linux import BoundTree
+        label = candidate.drive.drive_label
+        if label not in self.attachments:
+            raise TransferRefusal("WAITING_SOURCE", f"attach archive {label}")
+        path = self.attachments[label]
+        with ExitStack() as stack:
+            try:
+                observed = self.observer.observe(path)
+                expected = _identity(observed)
+                if path != Path(observed.mount_path) / "modelark":
+                    raise TransferRefusal("SOURCE_PATH_UNSAFE", "archive must be <mount>/modelark")
+
+                def attachment_check():
+                    if _identity(self.observer.observe(path)) != expected:
+                        raise TransferRefusal("SOURCE_CHANGED", label)
+
+                tree = stack.enter_context(BoundTree(path, verify=attachment_check))
+                drive = candidate.drive
+
+                def check():
+                    tree.check()
+                    annex = _annex_uuid(tree)
+                    fingerprint = identity_fingerprint_v1(
+                        fs_uuid=expected[0], annex_uuid=annex, serial=expected[1],
+                        filesystem_capacity_bytes=expected[2])
+                    if (expected[:3] != (drive.fs_uuid, drive.serial, drive.filesystem_capacity_bytes)
+                            or annex != drive.annex_uuid or fingerprint != drive.identity_fingerprint):
+                        raise TransferRefusal("SOURCE_CHANGED", label)
+
+                check()
+                stream = stack.enter_context(os.fdopen(_open_content(tree, candidate), "rb"))
+                decoded = original_stream(stream, compressed=candidate.copy.compressed,
+                                          expected_bytes=candidate.copy.orig_bytes,
+                                          max_decode_bytes=self.max_decode_bytes, check=check)
+            except OSError as exc:
+                raise _translate_io(exc, label) from exc
+            except TransferRefusal as exc:
+                translated = _translate_confinement(exc)
+                if translated is exc:
+                    raise
+                raise translated from exc
+            # Consumer exceptions (particularly destination ENOSPC/EIO) must
+            # never be attributed to the source by this context manager.
+            yield _SourceErrors(decoded, label)

--- a/modelark/slice/operator.py
+++ b/modelark/slice/operator.py
@@ -109,21 +109,58 @@ def approve(tx, seal):
 
 
 class _CheckedDestination(UsbDestination):
-    def __init__(self, tree, binding, store, tx, observer, path, proposal, caps, catalog):
+    def __init__(self, tree, binding, store, tx, observer, path, proposal, caps, catalog, evidence):
         self._observer, self._attachment_path = observer, path
         self._proposal, self._caps, self._catalog = proposal, caps, catalog
+        self._evidence = evidence
+        self._budget = None
         super().__init__(tree, binding, store, tx)
 
     @_port_io
     def check(self, binding, allocated, required_bytes):
         # Do not put capacity.verify into BoundTree.verify: it itself opens
         # confined paths. Core boundaries call this gate before every mutation.
-        self.tree.check()
-        evidence = self._observer.observe(self._attachment_path, writable=True, archives=_archives(self._catalog))
-        if (evidence.device_id, evidence.fs_uuid) != (binding.device_id, binding.filesystem_id):
+        first = self._budget is None
+        self._budget = (binding, allocated, required_bytes)
+        self._validate(refresh=first)
+
+    def _validate(self, *, refresh, reconcile=True):
+        binding, allocated, required_bytes = self._budget
+        archives = _archives(self._catalog)
+        self._observer.check_attachment(self.tree, self._evidence, archives=archives)
+        if refresh:
+            self._evidence = self._observer.observe(self._attachment_path, writable=True, archives=archives)
+        if (self._evidence.device_id, self._evidence.fs_uuid) != (binding.device_id, binding.filesystem_id):
             raise t.TransferRefusal("DESTINATION_CHANGED", "destination differs from reviewed device")
-        _capacity().verify(self.tree, evidence, self._proposal, self._caps, adapter=self)
-        super().check(binding, allocated, required_bytes)
+        _capacity().verify(self.tree, self._evidence, self._proposal, self._caps, adapter=self,
+                           refresh_volume=refresh)
+        if reconcile:
+            super().check(binding, allocated, required_bytes)
+
+    @_port_io
+    def create_file(self, path, token):
+        # Recovery may have just discarded an old temp since the engine's last
+        # check. Refresh physical eligibility, not its now-stale allocation total.
+        self._validate(refresh=True, reconcile=False)
+        return super().create_file(path, token)
+
+    @_port_io
+    def publish(self, temporary, path, token):
+        self._validate(refresh=True, reconcile=False)
+        return super().publish(temporary, path, token)
+
+    @_port_io
+    def list_paths(self, root):
+        # Core audits occur at Start, each artifact/attended resume and final receipt.
+        self._validate(refresh=True, reconcile=False)
+        return super().list_paths(root)
+
+    def _io_refusal(self, exc):
+        try:
+            self._observer.check_attachment(self.tree, self._evidence)
+        except t.TransferRefusal as refusal:
+            return refusal
+        return super()._io_refusal(exc)
 
 
 def _acknowledge_interrupt(store, tx, destination, sources, session=None):
@@ -170,7 +207,7 @@ def start(tx, destination_path, attachments):
             # Recovery may already own charged allocations. Full free-space
             # reconciliation belongs to the authenticated adapter, not fresh-start admission.
             destination = _CheckedDestination(tree, plan.destination, store, tx, observer, path,
-                                              plan.proposal, admission["capacity"], admission["catalog"])
+                                              plan.proposal, admission["capacity"], admission["catalog"], evidence)
             sources = FencedSources(admission["catalog"], LocalArchiveReader(attachments, observer=observer))
             try:
                 session = t.start(store, tx, destination, sources)

--- a/modelark/slice/operator.py
+++ b/modelark/slice/operator.py
@@ -1,0 +1,203 @@
+"""Internal assembly for the launch-guarded attended direct Slice CLI.
+
+All catalogs and attachments are explicit or sealed in private state. This module
+does not acquire a second application launch gate: the CLI already retains it.
+Never call these internal functions to bypass ModelArk's launch exclusion.
+"""
+from dataclasses import asdict, replace
+import hashlib
+import importlib
+from pathlib import Path
+import sqlite3
+from types import SimpleNamespace
+
+from . import domain as d
+from . import state as private_state
+from . import transaction as t
+from .authority import RESUMABLE_STATES
+from .catalog import read_catalog
+from .destination import UsbDestination, _port_io
+from .hardware import LinuxObserver
+from .linux import BoundTree
+from .local_source import LocalArchiveReader
+from .sources import FencedSources
+from .state import Store
+
+
+def _capacity():
+    return importlib.import_module("modelark.slice.capacity")
+
+
+def _store():
+    """Translate known private-state bootstrap/access failures at the operator boundary."""
+    try:
+        return Store()
+    except t.TransferRefusal:
+        raise  # Preserve existing typed STATE_BUSY and other precise refusals.
+    except (ValueError, OSError, sqlite3.Error) as exc:
+        raise t.TransferRefusal("STATE_UNAVAILABLE", str(exc)) from exc
+
+
+def _archives(catalog_path):
+    """Exclude the complete registered archive fleet, not only selected sources."""
+    path = Path(catalog_path).expanduser().resolve()
+    con = None
+    try:
+        con = sqlite3.connect(path.as_uri() + "?mode=ro", uri=True, isolation_level=None)
+        con.execute("PRAGMA query_only=ON")
+        con.execute("BEGIN")
+        if con.execute("PRAGMA user_version").fetchone()[0] != 7:
+            raise d.SliceRefusal("CATALOG_VERSION_UNSUPPORTED", "direct delivery requires catalog v7")
+        return tuple(SimpleNamespace(fs_uuid=uuid, serial=serial)
+                     for uuid, serial in con.execute("SELECT fs_uuid,serial FROM drives ORDER BY drive_label"))
+    except sqlite3.Error as exc:
+        raise d.SliceRefusal("CATALOG_UNAVAILABLE", str(exc)) from exc
+    finally:
+        if con is not None:
+            con.close()
+
+
+def _result(outcome, *, stop_requested=False):
+    result = asdict(outcome)
+    result["ok"] = outcome.state not in {"failed", "invalidated", "blocked_source", "waiting_source",
+                                        "waiting_destination"}
+    result["stop_requested"] = stop_requested
+    return result
+
+
+def preview(catalog_path, destination_path, repo_ids, root):
+    catalog_path = str(Path(catalog_path).expanduser().resolve())
+    spec = d.SliceSpec(tuple(repo_ids), "pending-device-observation", root)
+    snapshot = read_catalog(catalog_path, spec)
+    proposal = d.preview(spec, snapshot)
+    if not proposal.source_ready:
+        return {"ok": False, "state": "blocked", "executable": False,
+                "gaps": [asdict(gap) for gap in proposal.gaps], "preview": asdict(proposal)}
+    archives = _archives(catalog_path)
+    observer = LinuxObserver()
+    path = Path(destination_path).expanduser().absolute()
+    evidence = observer.observe(path, writable=True, archives=archives)
+    proposal = d.preview(replace(spec, destination_id=evidence.device_id), snapshot)
+    capacity = _capacity()
+    with BoundTree(path, writable=True) as tree:
+        caps = capacity.capture(tree, evidence, proposal, private_state.HOST_STATE_DIR.absolute())
+        admission = {"version": "modelark.slice.direct.v1", "catalog": catalog_path, "capacity": caps}
+        binding = t.DestinationBinding(evidence.device_id, evidence.fs_uuid,
+                                       "direct-v1:" + hashlib.sha256(d._json(admission)).hexdigest(),
+                                       evidence.available_bytes)
+        reserve = capacity.metadata_reserve_bytes(proposal, binding, caps, private_state.HOST_STATE_DIR.absolute())
+        plan = t.TransferPlan(proposal, binding, metadata_reserve_bytes=reserve)
+        fresh = observer.observe(path, writable=True, archives=archives)
+        capacity.verify(tree, fresh, proposal, caps)
+    approval = d.approve(proposal, expected_seal=proposal.seal, current_snapshot=snapshot)
+    store = _store()
+    tx = store.create(plan, approval, admission=admission)
+    return {"ok": True, "state": "ready", "executable": False, "transaction_id": tx,
+            "seal": plan.seal, "plan": asdict(plan), "admission": admission}
+
+
+def approve(tx, seal):
+    store = _store()
+    plan = store.load(tx)
+    admission = store.load_admission(tx)
+    if seal != plan.seal:
+        raise t.TransferRefusal("PREVIEW_STALE", "reviewed transaction seal differs")
+    snapshot = read_catalog(admission["catalog"], plan.proposal.spec)
+    d.approve(plan.proposal, expected_seal=plan.proposal.seal, current_snapshot=snapshot)
+    store.approve(tx, expected_seal=seal)
+    return _result(store.status(tx))
+
+
+class _CheckedDestination(UsbDestination):
+    def __init__(self, tree, binding, store, tx, observer, path, proposal, caps, catalog):
+        self._observer, self._attachment_path = observer, path
+        self._proposal, self._caps, self._catalog = proposal, caps, catalog
+        super().__init__(tree, binding, store, tx)
+
+    @_port_io
+    def check(self, binding, allocated, required_bytes):
+        # Do not put capacity.verify into BoundTree.verify: it itself opens
+        # confined paths. Core boundaries call this gate before every mutation.
+        self.tree.check()
+        evidence = self._observer.observe(self._attachment_path, writable=True, archives=_archives(self._catalog))
+        if (evidence.device_id, evidence.fs_uuid) != (binding.device_id, binding.filesystem_id):
+            raise t.TransferRefusal("DESTINATION_CHANGED", "destination differs from reviewed device")
+        _capacity().verify(self.tree, evidence, self._proposal, self._caps, adapter=self)
+        super().check(binding, allocated, required_bytes)
+
+
+def _acknowledge_interrupt(store, tx, destination, sources, session=None):
+    store.request_stop(tx)
+    try:
+        if session is not None:
+            return session.run()
+        # Interrupted Start releases its kernel attempt in transaction.start's
+        # BaseException handler. A fresh claim sees the unacknowledged stop and
+        # acknowledges it BEFORE destination checking or control/object writes.
+        result = t.start(store, tx, destination, sources)
+        if isinstance(result, t.Status):
+            return result
+        with result:
+            return result.run()
+    except t.TransferRefusal as exc:
+        if exc.code != "STOPPED":
+            raise
+        return t.Status(tx, "stopped", "STOPPED")
+
+
+def start(tx, destination_path, attachments):
+    store = _store()
+    plan = store.load(tx)
+    current = store.status(tx)
+    if current.state == "complete":
+        return _result(current)
+    if current.state == "ready":
+        raise t.TransferRefusal("APPROVAL_MISSING")
+    if current.state not in RESUMABLE_STATES:
+        raise t.TransferRefusal("NOT_RESUMABLE", current.state)
+    admission = store.load_admission(tx)
+    allowed = {source.drive.drive_label for artifact in plan.proposal.closure for source in artifact.sources}
+    if not isinstance(attachments, dict) or set(attachments) - allowed:
+        raise t.TransferRefusal("SOURCE_ATTACHMENT_UNSEALED", "attachment label is not a reviewed source")
+    archives = _archives(admission["catalog"])
+    observer = LinuxObserver()
+    path = Path(destination_path).expanduser().absolute()
+    try:
+        with BoundTree(path, writable=True) as tree:
+            evidence = observer.observe(path, writable=True, archives=archives)
+            if (evidence.device_id, evidence.fs_uuid) != (plan.destination.device_id, plan.destination.filesystem_id):
+                raise t.TransferRefusal("DESTINATION_CHANGED", "destination differs from reviewed device")
+            # Recovery may already own charged allocations. Full free-space
+            # reconciliation belongs to the authenticated adapter, not fresh-start admission.
+            destination = _CheckedDestination(tree, plan.destination, store, tx, observer, path,
+                                              plan.proposal, admission["capacity"], admission["catalog"])
+            sources = FencedSources(admission["catalog"], LocalArchiveReader(attachments, observer=observer))
+            try:
+                session = t.start(store, tx, destination, sources)
+            except KeyboardInterrupt:
+                return _result(_acknowledge_interrupt(store, tx, destination, sources), stop_requested=True)
+            if isinstance(session, t.Status):
+                return _result(session)
+            with session:
+                try:
+                    return _result(session.run())
+                except KeyboardInterrupt:
+                    return _result(_acknowledge_interrupt(store, tx, destination, sources, session),
+                                   stop_requested=True)
+    except FileNotFoundError as exc:
+        raise t.TransferRefusal("WAITING_DESTINATION", "destination attachment is absent; no new attempt retained") from exc
+
+
+def status(tx):
+    store = _store()
+    store.load(tx)
+    return _result(store.status(tx), stop_requested=store.stop_requested(tx))
+
+
+def stop(tx):
+    store = _store()
+    store.load(tx)
+    current = store.status(tx)
+    if current.state not in {"complete", "failed", "invalidated"}:
+        store.request_stop(tx)
+    return _result(store.status(tx), stop_requested=store.stop_requested(tx))

--- a/modelark/slice/operator.py
+++ b/modelark/slice/operator.py
@@ -21,6 +21,7 @@ from .hardware import LinuxObserver
 from .linux import BoundTree
 from .local_source import LocalArchiveReader
 from .paths import canonical_attachment
+from .io_errors import classify_io, io_boundary
 from .sources import FencedSources
 from .state import Store
 
@@ -80,7 +81,10 @@ def preview(catalog_path, destination_path, repo_ids, root):
     evidence = observer.observe(path, writable=True, archives=archives)
     proposal = d.preview(replace(spec, destination_id=evidence.device_id), snapshot)
     capacity = _capacity()
-    with BoundTree(path, writable=True) as tree:
+    with io_boundary(None, 'DESTINATION_UNPROVEN', 'destination preview setup/teardown failed'), \
+            BoundTree(path, writable=True) as tree, io_boundary(
+            lambda: observer.recheck_attachment(tree, evidence),
+            'DESTINATION_UNPROVEN', 'destination preview failed'):
         caps = capacity.capture(tree, evidence, proposal, private_state.HOST_STATE_DIR.absolute())
         admission = {"version": "modelark.slice.direct.v1", "catalog": catalog_path, "capacity": caps}
         binding = t.DestinationBinding(evidence.device_id, evidence.fs_uuid,
@@ -156,12 +160,8 @@ class _CheckedDestination(UsbDestination):
         self._validate(refresh=True, reconcile=False)
         return super().list_paths(root)
 
-    def _io_refusal(self, exc):
-        try:
-            self._observer.check_attachment(self.tree, self._evidence)
-        except t.TransferRefusal as refusal:
-            return refusal
-        return super()._io_refusal(exc)
+    def _recheck_attachment(self):
+        self._observer.recheck_attachment(self.tree, self._evidence)
 
 
 def _acknowledge_interrupt(store, tx, destination, sources, session=None):
@@ -200,8 +200,10 @@ def start(tx, destination_path, attachments):
     archives = _archives(admission["catalog"])
     observer = LinuxObserver()
     path = canonical_attachment(destination_path)
+    bound = False
     try:
         with BoundTree(path, writable=True) as tree:
+            bound = True
             evidence = observer.observe(path, writable=True, archives=archives)
             if (evidence.device_id, evidence.fs_uuid) != (plan.destination.device_id, plan.destination.filesystem_id):
                 raise t.TransferRefusal("DESTINATION_CHANGED", "destination differs from reviewed device")
@@ -223,7 +225,15 @@ def start(tx, destination_path, attachments):
                     return _result(_acknowledge_interrupt(store, tx, destination, sources, session),
                                    stop_requested=True)
     except FileNotFoundError as exc:
+        if bound:
+            raise t.TransferRefusal('DESTINATION_IO_FAILED',
+                                    'destination setup/teardown failed: ' + str(exc)) from exc
         raise t.TransferRefusal("WAITING_DESTINATION", "destination attachment is absent; no new attempt retained") from exc
+    except OSError as exc:
+        # Port operations classify while their descriptors are alive. This is only
+        # bootstrap/teardown IO, without trustworthy retained evidence for a wait.
+        raise classify_io(exc, None, t.TransferRefusal(
+            'DESTINATION_IO_FAILED', 'destination setup/teardown failed: ' + str(exc))) from exc
 
 
 def status(tx):

--- a/modelark/slice/operator.py
+++ b/modelark/slice/operator.py
@@ -68,6 +68,9 @@ def _result(outcome, *, stop_requested=False):
 
 
 def preview(catalog_path, destination_path, repo_ids, root):
+    if root is None:
+        from .folder_operator import preview as folder_preview
+        return folder_preview(catalog_path, destination_path, repo_ids)
     catalog_path = str(Path(catalog_path).expanduser().resolve())
     spec = d.SliceSpec(tuple(repo_ids), "pending-device-observation", root)
     snapshot = read_catalog(catalog_path, spec)
@@ -191,8 +194,14 @@ def start(tx, destination_path, attachments):
         return _result(current)
     if current.state == "ready":
         raise t.TransferRefusal("APPROVAL_MISSING")
+    if getattr(plan, "session_only", False):
+        from .fat32_operator import start as fat32_start
+        return fat32_start(store, tx, plan, destination_path, attachments)
     if current.state not in RESUMABLE_STATES:
         raise t.TransferRefusal("NOT_RESUMABLE", current.state)
+    if plan.is_folder:
+        from .folder_operator import start as folder_start
+        return folder_start(store, tx, plan, destination_path, attachments)
     admission = store.load_admission(tx)
     allowed = {source.drive.drive_label for artifact in plan.proposal.closure for source in artifact.sources}
     if not isinstance(attachments, dict) or set(attachments) - allowed:

--- a/modelark/slice/operator.py
+++ b/modelark/slice/operator.py
@@ -20,6 +20,7 @@ from .destination import UsbDestination, _port_io
 from .hardware import LinuxObserver
 from .linux import BoundTree
 from .local_source import LocalArchiveReader
+from .paths import canonical_attachment
 from .sources import FencedSources
 from .state import Store
 
@@ -75,7 +76,7 @@ def preview(catalog_path, destination_path, repo_ids, root):
                 "gaps": [asdict(gap) for gap in proposal.gaps], "preview": asdict(proposal)}
     archives = _archives(catalog_path)
     observer = LinuxObserver()
-    path = Path(destination_path).expanduser().absolute()
+    path = canonical_attachment(destination_path)
     evidence = observer.observe(path, writable=True, archives=archives)
     proposal = d.preview(replace(spec, destination_id=evidence.device_id), snapshot)
     capacity = _capacity()
@@ -198,7 +199,7 @@ def start(tx, destination_path, attachments):
         raise t.TransferRefusal("SOURCE_ATTACHMENT_UNSEALED", "attachment label is not a reviewed source")
     archives = _archives(admission["catalog"])
     observer = LinuxObserver()
-    path = Path(destination_path).expanduser().absolute()
+    path = canonical_attachment(destination_path)
     try:
         with BoundTree(path, writable=True) as tree:
             evidence = observer.observe(path, writable=True, archives=archives)

--- a/modelark/slice/paths.py
+++ b/modelark/slice/paths.py
@@ -1,0 +1,22 @@
+"""Slice attachment spelling and output encoding, without filesystem resolution."""
+import os
+from pathlib import Path
+
+
+def canonical_attachment(path):
+    """Normalize an attachment root lexically; BoundTree still confines its opening.
+
+    Host paths retain filesystem encoding semantics. This is not output-path
+    validation and must not be applied to sealed relative paths or catalog paths.
+    """
+    return Path(os.path.abspath(Path(path).expanduser()))
+
+
+def utf8_size(value):
+    """Count strict UTF-8 output bytes, refusing unsupported filesystem names."""
+    try:
+        return len(value.encode('utf-8'))
+    except UnicodeError as exc:
+        from .transaction import TransferRefusal
+        raise TransferRefusal('DESTINATION_LAYOUT_UNSUPPORTED',
+                              'non-UTF-8 output name') from exc

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -6,6 +6,7 @@ adapters and a public entry point are not provided by Slice 2.
 """
 from contextlib import contextmanager
 import hashlib
+import json
 import os
 from pathlib import Path
 import sqlite3
@@ -88,7 +89,7 @@ class Store:
             raise ValueError("unsafe slice state database")
         with self._connection() as con:
             version = con.execute("PRAGMA user_version").fetchone()[0]
-            if version not in (0, 1, 2, 3, 4, 5):
+            if version not in (0, 1, 2, 3, 4, 5, 6):
                 raise ValueError("unsupported slice state version")
             con.execute("CREATE TABLE IF NOT EXISTS transactions ("
                         "id TEXT PRIMARY KEY, plan TEXT NOT NULL, seal TEXT NOT NULL,"
@@ -118,6 +119,8 @@ class Store:
             if "attempt" not in columns:
                 con.execute("ALTER TABLE owners ADD COLUMN attempt TEXT")
             transaction_columns = {row[1] for row in con.execute("PRAGMA table_info(transactions)")}
+            if "admission" not in transaction_columns:
+                con.execute("ALTER TABLE transactions ADD COLUMN admission TEXT")
             if "acknowledged_stop_serial" not in transaction_columns:
                 con.execute("ALTER TABLE transactions ADD COLUMN acknowledged_stop_serial INTEGER NOT NULL DEFAULT 0")
                 # Legacy stopped rows can also contain a NEW, unacknowledged request.
@@ -128,7 +131,7 @@ class Store:
             con.execute("CREATE TABLE IF NOT EXISTS journal (tx TEXT NOT NULL REFERENCES transactions(id),"
                         "seq INTEGER NOT NULL, event TEXT NOT NULL, payload TEXT NOT NULL, digest TEXT NOT NULL,"
                         "PRIMARY KEY(tx,seq))")
-            con.execute("PRAGMA user_version=5")
+            con.execute("PRAGMA user_version=6")
 
     @contextmanager
     def _connection(self, *, write=True):
@@ -155,17 +158,53 @@ class Store:
         finally:
             con.close()
 
-    def create(self, plan, approval):
+    def create(self, plan, approval, *, admission=None):
         if plan.version != "modelark.slice.transaction.v3":
             from .transaction import TransferRefusal
             raise TransferRefusal("LEGACY_PLAN", "new transactions require protocol v3")
         validate_approval(plan.proposal, approval)
         plan.required_bytes(self.root)
+        encoded = None
+        if admission is not None:
+            self._validate_admission(plan, admission)
+            encoded = _json(admission).decode()
         tx = uuid.uuid4().hex
         with self._connection() as con:
-            con.execute("INSERT INTO transactions(id,plan,seal,state) VALUES(?,?,?,'ready')",
-                        (tx, plan.to_json(), plan.seal))
+            con.execute("INSERT INTO transactions(id,plan,seal,state,admission) VALUES(?,?,?,'ready',?)",
+                        (tx, plan.to_json(), plan.seal, encoded))
         return tx
+
+    @staticmethod
+    def _validate_admission(plan, admission):
+        from .transaction import TransferRefusal
+        try:
+            valid = (type(admission) is dict and set(admission) == {"version", "catalog", "capacity"}
+                     and admission["version"] == "modelark.slice.direct.v1"
+                     and isinstance(admission["catalog"], str) and Path(admission["catalog"]).is_absolute()
+                     and "\0" not in admission["catalog"]
+                     and os.path.normpath(admission["catalog"]) == admission["catalog"]
+                     and type(admission["capacity"]) is dict)
+            digest = hashlib.sha256(_json(admission)).hexdigest()
+        except (TypeError, ValueError) as exc:
+            raise TransferRefusal("ADMISSION_CORRUPT", "invalid direct admission record") from exc
+        if not valid or plan.destination.mount_id != "direct-v1:" + digest:
+            raise TransferRefusal("ADMISSION_CORRUPT", "direct admission differs from sealed binding")
+
+    def load_admission(self, tx):
+        from .transaction import TransferRefusal
+        plan = self.load(tx)
+        with self._connection(write=False) as con:
+            row = con.execute("SELECT admission FROM transactions WHERE id=?", (tx,)).fetchone()
+        if row is None:
+            raise TransferRefusal("TRANSACTION_MISSING", tx)
+        if row[0] is None:
+            raise TransferRefusal("ADMISSION_MISSING", "legacy internal transaction has no direct admission")
+        try:
+            admission = json.loads(row[0])
+        except (TypeError, ValueError) as exc:
+            raise TransferRefusal("ADMISSION_CORRUPT", "invalid admission JSON") from exc
+        self._validate_admission(plan, admission)
+        return admission
 
     def load(self, tx):
         from .transaction import TransferPlan, TransferRefusal

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -22,6 +22,49 @@ from .domain import _json, validate_approval
 HOST_STATE_DIR = Path.home() / ".local" / "state" / "modelark" / "slice"
 
 
+def _load_plan(payload):
+    """Tagged dispatch; never reinterpret a folder record as legacy USB authority."""
+    from .transaction import TransferPlan, TransferRefusal
+    from .folder_contract import _decode
+    from .folder_plan import NativePlan
+    from .fat32_plan import Fat32Plan
+    try:
+        record = _decode(payload)
+        if type(record) is not dict:
+            raise ValueError("plan envelope required")
+        if record.get("version") == "modelark.slice.native-transaction.v1":
+            return NativePlan.from_json(payload)
+        if record.get("version") == "modelark.slice.fat32-transaction.v1":
+            return Fat32Plan.from_json(payload)
+        return TransferPlan.from_json(payload)
+    except (ValueError, TypeError) as exc:
+        raise TransferRefusal("STATE_CORRUPT", str(exc)) from exc
+
+
+def _claims_overlap(first, second):
+    from .folder_contract import overlaps
+    if first.is_folder and second.is_folder:
+        if getattr(first, "session_only", False) or getattr(second, "session_only", False):
+            a, b = first.destination.target, second.destination.target
+            if a.filesystem_scope != b.filesystem_scope:
+                return False
+            if a.profile != b.profile:
+                from .transaction import TransferRefusal
+                raise TransferRefusal("DESTINATION_UNPROVEN", "mixed filesystem profiles")
+            # FAT observation requires exact enumerated parent spelling, rejects
+            # requested short aliases, and qualifies numbered short-name creation.
+            left, right = tuple(p.lower() for p in a.parts), tuple(p.lower() for p in b.parts)
+            common = min(len(left), len(right))
+            return left[:common] == right[:common]
+        return overlaps(first.destination.target, second.destination.target)
+    if not first.is_folder and not second.is_folder:
+        return first.destination.device_id == second.destination.device_id
+    folder, legacy = (first, second) if first.is_folder else (second, first)
+    keys = {key.casefold() for key in folder.backing_ids}
+    return (legacy.destination.device_id.casefold() in keys
+            or ("filesystem:" + legacy.destination.filesystem_id).casefold() in keys)
+
+
 class Reservation(NamedTuple):
     state: str
     stop_serial: int
@@ -89,7 +132,7 @@ class Store:
             raise ValueError("unsafe slice state database")
         with self._connection() as con:
             version = con.execute("PRAGMA user_version").fetchone()[0]
-            if version not in (0, 1, 2, 3, 4, 5, 6):
+            if version not in (0, 1, 2, 3, 4, 5, 6, 7, 8):
                 raise ValueError("unsupported slice state version")
             con.execute("CREATE TABLE IF NOT EXISTS transactions ("
                         "id TEXT PRIMARY KEY, plan TEXT NOT NULL, seal TEXT NOT NULL,"
@@ -131,7 +174,10 @@ class Store:
             con.execute("CREATE TABLE IF NOT EXISTS journal (tx TEXT NOT NULL REFERENCES transactions(id),"
                         "seq INTEGER NOT NULL, event TEXT NOT NULL, payload TEXT NOT NULL, digest TEXT NOT NULL,"
                         "PRIMARY KEY(tx,seq))")
-            con.execute("PRAGMA user_version=6")
+            if "consumed_attempt" not in {row[1] for row in con.execute("PRAGMA table_info(transactions)")}:
+                con.execute("ALTER TABLE transactions ADD COLUMN consumed_attempt TEXT")
+            # v8 fences binaries unaware of FAT's irrevocable single-attempt rule.
+            con.execute("PRAGMA user_version=8")
 
     @contextmanager
     def _connection(self, *, write=True):
@@ -159,9 +205,14 @@ class Store:
             con.close()
 
     def create(self, plan, approval, *, admission=None):
-        if plan.version != "modelark.slice.transaction.v3":
-            from .transaction import TransferRefusal
+        from .transaction import TransferRefusal, TransferPlan
+        from .folder_plan import NativePlan
+        from .fat32_plan import Fat32Plan
+        native = isinstance(plan, (NativePlan, Fat32Plan))
+        if not native and (not isinstance(plan, TransferPlan) or plan.version != "modelark.slice.transaction.v3"):
             raise TransferRefusal("LEGACY_PLAN", "new transactions require protocol v3")
+        if native and admission is not None:
+            raise TransferRefusal("ADMISSION_CORRUPT", "native admission is part of the plan")
         validate_approval(plan.proposal, approval)
         plan.required_bytes(self.root)
         encoded = None
@@ -193,6 +244,8 @@ class Store:
     def load_admission(self, tx):
         from .transaction import TransferRefusal
         plan = self.load(tx)
+        if plan.is_folder:
+            return {"version": plan.version, "catalog": plan.catalog}
         with self._connection(write=False) as con:
             row = con.execute("SELECT admission FROM transactions WHERE id=?", (tx,)).fetchone()
         if row is None:
@@ -207,12 +260,12 @@ class Store:
         return admission
 
     def load(self, tx):
-        from .transaction import TransferPlan, TransferRefusal
+        from .transaction import TransferRefusal
         with self._connection(write=False) as con:
             row = con.execute("SELECT plan,seal FROM transactions WHERE id=?", (tx,)).fetchone()
         if row is None:
             raise TransferRefusal("TRANSACTION_MISSING", tx)
-        plan = TransferPlan.from_json(row[0])
+        plan = _load_plan(row[0])
         if plan.seal != row[1]:
             raise TransferRefusal("STATE_CORRUPT", "plan seal differs")
         return plan
@@ -244,10 +297,24 @@ class Store:
     def reserve(self, tx, device):
         from .transaction import TransferRefusal, Status
         def inspect(con):
+            encoded, seal = con.execute("SELECT plan,seal FROM transactions WHERE id=?", (tx,)).fetchone()
+            plan = _load_plan(encoded)
+            if plan.seal != seal or plan.destination.device_id != device:
+                raise TransferRefusal("STATE_CORRUPT", "reservation differs from sealed plan")
             state, serial, acknowledged = con.execute(
                 "SELECT state,stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
             if state == "complete":
                 return None, Status(tx, state)
+            # Check durable namespace claims in the same snapshot/commit as reserve.
+            # A stopped owner still owns its output. A dead kernel lease is not
+            # permission to adopt its tree or acquire an overlapping legacy drive.
+            for other_tx, other_payload, other_seal in con.execute(
+                    "SELECT o.tx,t.plan,t.seal FROM owners o JOIN transactions t ON t.id=o.tx WHERE o.tx!=?", (tx,)):
+                other = _load_plan(other_payload)
+                if other.seal != other_seal:
+                    raise TransferRefusal("STATE_CORRUPT", "existing claim has a corrupt plan")
+                if _claims_overlap(plan, other):
+                    raise TransferRefusal("DESTINATION_BUSY", other_tx)
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
             if owner and owner[0] != tx:
                 raise TransferRefusal("DESTINATION_BUSY", owner[0])
@@ -276,6 +343,11 @@ class Store:
             row = con.execute("SELECT tx,attempt FROM owners WHERE device=?", (device,)).fetchone()
         return Attempt(*row) if row and row[1] is not None else None
 
+    def attempt_consumed(self, tx):
+        with self._connection(write=False) as con:
+            row = con.execute("SELECT consumed_attempt FROM transactions WHERE id=?", (tx,)).fetchone()
+        return bool(row and row[0] is not None)
+
     def claim(self, tx, device, attempt, reservation):
         """Publish an attempt only while its caller holds exclusion and its live marker."""
         from .transaction import TransferRefusal, Status
@@ -289,6 +361,15 @@ class Store:
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
             if not owner or owner[0] != tx or attempt.owner != tx:
                 raise TransferRefusal("EXECUTION_FENCE_LOST")
+            encoded, seal, consumed = con.execute(
+                "SELECT plan,seal,consumed_attempt FROM transactions WHERE id=?", (tx,)).fetchone()
+            plan = _load_plan(encoded)
+            if plan.seal != seal or plan.destination.device_id != device:
+                raise TransferRefusal("STATE_CORRUPT", "claim differs from sealed intent")
+            if getattr(plan, "session_only", False):
+                if consumed is not None:
+                    raise TransferRefusal("FAT32_NEW_ROOT_REQUIRED", "this intent has spent its only attempt")
+                con.execute("UPDATE transactions SET consumed_attempt=? WHERE id=?", (attempt.token, tx))
             con.execute("UPDATE owners SET attempt=? WHERE device=? AND tx=?", (attempt.token, device, tx))
             # Only a Start issued AFTER this exact stop was acknowledged may clear it.
             resume = (reservation.state == state == "stopped"

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -27,6 +27,19 @@ class TransferRefusal(ValueError):
         super().__init__(f"{code}: {detail}")
 
 
+def decode_proposal(p):
+    """Reconstruct the shared sealed domain closure without mutating the record."""
+    closure = []
+    for item in p["closure"]:
+        fields = dict(item)
+        sources = tuple(d.SourceEvidence(d.CopyFact(**s["copy"]), d.DriveFact(**s["drive"]),
+                                         d.AnchorFact(**s["anchor"]), s["digest_provenance"])
+                        for s in fields.pop("sources"))
+        closure.append(d.Artifact(**fields, sources=sources))
+    return d.SlicePreview(d.SliceSpec(**p["spec"]), p["snapshot_id"], tuple(closure),
+                          tuple(d.Gap(**g) for g in p["gaps"]), p["seal"], p["version"])
+
+
 @dataclass(frozen=True)
 class DestinationBinding:
     device_id: str
@@ -72,6 +85,14 @@ class TransferPlan:
     def seal(self):
         return hashlib.sha256(self.to_json().encode()).hexdigest()
 
+    @property
+    def control_path(self):
+        return ".modelark-slice-owner"
+
+    @property
+    def is_folder(self):
+        return False
+
     def to_json(self):
         payload = asdict(self)
         if self.version != "modelark.slice.transaction.v3":
@@ -108,15 +129,18 @@ class TransferPlan:
     def from_json(cls, payload):
         try:
             obj = json.loads(payload)
-            p = obj["proposal"]
-            closure = []
-            for item in p["closure"]:
-                sources = tuple(d.SourceEvidence(d.CopyFact(**s["copy"]), d.DriveFact(**s["drive"]),
-                                                 d.AnchorFact(**s["anchor"]), s["digest_provenance"])
-                                for s in item.pop("sources"))
-                closure.append(d.Artifact(**item, sources=sources))
-            proposal = d.SlicePreview(d.SliceSpec(**p["spec"]), p["snapshot_id"], tuple(closure),
-                                      tuple(d.Gap(**g) for g in p["gaps"]), p["seal"], p["version"])
+            # This decoder is legacy-USB-only. A folder envelope must never be
+            # duck-typed into a USB plan, even when it also supplies legacy fields.
+            if type(obj) is not dict or obj.get("version") not in {
+                    "modelark.slice.transaction.v1", "modelark.slice.transaction.v2",
+                    "modelark.slice.transaction.v3"}:
+                raise ValueError("unsupported legacy transaction envelope")
+            fields = {"proposal", "destination", "version"}
+            if obj["version"] == "modelark.slice.transaction.v3":
+                fields.add("metadata_reserve_bytes")
+            if set(obj) != fields:
+                raise ValueError("mixed or malformed legacy transaction envelope")
+            proposal = decode_proposal(obj["proposal"])
             return cls(proposal, DestinationBinding(**obj["destination"]), obj["version"],
                        obj.get("metadata_reserve_bytes"))
         except (KeyError, TypeError, ValueError) as exc:
@@ -193,6 +217,18 @@ def _same_source(artifact, candidate, snapshot):
     return expected == actual
 
 
+def _close_fat_abort(authority, destination, error):
+    """Publish a caught abort while authority is retained, then revoke every descriptor."""
+    try:
+        if isinstance(error, KeyboardInterrupt):
+            authority.store.request_stop(authority.tx)
+    finally:
+        try:
+            authority.close()
+        finally:
+            destination.end_session()
+
+
 def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault=None):
     plan = store.load(tx)
     status = store.status(tx)
@@ -209,11 +245,15 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
     if isinstance(authority, Status):
         return authority
     try:
+        if getattr(plan, "session_only", False):
+            destination.begin_session(authority)
         destination.check(plan.destination, 0 if not store.events(tx) else _allocated(store, tx, destination), required)
         authority.activate()
         session = Session(store, tx, plan, destination, sources, authority, fault)
         session._fault("reserved")
         session._audit_layout()
+        if plan.is_folder:
+            session._directory(plan.proposal.spec.destination_root)
         session._control()
         return session
     except TransferRefusal as exc:
@@ -222,9 +262,14 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
                 authority.refuse(exc)
         finally:
             authority.lease.close()
+            if getattr(plan, "session_only", False):
+                destination.end_session()
         raise
-    except BaseException:
-        authority.lease.close()
+    except BaseException as exc:
+        if getattr(plan, "session_only", False):
+            _close_fat_abort(authority, destination, exc)
+        else:
+            authority.lease.close()
         raise
 
 
@@ -264,7 +309,7 @@ def _operations(store, tx):
                 elif payload["state"] != "intent":
                     raise TransferRefusal("JOURNAL_CORRUPT", "prepared file lacks source proof")
             elif not ((kind == "directory" and path in directories)
-                      or (kind == "control" and path == ".modelark-slice-owner")
+                      or (kind == "control" and path == plan.control_path)
                       or (kind == "receipt" and path == receipt_path)):
                 raise TransferRefusal("JOURNAL_CORRUPT", path)
             temporary = payload.get("temporary")
@@ -334,7 +379,11 @@ class Session:
         self.close()
 
     def close(self):
-        self.authority.close()
+        try:
+            self.authority.close()
+        finally:
+            if getattr(self.plan, "session_only", False):
+                self.destination.end_session()
 
     def _boundary(self):
         head = self.authority.boundary()
@@ -347,7 +396,7 @@ class Session:
         self._verify_control()
 
     def _verify_control(self, *, required=False):
-        op = self.ops.get(".modelark-slice-owner")
+        op = self.ops.get(self.plan.control_path)
         if op is None or op["state"] != "complete":
             if required:
                 raise TransferRefusal("CONTROL_CORRUPT", "ownership record is not complete")
@@ -429,7 +478,7 @@ class Session:
                 raise TransferRefusal("OUTPUT_COLLISION", path)
 
     def _control(self):
-        path = ".modelark-slice-owner"
+        path = self.plan.control_path
         data = d._json({"transaction": self.transaction_id, "seal": self.plan.seal,
                         "store": str(self.store.root), "destination": asdict(self.plan.destination)})
         op = self._op(path, "control", size=len(data), sha=hashlib.sha256(data).hexdigest())
@@ -586,9 +635,28 @@ class Session:
         else:
             self._write(op, io.BytesIO(data))
         self.head = self.authority.append("receipt", receipt, expected_head=self.head)
+        if getattr(self.plan, "session_only", False):
+            # All destination IO, including retained-descriptor close errors,
+            # must settle before the authoritative host completion commit.
+            self.destination.end_session()
         self.authority.complete()
 
     def step(self):
+        if not getattr(self.plan, "session_only", False):
+            return self._step()
+        try:
+            result = self._step()
+        except BaseException as exc:
+            self._terminal = True
+            _close_fat_abort(self.authority, self.destination, exc)
+            raise
+        if result.state not in {"transferring", "verifying"}:
+            self._terminal = True
+            self.lease.close()
+            self.destination.end_session()
+        return result
+
+    def _step(self):
         if self._terminal:
             raise TransferRefusal("NOT_RESUMABLE", "session encountered a terminal refusal")
         try:
@@ -631,10 +699,11 @@ class Session:
                 self.lease.close()
                 raise
             states = {"STOPPED": "stopped", "WAITING_SOURCE": "waiting_source",
-                      "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source"}
+                      "WAITING_DESTINATION": "waiting_destination", "SOURCE_BLOCKED": "blocked_source",
+                      "DESTINATION_CAPACITY_WAIT": "waiting_destination"}
             state = _refusal_state(exc.code)
             # Stop ends this attempt; attended source/destination waits may retain it.
-            self._terminal = exc.code == "STOPPED" or exc.code not in states
+            self._terminal = exc.code in {"STOPPED", "DESTINATION_CAPACITY_WAIT"} or exc.code not in states
             try:
                 outcome = self.authority.transition(state, str(exc))
             except TransferRefusal as transition_error:

--- a/modelark/web/server.py
+++ b/modelark/web/server.py
@@ -330,6 +330,22 @@ class Handler(BaseHTTPRequestHandler):
 
 def serve(port: int = 8077, open_browser: bool = True, resume: bool = False,
           host: str = "127.0.0.1"):
+    """Direct portal entry: acquire the same launch gate as the CLI."""
+    from modelark.instance import launch
+    with launch() as permit:
+        return _serve_in_instance(permit, port=port, open_browser=open_browser, resume=resume, host=host)
+
+
+def _serve_in_instance(permit, port=8077, open_browser=True, resume=False, host="127.0.0.1"):
+    """Explicit one-use handoff from an already guarded CLI launch."""
+    from modelark.instance import _LaunchPermit
+    if type(permit) is not _LaunchPermit:
+        raise SystemExit("invalid ModelArk launch permit")
+    permit.consume_server()
+    return _serve(port=port, open_browser=open_browser, resume=resume, host=host)
+
+
+def _serve(port=8077, open_browser=True, resume=False, host="127.0.0.1"):
     if not _is_loopback_name(host):
         raise ValueError("the operator portal has no remote authentication; refusing a non-loopback bind")
     telemetry.configure(**wishlist.logging_config())   # file + stdout; flushes per record (unlike print → journald)

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -191,7 +191,15 @@ def _check(
     if not unit_path.is_file():
         raise RuntimeError(f"systemd user unit is missing: {unit_path}")
     _validate_unit(unit_path, source, executable, data_dir, state_dir, config, port)
-    subprocess.run([str(executable), "--help"], check=True, stdout=subprocess.DEVNULL)
+    # Inspect the installed distribution without launching another ModelArk instance.
+    # The active service owns application-wide launch exclusion (DEC-124).
+    subprocess.run([
+        str(venv / "bin" / "python"), "-I", "-c",
+        "import importlib.metadata as m; "
+        "d=m.distribution('modelark'); "
+        "assert any(e.group=='console_scripts' and e.name=='modelark' "
+        "and e.value=='modelark.cli:main' for e in d.entry_points), 'missing ModelArk entry point'",
+    ], check=True, stdout=subprocess.DEVNULL)
     subprocess.run(["systemctl", "--user", "is-active", "--quiet", UNIT_NAME], check=True)
     request = urllib.request.Request(
         f"http://127.0.0.1:{port}/api/meta",

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -176,6 +176,17 @@ def _validate_unit(
             "installed unit does not match the requested deployment: " + ", ".join(missing))
 
 
+def _installed_metadata_argv(venv: Path) -> list[str]:
+    """Validate installation metadata without entering the single-instance application."""
+    return [
+        str(venv / "bin" / "python"), "-I", "-c",
+        "import importlib.metadata as m; "
+        "d=m.distribution('modelark'); "
+        "assert any(e.group=='console_scripts' and e.name=='modelark' "
+        "and e.value=='modelark.cli:main' for e in d.entry_points), 'missing ModelArk entry point'",
+    ]
+
+
 def _check(
     source: Path,
     venv: Path,
@@ -193,13 +204,7 @@ def _check(
     _validate_unit(unit_path, source, executable, data_dir, state_dir, config, port)
     # Inspect the installed distribution without launching another ModelArk instance.
     # The active service owns application-wide launch exclusion (DEC-124).
-    subprocess.run([
-        str(venv / "bin" / "python"), "-I", "-c",
-        "import importlib.metadata as m; "
-        "d=m.distribution('modelark'); "
-        "assert any(e.group=='console_scripts' and e.name=='modelark' "
-        "and e.value=='modelark.cli:main' for e in d.entry_points), 'missing ModelArk entry point'",
-    ], check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(_installed_metadata_argv(venv), check=True, stdout=subprocess.DEVNULL)
     subprocess.run(["systemctl", "--user", "is-active", "--quiet", UNIT_NAME], check=True)
     request = urllib.request.Request(
         f"http://127.0.0.1:{port}/api/meta",
@@ -300,7 +305,7 @@ def main(argv: list[str] | None = None) -> None:
         if not (venv / "bin" / "python").is_file():
             _run([sys.executable, "-m", "venv", venv], args.dry_run)
         _run([venv / "bin" / "python", "-m", "pip", "install", source], args.dry_run)
-        _run([executable, "--help"], args.dry_run)
+        _run(_installed_metadata_argv(venv), args.dry_run)
     elif not args.dry_run and not executable.is_file():
         parser.error(f"--skip-install requested but {executable} does not exist")
 

--- a/scripts/migrate_legacy_runtime.py
+++ b/scripts/migrate_legacy_runtime.py
@@ -351,6 +351,12 @@ def execute(source_data_dir: Path, destination_data_dir: Path, backup_root: Path
 
 
 def main(argv: list[str] | None = None) -> int:
+    from modelark.instance import launch
+    with launch():
+        return _main(argv)
+
+
+def _main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source-data-dir", type=Path, required=True)
     parser.add_argument("--destination-data-dir", type=Path, required=True)

--- a/scripts/migrate_provenance.py
+++ b/scripts/migrate_provenance.py
@@ -72,6 +72,12 @@ def _cmd_leftovers(args: argparse.Namespace) -> dict:
 
 
 def main(argv: list[str] | None = None) -> int:
+    from modelark.instance import launch
+    with launch():
+        return _main(argv)
+
+
+def _main(argv: list[str] | None = None) -> int:
     parser = _parser()
     args = parser.parse_args(argv)
     if args.cmd == "publish" and args.confirm_stopped != _CONFIRMATION:

--- a/scripts/qualify_fat32_slice.py
+++ b/scripts/qualify_fat32_slice.py
@@ -1,0 +1,254 @@
+"""Attended kernel-vfat test on a NEW disposable image; never accepts a device.
+
+Run as the ordinary operator with .venv-dev Python. Only mount/unmount request
+sudo. Image, private synthetic state and test outputs are retained under /tmp.
+This tests driver/port behavior, not real archive or physical USB admission.
+"""
+import argparse
+from dataclasses import replace
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+from unittest.mock import patch
+
+
+def public_workflow(base, exports, mounted):
+    """Real public routing and vfat I/O; source/hardware evidence is synthetic."""
+    from modelark.slice import fat32_operator as fat, folder_operator as folder, operator
+    from modelark.slice import transaction as t
+    from modelark.slice.fat32_observation import (
+        Fat32FolderEvidence, Fat32FolderObserver, Fat32Tree, _mount_policy, check_directory,
+    )
+    from modelark.slice.folder_contract import CapacityObservation
+    from test_slice_transaction import DATA, Sources, proposal
+
+    canonical = Fat32FolderObserver()
+    _, _, snapshot = proposal()
+
+    class SyntheticBackingObserver:
+        def observe(self, destination, **kwargs):
+            destination = Path(destination)
+            with Fat32Tree(destination.parent) as retained:
+                _mount_policy(mounted)
+                check_directory(retained.fd)
+                parts = canonical._canonical_parent(retained, mounted)
+                try:
+                    os.stat(destination.name, dir_fd=retained.fd, follow_symlinks=False)
+                except FileNotFoundError:
+                    pass
+                else:
+                    raise t.TransferRefusal("OUTPUT_COLLISION")
+                fs = os.fstatvfs(retained.fd)
+                return Fat32FolderEvidence(
+                    str(destination.parent), str(destination), "synthetic-loop-uuid",
+                    "synthetic-public-loop", parts, destination.name, ("synthetic-loop",),
+                    retained.mount_id, mounted.major_minor,
+                    CapacityObservation(fs.f_bavail * fs.f_frsize, None), 255, fs.f_frsize)
+
+        def recheck(self, retained, evidence, **kwargs):
+            retained.check()
+            _mount_policy(mounted)
+            check_directory(retained.fd)
+            assert canonical._canonical_parent(retained, mounted) == evidence.parent_parts
+            fs = os.fstatvfs(retained.fd)
+            return replace(evidence, capacity=CapacityObservation(fs.f_bavail * fs.f_frsize, None))
+
+    child = exports / "public-delivery"
+    # Deliberately leave folder._filesystem_type unpatched: dispatch must read
+    # the actual kernel mount table. Never fabricate physical USB admission.
+    with (patch.object(fat, "Fat32FolderObserver", SyntheticBackingObserver),
+          patch.object(fat, "read_catalog", return_value=snapshot),
+          patch.object(folder, "read_catalog", return_value=snapshot),
+          patch.object(operator, "read_catalog", return_value=snapshot),
+          patch.object(operator, "_archives", return_value=()),
+          patch.object(fat, "FencedSources", side_effect=lambda *args: Sources(snapshot, t))):
+        preview = operator.preview(base / "synthetic-catalog-never-opened", child, ("org/model",), None)
+        assert not child.exists()
+        assert preview["resume_policy"] == "new-root-after-any-ended-attempt"
+        operator.approve(preview["transaction_id"], preview["seal"])
+        assert not child.exists()
+        result = operator.start(preview["transaction_id"], child, {})
+        assert result["state"] == "complete" and result["ok"]
+        assert (child / "org/model/model.safetensors").read_bytes() == DATA
+        report = json.loads((child / ".modelark-slice-receipt.json").read_text())
+        assert report["host_transaction_completion"] == "not-claimed"
+        assert not (exports / ".modelark-slice-owner").exists()
+
+
+def parent_alias_checks(exports, mounted):
+    from modelark.slice.fat32_observation import Fat32FolderObserver, Fat32Tree
+    from modelark.slice.transaction import TransferRefusal
+
+    canonical = Fat32FolderObserver()
+    parent = exports / "LongParentForAlias"
+    parent.mkdir()
+    with Fat32Tree(parent) as exact:
+        assert canonical._canonical_parent(exact, mounted)[-1] == parent.name
+        # Known isolated test vector for shortname=mixed, codepage=437.
+        # Require actual alias resolution before testing the refusal, so an
+        # absent alias cannot be mistaken for successful protection.
+        for spelling in ("longparentforalias", "LONGPA~1"):
+            with Fat32Tree(exports / spelling) as alias:
+                assert Fat32Tree.identity(alias.fd) == Fat32Tree.identity(exact.fd)
+                try:
+                    canonical._canonical_parent(alias, mounted)
+                except TransferRefusal as exc:
+                    assert exc.code in {"PATH_UNSAFE", "DESTINATION_LAYOUT_UNSUPPORTED"}
+                else:
+                    raise AssertionError("parent alias admitted: " + spelling)
+    try:
+        (exports / "longparentforalias").mkdir()
+    except FileExistsError:
+        pass
+    else:
+        raise AssertionError("case-equivalent directory creation succeeded")
+
+
+def exercise(base, mount):
+    repo = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo))
+    sys.path.insert(0, str(repo / "tests"))
+    from modelark.slice import domain as d, state, transaction as t
+    from modelark.slice.fat32_destination import Fat32Destination
+    from modelark.slice.fat32_observation import Fat32Tree, _mount_policy, check_directory
+    from modelark.slice.fat32_plan import Fat32Intent, Fat32Plan, binding_for, estimate_metadata
+    from modelark.slice.folder_contract import CapacityObservation, FolderProfile
+    from modelark.slice.host_observation import parse_mounts, read_fs_text
+    from modelark.slice.linux import rename_noreplace
+    from test_slice_transaction import DATA, Sources, proposal
+    from test_slice_fat32_transactions import FAULTS
+
+    state.HOST_STATE_DIR = base / "private-host-state"
+    store = state.Store()
+    exports = mount / "exports"
+    exports.mkdir()
+    (exports / "sibling.txt").write_bytes(b"untouched synthetic sibling")
+    checks = []
+    with Fat32Tree(exports, writable=True) as tree:
+        matches = [m for m in parse_mounts(read_fs_text("/proc/self/mountinfo"))
+                   if m.mount_id == tree.mount_id]
+        assert len(matches) == 1 and matches[0].fs_type == "vfat"
+        _mount_policy(matches[0])
+        check_directory(tree.fd)
+        # The loop image deliberately is not a qualified physical USB source or
+        # destination. Driver/port tests use explicit synthetic backing evidence.
+        def recheck(retained):
+            retained.check()
+            check_directory(retained.fd)
+
+        for name, data in (("rename-source.txt", b"source"), ("rename-target.txt", b"target")):
+            fd = os.open(name, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600, dir_fd=tree.fd)
+            try:
+                os.write(fd, data)
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        try:
+            rename_noreplace(tree.fd, "rename-source.txt", tree.fd, "rename-target.txt")
+        except FileExistsError:
+            pass
+        else:
+            raise AssertionError("RENAME_NOREPLACE overwrote existing target")
+        assert (exports / "rename-target.txt").read_bytes() == b"target"
+        rename_noreplace(tree.fd, "rename-source.txt", tree.fd, "rename-published.txt")
+        os.fsync(tree.fd)
+        assert (exports / "rename-published.txt").read_bytes() == b"source"
+        checks.append("kernel-no-replace-and-directory-flush")
+        parent_alias_checks(exports, matches[0])
+        checks.append("real-vfat-exact-parent-case-and-numbered-short-alias-refusal")
+        public_workflow(base, exports, matches[0])
+        checks.append("public-preview-approve-start-real-vfat-synthetic-source-and-backing")
+
+        def create(child):
+            target = Fat32Intent(FolderProfile.FAT32_SESSION, "synthetic-loop-qualification",
+                                 ("exports",), child)
+            catalog, backing = str(base / "synthetic-catalog-never-opened"), ("synthetic-loop",)
+            binding = binding_for(target, catalog, str(exports), backing)
+            original, _, snapshot = proposal()
+            preview = d.preview(replace(original.spec, destination_id=target.target_id,
+                                        destination_root=child), snapshot)
+            fs = os.fstatvfs(tree.fd)
+            capacity = CapacityObservation(fs.f_bavail * fs.f_frsize, None)
+            reserve = estimate_metadata(preview, binding, catalog, str(exports), backing,
+                                        capacity, store.root)
+            plan = Fat32Plan(preview, binding, catalog, str(exports), backing, capacity, reserve)
+            approval = d.approve(preview, expected_seal=preview.seal, current_snapshot=snapshot)
+            tx = store.create(plan, approval)
+            store.approve(tx, expected_seal=plan.seal)
+            return tx, plan, Sources(snapshot, t)
+
+        def run(tx, plan, sources, fault=None):
+            with Fat32Destination(tree, plan.destination, store, tx, recheck=recheck) as port:
+                with t.start(store, tx, port, sources, fault=fault) as session:
+                    return session.run()
+
+        tx, plan, sources = create("complete")
+        assert run(tx, plan, sources).state == "complete"
+        assert (exports / "complete/org/model/model.safetensors").read_bytes() == DATA
+        report = json.loads((exports / "complete/.modelark-slice-receipt.json").read_text())
+        assert report["host_transaction_completion"] == "not-claimed"
+        checks.append("real-vfat-port-completion-original-hashes-and-report")
+
+        for index, point in enumerate(FAULTS):
+            tx, plan, sources = create("fault-" + str(index))
+            reached = False
+
+            def crash(current):
+                nonlocal reached
+                if current == point:
+                    reached = True
+                    raise RuntimeError("synthetic interruption")
+
+            try:
+                run(tx, plan, sources, crash)
+            except RuntimeError as exc:
+                assert str(exc) == "synthetic interruption"
+            else:
+                raise AssertionError("fault boundary was not reached: " + point)
+            assert reached and store.attempt_consumed(tx)
+            assert store.status(tx).state != "complete"
+            try:
+                run(tx, plan, sources)
+            except t.TransferRefusal as exc:
+                assert exc.code == "FAT32_NEW_ROOT_REQUIRED"
+            else:
+                raise AssertionError("consumed FAT intent resumed")
+            checks.append("interruption:" + point)
+        assert (exports / "sibling.txt").read_bytes() == b"untouched synthetic sibling"
+        checks.append("sibling-preserved")
+    return checks
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+    if os.geteuid() == 0:
+        raise SystemExit("Run as your ordinary user; the script requests sudo only for mount/unmount.")
+    base = Path(tempfile.mkdtemp(prefix="modelark-fat32-qualification-"))
+    image, mount = base / "disposable.img", base / "mount"
+    mount.mkdir(mode=0o700)
+    print("Disposable qualification directory:", base, flush=True)
+    # -C creates a new regular image in a fresh private directory. No device/path
+    # argument is accepted from the operator; no existing filesystem is formatted.
+    subprocess.run(["/usr/sbin/mkfs.fat", "-F", "32", "-C", str(image), "65536"], check=True)
+    options = (f"loop,uid={os.geteuid()},gid={os.getegid()},umask=0077,"
+               "shortname=mixed,codepage=437,iocharset=iso8859-1,utf8=1")
+    mounted = False
+    try:
+        subprocess.run(["sudo", "--", "mount", "-t", "vfat", "-o", options, str(image), str(mount)], check=True)
+        mounted = True
+        checks = exercise(base, mount)
+    finally:
+        # Never lazy/force unmount; a failed detach stays visible for the operator.
+        if mounted or os.path.ismount(mount):
+            subprocess.run(["sudo", "--", "umount", "--", str(mount)], check=True)
+    result = {"status": "passed", "checks": checks, "retained_directory": str(base),
+              "physical_USB_or_archive_test": False}
+    print(json.dumps(result, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -11,6 +11,8 @@ import tempfile
 from pathlib import Path
 from unittest import SkipTest, mock
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 from scripts import deploy
@@ -40,6 +42,53 @@ def test_health_check_does_not_launch_a_second_application(tmp_path, monkeypatch
     assert any(call[:4] == ["systemctl", "--user", "is-active", "--quiet"] for call in calls)
     assert calls[0][0] == str(venv / "bin/python")
     assert "importlib.metadata" in calls[0][3]
+    assert calls[0] == deploy._installed_metadata_argv(venv)
+
+
+def test_update_validates_metadata_and_restarts_without_launching_another_instance(tmp_path, monkeypatch):
+    import uuid
+    from modelark import instance
+
+    source, venv = tmp_path / "source", tmp_path / "venv"
+    source.mkdir()
+    (source / "pyproject.toml").touch()
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin/python").touch()
+    executable = venv / "bin/modelark"
+    executable.touch()
+    data, state = tmp_path / "data", tmp_path / "state"
+    monkeypatch.setattr(instance, "_ADDRESS", "\0modelark-deploy-test-" + uuid.uuid4().hex)
+    monkeypatch.setattr(deploy.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(deploy.shutil, "which", lambda command: "/mock/systemctl")
+    monkeypatch.setattr(deploy, "_xdg_path", lambda name, fallback: tmp_path / name.lower())
+    directories, units, calls = [], [], []
+    monkeypatch.setattr(deploy, "_mkdir_private", lambda path, dry_run: directories.append(path))
+    monkeypatch.setattr(deploy, "_write_unit", lambda *args: units.append(args))
+
+    def run(argv, **kwargs):
+        assert kwargs["check"] is True
+        calls.append(argv)
+        if argv[0] == str(executable):
+            # Model the actual executable's first action. Help is deliberately NOT
+            # exempt from singleton exclusion, so the old postinstall probe fails.
+            with instance.launch():
+                pytest.fail("deployment launched another ModelArk application")
+
+    monkeypatch.setattr(deploy.subprocess, "run", run)
+    with instance.launch():
+        with pytest.raises(SystemExit, match="already running"):
+            with instance.launch():
+                pytest.fail("fixture must retain the application's launch guard")
+        deploy.main(["--source", str(source), "--venv", str(venv),
+                     "--data-dir", str(data), "--state-dir", str(state), "--start"])
+    assert calls[0] == [str(venv / "bin/python"), "-m", "pip", "install", str(source)]
+    assert calls[1][0:3] == [str(venv / "bin/python"), "-I", "-c"]
+    assert "importlib.metadata" in calls[1][3]
+    assert calls[1] == deploy._installed_metadata_argv(venv)
+    assert all(str(executable) != call[0] for call in calls)
+    assert calls[-1] == ["systemctl", "--user", "restart", deploy.UNIT_NAME]
+    assert directories == [data, state] and len(units) == 1
+    assert not data.exists() and not state.exists()
 
 def test_unit_is_unprivileged_explicit_and_resume_is_opt_in(tmp_path):
     source = tmp_path / "source with space"

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -15,6 +15,32 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 from scripts import deploy
 
+
+def test_health_check_does_not_launch_a_second_application(tmp_path, monkeypatch):
+    source, venv = tmp_path / "source", tmp_path / "venv"
+    executable = venv / "bin/modelark"
+    executable.parent.mkdir(parents=True)
+    executable.touch()
+    unit = tmp_path / "modelark.service"
+    data, state = tmp_path / "data", tmp_path / "state"
+    unit.write_text(deploy.render_unit(source, executable, data, state, None, 8077, False))
+    calls = []
+    monkeypatch.setattr(subprocess, "run", lambda args, **kwargs: calls.append(args))
+    class Response:
+        status = 200
+        def read(self):
+            return b'{"os":"linux"}'
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            pass
+    monkeypatch.setattr(deploy.urllib.request, "urlopen", lambda *a, **k: Response())
+    deploy._check(source, venv, unit, data, state, None, 8077)
+    assert all(str(executable) != call[0] for call in calls)
+    assert any(call[:4] == ["systemctl", "--user", "is-active", "--quiet"] for call in calls)
+    assert calls[0][0] == str(venv / "bin/python")
+    assert "importlib.metadata" in calls[0][3]
+
 def test_unit_is_unprivileged_explicit_and_resume_is_opt_in(tmp_path):
     source = tmp_path / "source with space"
     executable = source / ".venv/bin/modelark"

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,0 +1,176 @@
+"""Launch-level singleton checks use unique disposable socket namespaces only."""
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def instance(monkeypatch):
+    from modelark import instance
+    monkeypatch.setattr(instance, "_ADDRESS", "\0modelark-test-instance-" + uuid.uuid4().hex)
+    return instance
+
+
+def test_rejects_even_second_launch_in_same_process(instance):
+    with instance.launch():
+        with pytest.raises(SystemExit, match="ModelArk is already running"):
+            with instance.launch():
+                pytest.fail("second instance accepted")
+    with instance.launch():
+        pass
+
+
+def test_error_releases_instance(instance):
+    with pytest.raises(RuntimeError, match="boom"):
+        with instance.launch():
+            raise RuntimeError("boom")
+    with instance.launch():
+        pass
+
+
+def test_cli_parser_and_command_errors_release(instance, monkeypatch):
+    from modelark import cli
+    with pytest.raises(SystemExit):
+        cli.main(["not-a-command"])
+
+    def fail(args):
+        raise RuntimeError("command failed")
+
+    monkeypatch.setattr(cli, "cmd_query", fail)
+    with pytest.raises(RuntimeError, match="command failed"):
+        cli.main(["query", "SELECT 1"])
+    with instance.launch():
+        pass
+
+
+def test_direct_portal_error_releases(instance, monkeypatch):
+    from modelark.web import server
+
+    def fail(**kwargs):
+        raise RuntimeError("portal failed")
+
+    monkeypatch.setattr(server, "_serve", fail)
+    with pytest.raises(RuntimeError, match="portal failed"):
+        server.serve(open_browser=False)
+    with instance.launch():
+        pass
+
+
+@pytest.mark.parametrize("argv", [["--help"], ["--version"], ["query", "SELECT 1"],
+                                  ["--data-dir", "/tmp/other-modelark", "--state-dir", "/tmp/other-state",
+                                   "--config", "/tmp/other-config", "serve", "--port", "12345"]])
+def test_busy_cli_precedes_parser_config_and_command(instance, monkeypatch, argv):
+    from modelark import cli
+    for target in ("argparse.ArgumentParser", "db.configure", "wishlist.configure", "db.connect"):
+        obj = cli
+        parts = target.split(".")
+        for part in parts[:-1]:
+            obj = getattr(obj, part)
+        monkeypatch.setattr(obj, parts[-1], lambda *a, **k: pytest.fail("launch side effect"))
+    with instance.launch():
+        with pytest.raises(SystemExit, match="ModelArk is already running"):
+            cli.main(argv)
+
+
+def test_busy_direct_portal_precedes_logging_and_bootstrap(instance, monkeypatch):
+    from modelark.web import server
+    monkeypatch.setattr(server.telemetry, "configure", lambda **k: pytest.fail("logging"))
+    monkeypatch.setattr(server.data, "conn", lambda: pytest.fail("database"))
+    monkeypatch.setattr(server.plan, "bootstrap", lambda *a: pytest.fail("bootstrap"))
+    with instance.launch():
+        with pytest.raises(SystemExit, match="ModelArk is already running"):
+            server.serve(open_browser=False)
+
+
+def test_cli_to_portal_uses_one_explicit_launch_permit(instance, monkeypatch):
+    from modelark import cli
+    from modelark.web import server
+    called = []
+
+    def serving(**kwargs):
+        with pytest.raises(SystemExit, match="ModelArk is already running"):
+            with instance.launch():
+                pytest.fail("portal launch not retained")
+        called.append(kwargs)
+
+    monkeypatch.setattr(server, "_serve", serving)
+    cli.main(["serve", "--no-open", "--port", "12345"])
+    assert called == [{"port": 12345, "open_browser": False, "resume": False, "host": "127.0.0.1"}]
+    with instance.launch():
+        pass
+
+
+def test_portal_permit_is_single_use_and_not_valid_after_release(instance, monkeypatch):
+    from modelark.web import server
+    monkeypatch.setattr(server, "_serve", lambda **k: None)
+    with instance.launch() as permit:
+        server._serve_in_instance(permit)
+        with pytest.raises(SystemExit, match="launch permit"):
+            server._serve_in_instance(permit)
+    with pytest.raises(SystemExit, match="launch permit"):
+        server._serve_in_instance(permit)
+
+
+def test_fork_child_retains_kernel_ownership_until_it_exits(instance):
+    ready_read, ready_write = os.pipe()
+    stop_read, stop_write = os.pipe()
+    child = None
+    try:
+        with instance.launch():
+            child = os.fork()
+            if child == 0:
+                os.close(ready_read)
+                os.close(stop_write)
+                os.write(ready_write, b"ready")
+                os.read(stop_read, 1)
+                os._exit(0)
+            os.close(ready_write)
+            ready_write = -1
+            os.close(stop_read)
+            stop_read = -1
+            assert os.read(ready_read, 5) == b"ready"
+        with pytest.raises(SystemExit, match="ModelArk is already running"):
+            with instance.launch():
+                pytest.fail("retained child descriptor ignored")
+        os.write(stop_write, b"x")
+        assert os.waitpid(child, 0)[1] == 0
+        child = None
+        with instance.launch():
+            pass
+    finally:
+        if child:
+            os.kill(child, signal.SIGKILL)
+            os.waitpid(child, 0)
+        for fd in (ready_read, ready_write, stop_read, stop_write):
+            if fd >= 0:
+                os.close(fd)
+
+
+def test_cold_process_rejection_and_sigkill_release(instance):
+    code = (
+        "import sys;from modelark import instance;"
+        "instance._ADDRESS='\\0'+sys.argv[1];"
+        "guard=instance.launch();guard.__enter__();"
+        "print('ready',flush=True);sys.stdin.read()"
+    )
+    child = subprocess.Popen([sys.executable, "-c", code, instance._ADDRESS[1:]],
+                             cwd=Path(__file__).parents[1], stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        assert child.stdout.readline() == "ready\n"
+        with pytest.raises(SystemExit, match="ModelArk is already running"):
+            with instance.launch():
+                pytest.fail("cold process ignored")
+        child.kill()
+        child.wait()
+        with instance.launch():
+            pass
+    finally:
+        if child.poll() is None:
+            child.kill()
+        child.communicate()

--- a/tests/test_instance_maintenance.py
+++ b/tests/test_instance_maintenance.py
@@ -1,0 +1,26 @@
+"""Offline maintenance entrypoints share launch exclusion; never open a real catalog."""
+import importlib
+import uuid
+
+import pytest
+
+
+@pytest.mark.parametrize("name", ["scripts.migrate_provenance", "scripts.migrate_legacy_runtime"])
+def test_migration_refuses_before_parsing_or_accessing_catalog(name, monkeypatch):
+    from modelark import instance
+    module = importlib.import_module(name)
+    monkeypatch.setattr(instance, "_ADDRESS", "\0modelark-test-maintenance-" + uuid.uuid4().hex)
+    monkeypatch.setattr(module, "_main", lambda *a: pytest.fail("migration startup side effect"))
+    with instance.launch(), pytest.raises(SystemExit, match="ModelArk is already running"):
+        module.main([])
+
+
+@pytest.mark.parametrize("name", ["scripts.migrate_provenance", "scripts.migrate_legacy_runtime"])
+def test_migration_releases_launch_guard_after_completion(name, monkeypatch):
+    from modelark import instance
+    module = importlib.import_module(name)
+    monkeypatch.setattr(instance, "_ADDRESS", "\0modelark-test-maintenance-" + uuid.uuid4().hex)
+    monkeypatch.setattr(module, "_main", lambda *a: 7)
+    assert module.main([]) == 7
+    with instance.launch():
+        pass

--- a/tests/test_slice_capacity.py
+++ b/tests/test_slice_capacity.py
@@ -152,6 +152,13 @@ def test_path_byte_limits_are_not_character_limits():
         c.layout(['delivery/' + '\u00e9' * 128])
 
 
+@pytest.mark.parametrize('path', ['delivery-\udcff/file', 'delivery/\udcff', 'delivery/\ud800'])
+def test_non_utf8_full_paths_refuse_before_encoding(path):
+    from modelark.slice import capacity as c
+    with pytest.raises(TransferRefusal, match='DESTINATION_LAYOUT_UNSUPPORTED'):
+        c.layout([path])
+
+
 def _parent_path_bytes(length):
     """Produce an exact-length ASCII parent with individually valid ext4 components."""
     parts = []

--- a/tests/test_slice_capacity.py
+++ b/tests/test_slice_capacity.py
@@ -1,5 +1,8 @@
 """Conservative admission math and synthetic superblocks; no actual block device access."""
 import struct
+import errno
+import os
+from pathlib import PurePosixPath
 from types import SimpleNamespace
 import uuid
 
@@ -147,6 +150,96 @@ def test_path_byte_limits_are_not_character_limits():
     from modelark.slice import capacity as c
     with pytest.raises(TransferRefusal, match='DESTINATION_LAYOUT_UNSUPPORTED'):
         c.layout(['delivery/' + '\u00e9' * 128])
+
+
+def _parent_path_bytes(length):
+    """Produce an exact-length ASCII parent with individually valid ext4 components."""
+    parts = []
+    while length > 255:
+        parts.append('a' * 255)
+        length -= 256
+    parts.append('b' * length)
+    return '/'.join(parts)
+
+
+@pytest.mark.parametrize('name', ['x', '.modelark-slice-receipt.json'])
+@pytest.mark.parametrize('unicode_parent', [False, True])
+def test_short_final_basename_does_not_hide_overlong_generated_temporary_path(name, unicode_parent):
+    from modelark.slice import capacity as c
+    parent = _parent_path_bytes(4056)
+    if unicode_parent:
+        parent = '\u00e9' * 127 + 'a' + parent[255:]
+    final = parent + '/' + name
+    temporary = str(PurePosixPath(final).parent / ('.slice-' + 'a' * 32))
+    assert len(final.encode('utf-8')) < 4096
+    assert len(temporary.encode('utf-8')) == 4096
+    with pytest.raises(TransferRefusal, match='DESTINATION_LAYOUT_UNSUPPORTED'):
+        c.layout([final])
+
+
+def test_generated_temporary_path_accepts_last_valid_byte_length():
+    from modelark.slice import capacity as c
+    parent = _parent_path_bytes(4055)
+    final = parent + '/x'
+    temporary = str(PurePosixPath(final).parent / ('.slice-' + 'a' * 32))
+    assert len(temporary.encode('utf-8')) == 4095
+    directories, _ = c.layout([final])
+    assert parent in directories
+
+
+def test_capture_checks_control_and_receipt_temporary_names_too(admitted, monkeypatch):
+    c, tree, evidence, proposal, _ = admitted
+    checked = []
+    layout = c.layout
+    def observe(paths):
+        checked.extend(paths)
+        return layout(paths)
+    monkeypatch.setattr(c, 'layout', observe)
+    c.capture(tree, evidence, proposal, '/private')
+    assert '.modelark-slice-owner' in checked
+    assert str(PurePosixPath(proposal.spec.destination_root) / '.modelark-slice-receipt.json') in checked
+    assert all(len(str(PurePosixPath(path).parent / ('.slice-' + 'a' * 32)).encode('utf-8')) < 4096
+               for path in checked)
+
+
+def test_inherited_default_acl_on_legacy_owned_directory_refuses_even_after_root_acl_removed(
+        admitted, tmp_path, monkeypatch):
+    from modelark.slice.destination import OWNER_XATTR, UsbDestination, owner_marker
+    from modelark.slice.transaction import DestinationBinding
+    c, tree, evidence, proposal, caps = admitted
+    private = tmp_path / 'private-state'
+    private.mkdir(mode=0o700)
+    binding = DestinationBinding(evidence.device_id, evidence.fs_uuid, evidence.profile, evidence.available_bytes)
+    store = SimpleNamespace(root=private, load=lambda tx: SimpleNamespace(destination=binding, seal='a' * 64))
+    adapter = UsbDestination(tree, binding, store, 'b' * 32)
+    # Linux POSIX ACL xattr v2: owner, owning group and other default entries.
+    acl = struct.pack('<I', 2) + b''.join(struct.pack('<HHI', tag, permissions, 0xffffffff)
+                                         for tag, permissions in [(1, 7), (4, 5), (32, 5)])
+    os.setxattr(tree.fd, 'system.posix_acl_default', acl)
+    # Reproduce a trusted pre-fix directory/certificate; do not run today's create
+    # preconditions because they now reject the root default ACL before creation.
+    os.mkdir('models', dir_fd=tree.fd)
+    child = tree.open('models', os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        token = '1' * 32
+        os.setxattr(child, OWNER_XATTR, owner_marker(token))
+        os.fsync(child)
+        adapter._certify(child, 'models', token, 'directory')
+        inherited = os.getxattr(child, 'system.posix_acl_default')
+        assert inherited == acl
+        os.removexattr(tree.fd, 'system.posix_acl_default')
+        with pytest.raises(OSError) as missing:
+            os.getxattr(tree.fd, 'system.posix_acl_default')
+        assert missing.value.errno == errno.ENODATA
+        monkeypatch.setattr(c, '_free', lambda current: (evidence.available_bytes, caps['free_inodes'] - 1))
+        before = adapter._database.read_bytes()
+        with pytest.raises(TransferRefusal, match='DESTINATION_CAPACITY_UNPROVEN'):
+            c.verify(tree, evidence, proposal, caps, adapter)
+        assert os.getxattr(child, 'system.posix_acl_default') == inherited
+        assert adapter._database.read_bytes() == before
+        assert os.listdir(child) == []
+    finally:
+        os.close(child)
 
 
 def test_block_descriptor_is_verified_before_any_read(admitted, monkeypatch):

--- a/tests/test_slice_capacity.py
+++ b/tests/test_slice_capacity.py
@@ -1,0 +1,191 @@
+"""Conservative admission math and synthetic superblocks; no actual block device access."""
+import struct
+from types import SimpleNamespace
+import uuid
+
+import pytest
+
+from modelark.slice import domain as d
+from modelark.slice.capacity import _volume as PRODUCTION_VOLUME
+from modelark.slice.linux import BoundTree
+from modelark.slice.transaction import TransferRefusal
+from test_slice_domain import facts, spec
+
+
+def superblock():
+    data = bytearray(1024)
+    for offset, value in [(0x18, 2), (0x1c, 2), (0x4c, 1), (0x5c, 0x3c),
+                          (0x60, 0x2c6), (0x64, 0x46b), (0xe0, 8)]:
+        struct.pack_into('<I', data, offset, value)
+    struct.pack_into('<H', data, 0x38, 0xef53)
+    struct.pack_into('<H', data, 0x58, 256)
+    data[0x68:0x78] = uuid.UUID('12345678-1234-1234-1234-123456789abc').bytes
+    return data
+
+
+def test_superblock_accepts_only_documented_profile():
+    from modelark.slice import capacity as c
+    result = c.parse_superblock(superblock(), '12345678-1234-1234-1234-123456789abc')
+    assert result['block_size'] == 4096
+    assert result['incompat'] & 4 == 0
+
+
+@pytest.mark.parametrize('offset,bit', [(0x5c, 0x1000), (0x60, 0x8000), (0x60, 0x4000),
+                                      (0x64, 0x100), (0x64, 0x200), (0x64, 0x10)])
+def test_unknown_quota_bigalloc_inline_eainode_and_conflicting_checksums_refuse(offset, bit):
+    from modelark.slice import capacity as c
+    data = superblock()
+    struct.pack_into('<I', data, offset, struct.unpack_from('<I', data, offset)[0] | bit)
+    with pytest.raises(TransferRefusal, match='DESTINATION_CAPACITY_UNPROVEN'):
+        c.parse_superblock(data, '12345678-1234-1234-1234-123456789abc')
+
+
+@pytest.fixture
+def admitted(tmp_path, monkeypatch):
+    from modelark.slice import capacity as c
+    root = tmp_path / 'destination'
+    root.mkdir()
+    tree = BoundTree(root)
+    evidence = SimpleNamespace(profile='hardware-v1', fs_uuid='fs-a', device_id='usb-destination',
+                               available_bytes=1 << 30, block_size=4096, name_max=255,
+                               mount_id=tree.mount_id, mount_path=str(tree.path))
+    proposal = d.preview(spec(d), facts(d))
+    monkeypatch.setattr(c, '_volume', lambda *a: {'block_size': 4096, 'uuid': 'fs-a'})
+    monkeypatch.setattr(c, '_root_metadata', lambda *a: (4096, 0))
+    monkeypatch.setattr(c, '_free', lambda *a: (evidence.available_bytes, 100000))
+    try:
+        caps = c.capture(tree, evidence, proposal, tmp_path / 'private')
+        yield c, tree, evidence, proposal, caps
+    finally:
+        tree.close()
+
+
+def test_capture_seals_capacity_and_inode_budget(admitted):
+    c, tree, evidence, proposal, caps = admitted
+    assert caps['reserve_bytes'] > proposal.total_bytes
+    assert caps['required_inodes'] == len(caps['directory_paths']) + len(caps['file_paths'])
+    c.verify(tree, evidence, proposal, caps)
+
+
+@pytest.mark.parametrize('field,value', [('mount_id', -999), ('mount_path', '/different/mount')])
+def test_observation_must_describe_the_retained_attachment(admitted, field, value):
+    c, tree, evidence, proposal, caps = admitted
+    setattr(evidence, field, value)
+    with pytest.raises(TransferRefusal, match='DESTINATION_CHANGED'):
+        c.capture(tree, evidence, proposal, '/private')
+    with pytest.raises(TransferRefusal, match='DESTINATION_CHANGED'):
+        c.verify(tree, evidence, proposal, caps)
+
+
+def test_durable_root_identity_does_not_seal_transient_device_number(admitted, monkeypatch):
+    c, tree, evidence, proposal, caps = admitted
+    assert len(caps['root_identity']) == 2
+    identity = tree.identity
+    monkeypatch.setattr(tree, 'check', lambda: None)
+    monkeypatch.setattr(tree, 'identity', lambda fd: (999999, *identity(fd)[1:]))
+    c.verify(tree, evidence, proposal, caps)
+
+
+def test_changed_hardware_or_unowned_root_name_refuses(admitted):
+    c, tree, evidence, proposal, caps = admitted
+    evidence.profile = 'replacement'
+    with pytest.raises(TransferRefusal, match='DESTINATION_CHANGED'):
+        c.verify(tree, evidence, proposal, caps)
+    evidence.profile = 'hardware-v1'
+    (tree.path / 'unknown').touch()
+    with pytest.raises(TransferRefusal, match='OUTPUT_COLLISION'):
+        c.verify(tree, evidence, proposal, caps)
+
+
+def test_unknown_root_control_is_not_adopted(admitted):
+    c, tree, evidence, proposal, _ = admitted
+    (tree.path / '.modelark-slice-owner').touch()
+    with pytest.raises(TransferRefusal, match='OUTPUT_COLLISION'):
+        c.capture(tree, evidence, proposal, '/private')
+
+
+def test_inode_exhaustion_refuses_before_approval(admitted, monkeypatch):
+    c, tree, evidence, proposal, _ = admitted
+    monkeypatch.setattr(c, '_free', lambda *a: (1 << 30, 0))
+    with pytest.raises(TransferRefusal, match='DESTINATION_INODES_INSUFFICIENT'):
+        c.capture(tree, evidence, proposal, '/private')
+
+
+def test_unknown_or_indexed_initial_root_refuses(admitted, monkeypatch):
+    c, tree, evidence, proposal, _ = admitted
+    monkeypatch.setattr(c, '_root_metadata', lambda *a: (4096, 0x1000))
+    with pytest.raises(TransferRefusal, match='DESTINATION_CAPACITY_UNPROVEN'):
+        c.capture(tree, evidence, proposal, '/private')
+
+
+def test_large_directory_fanout_is_non_executable():
+    from modelark.slice import capacity as c
+    files = ['delivery/' + 'a' * 230 + str(i) for i in range(30)]
+    with pytest.raises(TransferRefusal, match='DESTINATION_LAYOUT_UNSUPPORTED'):
+        c.layout(files)
+
+
+@pytest.mark.parametrize('change', ['short', 'uuid', 'magic', 'block', 'cluster', 'external-journal', 'no-journal'])
+def test_superblock_identity_and_required_layout_rejections(change):
+    from modelark.slice import capacity as c
+    data = superblock()
+    if change == 'short':
+        data = data[:-1]
+    elif change == 'uuid':
+        data[0x68] ^= 1
+    elif change == 'magic':
+        data[0x38] = 0
+    elif change in {'block', 'cluster', 'external-journal', 'no-journal'}:
+        offset, value = {'block': (0x18, 1), 'cluster': (0x1c, 3),
+                         'external-journal': (0xe4, 1), 'no-journal': (0xe0, 0)}[change]
+        struct.pack_into('<I', data, offset, value)
+    with pytest.raises(TransferRefusal, match='DESTINATION_CAPACITY_UNPROVEN'):
+        c.parse_superblock(data, '12345678-1234-1234-1234-123456789abc')
+
+
+def test_path_byte_limits_are_not_character_limits():
+    from modelark.slice import capacity as c
+    with pytest.raises(TransferRefusal, match='DESTINATION_LAYOUT_UNSUPPORTED'):
+        c.layout(['delivery/' + '\u00e9' * 128])
+
+
+def test_block_descriptor_is_verified_before_any_read(admitted, monkeypatch):
+    import os
+    _, tree, evidence, _, _ = admitted
+    monkeypatch.setattr(os, 'pread', lambda *a: pytest.fail('must not read a regular file as a device'))
+    # Production probe uses a separate descriptor, represented by this ordinary disposable file.
+    path = tree.path / 'not-device'
+    path.touch()
+    fd = os.open(path, os.O_RDONLY)
+    monkeypatch.setattr(os, 'open', lambda *a, **k: os.dup(fd))
+    try:
+        with pytest.raises(TransferRefusal, match='superblock descriptor differs'):
+            PRODUCTION_VOLUME(tree, evidence)
+    finally:
+        os.close(fd)
+
+
+@pytest.mark.parametrize('bit', [2, 8])
+def test_large_file_features_must_already_be_enabled(bit):
+    from modelark.slice import capacity as c
+    data = superblock()
+    struct.pack_into('<I', data, 0x64, struct.unpack_from('<I', data, 0x64)[0] & ~bit)
+    with pytest.raises(TransferRefusal, match='DESTINATION_CAPACITY_UNPROVEN'):
+        c.parse_superblock(data, '12345678-1234-1234-1234-123456789abc')
+
+
+def test_legacy_inline_marker_cannot_supply_external_allocation_proof(tmp_path):
+    import os
+    from modelark.slice import capacity as c
+    from modelark.slice.destination import OWNER_XATTR, owner_marker
+    path = tmp_path / 'file'
+    path.touch()
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.setxattr(fd, OWNER_XATTR, b'a' * 32)
+        with pytest.raises(TransferRefusal, match='DESTINATION_ALLOCATION_UNPROVEN'):
+            c._require_unique_marker(fd, 'a' * 32)
+        os.setxattr(fd, OWNER_XATTR, owner_marker('a' * 32))
+        c._require_unique_marker(fd, 'a' * 32)
+    finally:
+        os.close(fd)

--- a/tests/test_slice_cli.py
+++ b/tests/test_slice_cli.py
@@ -27,6 +27,9 @@ def operator(monkeypatch):
 
 
 @pytest.mark.parametrize("argv,name,expected", [
+    (["preview", "--catalog", "/explicit/catalog.sqlite", "--destination", "/exports/delivery",
+      "--repo", "org/a"], "preview",
+     ("/explicit/catalog.sqlite", "/exports/delivery", ("org/a",), None)),
     (["preview", "--catalog", "/explicit/catalog.sqlite", "--destination", "/usb",
       "--repo", "org/a", "--repo", "org/b", "--root", "delivery"], "preview",
      ("/explicit/catalog.sqlite", "/usb", ("org/a", "org/b"), "delivery")),

--- a/tests/test_slice_cli.py
+++ b/tests/test_slice_cli.py
@@ -121,3 +121,18 @@ def test_operator_refusal_result_is_nonzero(operator, capsys):
         cli.main(["slice", "start", "tx", "--destination", "/usb"])
     assert caught.value.code == 1
     assert json.loads(capsys.readouterr().out) == {"ok": False, "state": "waiting_source"}
+
+
+def test_surrogate_escaped_root_returns_json_layout_refusal(operator, capsys):
+    import os
+    from modelark import cli
+    from modelark.slice.capacity import layout
+    fake, _ = operator
+    fake.preview = lambda catalog, destination, repos, root: layout([root + '/org/model/file'])
+    with pytest.raises(SystemExit) as caught:
+        cli.main(['slice', 'preview', '--catalog', '/unused', '--destination', '/usb',
+                  '--repo', 'org/model', '--root', os.fsdecode(b'delivery-\xff')])
+    assert caught.value.code == 1
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)['code'] == 'DESTINATION_LAYOUT_UNSUPPORTED'
+    assert captured.err == ''

--- a/tests/test_slice_cli.py
+++ b/tests/test_slice_cli.py
@@ -1,0 +1,123 @@
+"""Operator CLI dispatch only: mocked operator, disposable launch socket, no devices/state."""
+import json
+import sys
+from types import SimpleNamespace
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def operator(monkeypatch):
+    from modelark import instance
+    from modelark import cli
+    calls = []
+    fake = SimpleNamespace()
+    for name in ("preview", "approve", "start", "status", "stop"):
+        def call(*args, _name=name):
+            calls.append((_name, args))
+            return {"z": 1, "ok": True, "operation": _name}
+        setattr(fake, name, call)
+    monkeypatch.setitem(sys.modules, "modelark.slice.operator", fake)
+    monkeypatch.setattr(instance, "_ADDRESS", "\0modelark-slice-cli-test-" + uuid.uuid4().hex)
+    monkeypatch.setattr(cli.db, "configure", lambda *a: pytest.fail("default db configuration"))
+    monkeypatch.setattr(cli.db, "connect", lambda *a, **k: pytest.fail("default catalog access"))
+    monkeypatch.setattr(cli.wishlist, "configure", lambda *a: pytest.fail("global configuration"))
+    return fake, calls
+
+
+@pytest.mark.parametrize("argv,name,expected", [
+    (["preview", "--catalog", "/explicit/catalog.sqlite", "--destination", "/usb",
+      "--repo", "org/a", "--repo", "org/b", "--root", "delivery"], "preview",
+     ("/explicit/catalog.sqlite", "/usb", ("org/a", "org/b"), "delivery")),
+    (["approve", "tx", "--seal", "sealed"], "approve", ("tx", "sealed")),
+    (["start", "tx", "--destination", "/usb", "--source", "drive-a=/source/modelark",
+      "--source", "drive-b=/second/modelark"], "start",
+     ("tx", "/usb", {"drive-a": "/source/modelark", "drive-b": "/second/modelark"})),
+    (["status", "tx"], "status", ("tx",)),
+    (["stop", "tx"], "stop", ("tx",)),
+])
+def test_exact_operator_dispatch(operator, capsys, argv, name, expected):
+    from modelark import cli
+    _, calls = operator
+    cli.main(["slice", *argv])
+    assert calls == [(name, expected)]
+    assert capsys.readouterr().out == json.dumps(
+        {"z": 1, "ok": True, "operation": name}, sort_keys=True) + "\n"
+
+
+@pytest.mark.parametrize("source", ["missing-equals", "=path", "label=", " label=/path",
+                                    "label =/path", "../label=/path"])
+def test_malformed_attachment_never_dispatches(operator, source):
+    from modelark import cli
+    _, calls = operator
+    with pytest.raises(SystemExit) as caught:
+        cli.main(["slice", "start", "tx", "--destination", "/usb", "--source", source])
+    assert caught.value.code != 0
+    assert calls == []
+
+
+def test_duplicate_source_label_never_dispatches(operator):
+    from modelark import cli
+    _, calls = operator
+    with pytest.raises(SystemExit) as caught:
+        cli.main(["slice", "start", "tx", "--destination", "/usb",
+                  "--source", "a=/first", "--source", "a=/second"])
+    assert caught.value.code != 0
+    assert calls == []
+
+
+@pytest.mark.parametrize("option", ["--data-dir", "--state-dir", "--config"])
+def test_slice_rejects_global_runtime_overrides(operator, option):
+    from modelark import cli
+    _, calls = operator
+    with pytest.raises(SystemExit) as caught:
+        cli.main([option, "/unused", "slice", "status", "tx"])
+    assert caught.value.code != 0
+    assert calls == []
+
+
+@pytest.mark.parametrize("kind", ["transaction", "domain"])
+def test_typed_refusal_is_json_and_nonzero(operator, capsys, kind):
+    from modelark import cli
+    from modelark.slice.domain import SliceRefusal
+    from modelark.slice.transaction import TransferRefusal
+    fake, _ = operator
+
+    def refuse(tx):
+        refusal = TransferRefusal if kind == "transaction" else SliceRefusal
+        raise refusal("APPROVAL_MISSING", "explicit approval required")
+
+    fake.status = refuse
+    with pytest.raises(SystemExit) as caught:
+        cli.main(["slice", "status", "tx"])
+    assert caught.value.code == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": False, "code": "APPROVAL_MISSING", "detail": "explicit approval required"}
+
+
+def test_slice_help_does_not_import_operator(operator, monkeypatch, capsys):
+    from modelark import cli
+    monkeypatch.delitem(sys.modules, "modelark.slice.operator")
+    with pytest.raises(SystemExit) as caught:
+        cli.main(["slice", "--help"])
+    assert caught.value.code == 0
+    assert "modelark.slice.operator" not in sys.modules
+    assert "preview" in capsys.readouterr().out
+
+
+def test_no_sources_does_not_invent_attachment(operator):
+    from modelark import cli
+    _, calls = operator
+    cli.main(["slice", "start", "tx", "--destination", "/usb"])
+    assert calls == [("start", ("tx", "/usb", {}))]
+
+
+def test_operator_refusal_result_is_nonzero(operator, capsys):
+    from modelark import cli
+    fake, _ = operator
+    fake.start = lambda *args: {"ok": False, "state": "waiting_source"}
+    with pytest.raises(SystemExit) as caught:
+        cli.main(["slice", "start", "tx", "--destination", "/usb"])
+    assert caught.value.code == 1
+    assert json.loads(capsys.readouterr().out) == {"ok": False, "state": "waiting_source"}

--- a/tests/test_slice_decoding.py
+++ b/tests/test_slice_decoding.py
@@ -1,0 +1,112 @@
+"""Bounded original-byte decoding; no whole-file scratch or unsafe header allocation."""
+import io
+import struct
+
+import pytest
+
+from modelark.slice.transaction import TransferRefusal
+
+
+def decode(blob, *, expected, compressed=True, limit=64 << 20):
+    from modelark.slice.decoding import original_stream
+    stream = original_stream(io.BytesIO(blob), compressed=compressed,
+                             expected_bytes=expected, max_decode_bytes=limit)
+    pieces = []
+    while piece := stream.read(17):
+        pieces.append(piece)
+    return b"".join(pieces)
+
+
+def znn(data):
+    from modelark.streamznn import _zipnn
+    return bytes(_zipnn(dtype="bfloat16", threads=1).compress(bytearray(data)))
+
+
+@pytest.mark.parametrize("kind", ["raw", "whole", "stream", "zstd"])
+def test_actual_original_bytes(kind):
+    data = bytes(range(128)) * 16
+    if kind == "raw":
+        blob = data
+    elif kind == "whole":
+        blob = znn(data)
+    elif kind == "stream":
+        chunks = [znn(data[:1024]), znn(data[1024:])]
+        blob = b"SZNN\x01" + b"".join(struct.pack("<I", len(c)) + c for c in chunks)
+    else:
+        zstandard = pytest.importorskip("zstandard")
+        blob = zstandard.ZstdCompressor().compress(data)
+    assert decode(blob, expected=len(data), compressed=kind != "raw") == data
+
+
+@pytest.mark.parametrize("field,value", [(16, 1 << 45), (24, 1 << 45)])
+def test_huge_zipnn_header_refused_before_native_decoder(field, value, monkeypatch):
+    blob = bytearray(znn(bytes(128)))
+    blob[field:field + 8] = value.to_bytes(8, "little")
+    monkeypatch.setattr("zipnn.ZipNN.decompress", lambda *a, **k: pytest.fail("unsafe decode"))
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_LIMIT"):
+        decode(blob, expected=128)
+
+
+def test_huge_stream_frame_refused_without_reading_payload():
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_LIMIT"):
+        decode(b"SZNN\x01" + struct.pack("<I", 0xffffffff), expected=128)
+
+
+@pytest.mark.parametrize("kind", ["whole", "stream", "zstd"])
+def test_truncation_is_not_silent(kind):
+    if kind == "zstd":
+        zstandard = pytest.importorskip("zstandard")
+        blob = zstandard.ZstdCompressor().compress(bytes(1024))
+    else:
+        blob = znn(bytes(1024))
+        if kind == "stream":
+            blob = b"SZNN\x01" + struct.pack("<I", len(blob)) + blob
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE"):
+        decode(blob[:-1], expected=1024)
+
+
+def test_unknown_codec_and_nonbyte_zipnn_refused():
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_UNSUPPORTED"):
+        decode(b"not compressed", expected=14)
+    blob = bytearray(znn(bytes(128)))
+    blob[8] = 2
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_UNSUPPORTED"):
+        decode(blob, expected=128)
+
+
+def test_decoded_total_cannot_exceed_expected():
+    zstandard = pytest.importorskip("zstandard")
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_LIMIT"):
+        decode(zstandard.ZstdCompressor().compress(bytes(1024)), expected=12)
+
+
+def test_read_requires_explicit_bounded_request():
+    from modelark.slice.decoding import original_stream
+    stream = original_stream(io.BytesIO(b"abc"), compressed=False, expected_bytes=3)
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_LIMIT"):
+        stream.read()
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float16", "bfloat16"])
+def test_byte_dtype_is_read_from_validated_header(dtype):
+    from modelark.streamznn import _zipnn
+    data = bytes(range(128)) * 8
+    blob = bytes(_zipnn(dtype=dtype, threads=1).compress(bytearray(data)))
+    assert decode(blob, expected=len(data)) == data
+
+
+def test_zstd_unknown_content_size_and_trailing_data():
+    zstandard = pytest.importorskip("zstandard")
+    data = bytes(10000)
+    blob = zstandard.ZstdCompressor(write_content_size=False).compress(data)
+    assert decode(blob, expected=len(data)) == data
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_INVALID"):
+        decode(blob + b"trailing", expected=len(data))
+
+
+def test_zstd_window_bound_precedes_decoder_allocation(monkeypatch):
+    zstandard = pytest.importorskip("zstandard")
+    blob = zstandard.ZstdCompressor().compress(bytes(1 << 20))
+    monkeypatch.setattr(zstandard, "ZstdDecompressor", lambda **k: pytest.fail("oversize window"))
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_LIMIT"):
+        decode(blob, expected=1 << 20, limit=128 << 10)

--- a/tests/test_slice_destination.py
+++ b/tests/test_slice_destination.py
@@ -1,0 +1,196 @@
+"""Disposable Linux destination contracts; never use an actual archive or USB drive."""
+import importlib
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice.transaction import DestinationBinding, TransferRefusal
+
+
+@pytest.fixture
+def destination(tmp_path):
+    module = importlib.import_module("modelark.slice.destination")
+    linux = importlib.import_module("modelark.slice.linux")
+    root = tmp_path / "destination"
+    root.mkdir()
+    private = tmp_path / "private"
+    private.mkdir(mode=0o700)
+    binding = DestinationBinding("test-device", "test-filesystem", "test-mount", 10_000_000)
+    plan = SimpleNamespace(destination=binding, seal="a" * 64)
+    store = SimpleNamespace(root=private, load=lambda tx: plan)
+    with linux.BoundTree(root, writable=True) as tree:
+        adapter = module.UsbDestination(tree, binding, store, "b" * 32)
+        yield adapter, root, store, module
+
+
+def test_certified_directory_and_file_survive_adapter_reconstruction(destination):
+    adapter, root, store, module = destination
+    adapter.create_directory("delivery", "1" * 32)
+    adapter.create_file("delivery/.slice-" + "2" * 32, "2" * 32)
+    adapter.append("delivery/.slice-" + "2" * 32, "2" * 32, b"original bytes")
+    adapter.flush("delivery/.slice-" + "2" * 32)
+    reopened = module.UsbDestination(adapter.tree, adapter.binding, store, adapter.tx)
+    assert reopened.inspect("delivery").token == "1" * 32
+    reopened.publish("delivery/.slice-" + "2" * 32, "delivery/model", "2" * 32)
+    with reopened.read("delivery/model") as stream:
+        assert stream.read() == b"original bytes"
+    assert (root / "delivery/model").stat().st_nlink == 2
+    reopened.discard_temporary("delivery/.slice-" + "2" * 32, "2" * 32)
+    assert (root / "delivery/model").stat().st_nlink == 1
+
+
+def test_directory_crash_before_certificate_is_never_adopted(destination, monkeypatch):
+    adapter, root, _, _ = destination
+    def crash(*args):
+        raise RuntimeError("power cut before durable certificate")
+    monkeypatch.setattr(adapter, "_certify", crash)
+    with pytest.raises(RuntimeError):
+        adapter.create_directory("uncertain", "1" * 32)
+    assert (root / "uncertain").is_dir()
+    assert adapter.inspect("uncertain").token is None
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.create_directory("uncertain", "1" * 32)
+    assert (root / "uncertain").is_dir()
+
+
+def test_file_crash_before_certificate_never_leaves_a_named_object(destination, monkeypatch):
+    adapter, root, _, _ = destination
+    monkeypatch.setattr(adapter, "_certify", lambda *args: (_ for _ in ()).throw(RuntimeError("crash")))
+    with pytest.raises(RuntimeError):
+        adapter.create_file(".slice-" + "1" * 32, "1" * 32)
+    assert tuple(root.iterdir()) == ()
+
+
+def test_copied_xattr_and_name_cannot_authenticate_replacement_inode(destination):
+    adapter, root, _, module = destination
+    path, token = ".slice-" + "2" * 32, "2" * 32
+    adapter.create_file(path, token)
+    (root / path).rename(root / "stolen")
+    (root / path).write_bytes(b"foreign")
+    os.setxattr(root / path, module.OWNER_XATTR, token.encode())
+    assert adapter.inspect(path).token is None
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.append(path, token, b"must not append")
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.discard_temporary(path, token)
+    assert (root / path).read_bytes() == b"foreign"
+
+
+def test_publish_never_replaces_foreign_destination(destination):
+    adapter, root, _, _ = destination
+    path, token = ".slice-" + "2" * 32, "2" * 32
+    adapter.create_file(path, token)
+    (root / "final").write_bytes(b"foreign")
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.publish(path, "final", token)
+    assert (root / "final").read_bytes() == b"foreign"
+    assert adapter.inspect(path).token == token
+
+
+def test_symlink_escape_is_not_followed(destination, tmp_path):
+    adapter, root, _, _ = destination
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "escape").symlink_to(outside, target_is_directory=True)
+    with pytest.raises((TransferRefusal, OSError)):
+        adapter.create_file("escape/.slice-" + "2" * 32, "2" * 32)
+    assert not tuple(outside.iterdir())
+
+
+def test_allocation_counts_hardlinked_inode_once_and_rejects_drift(destination, monkeypatch):
+    adapter, root, _, _ = destination
+    path, token = ".slice-" + "2" * 32, "2" * 32
+    adapter.create_file(path, token)
+    adapter.append(path, token, b"a" * 8192)
+    adapter.publish(path, "model", token)
+    own = adapter.inspect(path).allocated_bytes
+    root_delta = os.fstat(adapter.tree.fd).st_blocks * 512 - adapter._root_blocks
+    monkeypatch.setattr(adapter, "_available", lambda: adapter.binding.available_bytes - own - root_delta)
+    adapter.check(adapter.binding, own, 1_000_000)
+    monkeypatch.setattr(adapter, "_available", lambda: adapter.binding.available_bytes - own - root_delta - 4096)
+    with pytest.raises(TransferRefusal, match="DESTINATION_CAPACITY_CHANGED"):
+        adapter.check(adapter.binding, own, 1_000_000)
+
+
+def test_unknown_objects_are_reported_without_traversing_symlinks(destination):
+    adapter, root, _, _ = destination
+    adapter.create_directory("delivery", "1" * 32)
+    (root / "delivery/foreign").write_bytes(b"unknown")
+    (root / "delivery/link").symlink_to("/etc")
+    assert adapter.list_paths("delivery") == ("delivery/foreign", "delivery/link")
+
+
+def test_mutating_final_path_is_forbidden(destination):
+    adapter, root, _, _ = destination
+    token = "2" * 32
+    path = ".slice-" + token
+    adapter.create_file(path, token)
+    adapter.publish(path, "model", token)
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.discard_temporary("model", token)
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.append("model", token, b"not allowed")
+    assert (root / "model").exists()
+
+
+def test_certified_but_unlinked_file_crash_can_retry_without_adoption(destination, monkeypatch):
+    adapter, root, _, module = destination
+    token = "2" * 32
+    path = ".slice-" + token
+    link = module.linux.link_fd
+    monkeypatch.setattr(module.linux, "link_fd", lambda *args: (_ for _ in ()).throw(RuntimeError("crash")))
+    with pytest.raises(RuntimeError):
+        adapter.create_file(path, token)
+    assert tuple(root.iterdir()) == ()
+    monkeypatch.setattr(module.linux, "link_fd", link)
+    adapter.create_file(path, token)
+    assert adapter.inspect(path).token == token
+
+
+def test_external_hardlinks_never_receive_allocation_credit(destination, tmp_path, monkeypatch):
+    adapter, root, _, _ = destination
+    token = "2" * 32
+    path = ".slice-" + token
+    adapter.create_file(path, token)
+    os.link(root / path, tmp_path / "foreign-link")
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.check(adapter.binding, adapter.inspect(path).allocated_bytes, 1_000_000)
+
+
+def test_other_transaction_cannot_use_an_existing_certificate(destination):
+    adapter, _, store, module = destination
+    token = "2" * 32
+    path = ".slice-" + token
+    adapter.create_file(path, token)
+    other = module.UsbDestination(adapter.tree, adapter.binding, store, "c" * 32)
+    assert other.inspect(path).token is None
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        other.discard_temporary(path, token)
+
+
+@pytest.mark.parametrize("path", [".", "..", "../escape", "/absolute", "a//b", "a/../b", ""])
+def test_noncanonical_paths_refuse_before_creation(destination, path):
+    adapter, root, _, _ = destination
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.create_directory(path, "1" * 32)
+    assert tuple(root.iterdir()) == ()
+
+
+def test_publication_links_retained_inode_not_replaced_source_name(destination, monkeypatch):
+    adapter, root, _, module = destination
+    token = "2" * 32
+    path = ".slice-" + token
+    adapter.create_file(path, token)
+    adapter.append(path, token, b"authentic")
+    link = module.linux.link_fd
+    def replace_source_then_link(fd, parent, name):
+        (root / path).rename(root / "displaced-original")
+        (root / path).write_bytes(b"foreign replacement")
+        return link(fd, parent, name)
+    monkeypatch.setattr(module.linux, "link_fd", replace_source_then_link)
+    adapter.publish(path, "model", token)
+    assert (root / "model").read_bytes() == b"authentic"
+    assert (root / path).read_bytes() == b"foreign replacement"
+    assert adapter.inspect("model").token == token
+    assert adapter.inspect(path).token is None

--- a/tests/test_slice_destination.py
+++ b/tests/test_slice_destination.py
@@ -124,6 +124,35 @@ def test_unknown_objects_are_reported_without_traversing_symlinks(destination):
     assert adapter.list_paths("delivery") == ("delivery/foreign", "delivery/link")
 
 
+def test_layout_walk_handles_deep_valid_paths_without_python_recursion(destination):
+    adapter, root, _, _ = destination
+    adapter.create_directory("delivery", "1" * 32)
+    created, leaves = [], []
+    current = "delivery"
+    try:
+        # 1100 short components are valid Linux paths, but exceed Python's normal
+        # recursion budget. These unknown directories must still reach the audit.
+        for _ in range(1100):
+            current += "/d"
+            os.mkdir(root / current)
+            created.append(current)
+        assert len(os.fsencode(root / current)) < 4096
+        foreign = current + "/foreign"
+        (root / foreign).write_bytes(b"unknown content")
+        leaves.append(foreign)
+        link = current + "/link"
+        (root / link).symlink_to("/etc")
+        leaves.append(link)
+        assert adapter.list_paths("delivery") == tuple(sorted([*created, *leaves]))
+    finally:
+        # Avoid delegating cleanup of this deliberately deep fixture to a recursive
+        # shutil/pytest walk. Remove only this test's exact created paths.
+        for path in leaves:
+            os.unlink(root / path)
+        for path in reversed(created):
+            os.rmdir(root / path)
+
+
 def test_mutating_final_path_is_forbidden(destination):
     adapter, root, _, _ = destination
     token = "2" * 32

--- a/tests/test_slice_destination.py
+++ b/tests/test_slice_destination.py
@@ -1,6 +1,9 @@
 """Disposable Linux destination contracts; never use an actual archive or USB drive."""
 import importlib
+import errno
+import json
 import os
+import sqlite3
 from types import SimpleNamespace
 
 import pytest
@@ -194,3 +197,194 @@ def test_publication_links_retained_inode_not_replaced_source_name(destination, 
     assert (root / path).read_bytes() == b"foreign replacement"
     assert adapter.inspect("model").token == token
     assert adapter.inspect(path).token is None
+
+
+@pytest.mark.parametrize("operation,number", [("append", errno.ENOSPC), ("append", errno.EIO),
+                                            ("flush", errno.ENOSPC), ("flush", errno.EIO)])
+def test_write_and_flush_errors_are_typed(destination, monkeypatch, operation, number):
+    adapter, _, _, module = destination
+    token, path = "2" * 32, ".slice-" + "2" * 32
+    adapter.create_file(path, token)
+    def fail(*args):
+        raise OSError(number, "synthetic destination error")
+    monkeypatch.setattr(module.os, "write" if operation == "append" else "fsync", fail)
+    with pytest.raises(TransferRefusal, match="DESTINATION_IO_FAILED"):
+        if operation == "append":
+            adapter.append(path, token, b"bytes")
+        else:
+            adapter.flush(path)
+
+
+def test_failed_write_rechecks_attachment_before_classifying_error(destination, monkeypatch):
+    adapter, _, _, module = destination
+    token, path = "2" * 32, ".slice-" + "2" * 32
+    adapter.create_file(path, token)
+    mounts = {adapter.tree.mount_id}
+    adapter.tree._mount_ids = lambda: mounts
+    def disappeared(*args):
+        mounts.clear()
+        raise OSError(errno.EIO, "synthetic removed device")
+    monkeypatch.setattr(module.os, "write", disappeared)
+    with pytest.raises(TransferRefusal, match="WAITING_DESTINATION"):
+        adapter.append(path, token, b"bytes")
+
+
+def test_destination_read_failure_is_typed_but_consumer_errors_are_not(destination, monkeypatch):
+    adapter, _, _, module = destination
+    token, path = "2" * 32, ".slice-" + "2" * 32
+    adapter.create_file(path, token)
+    with pytest.raises(OSError) as caught:
+        with adapter.read(path):
+            raise OSError(errno.ENOSPC, "consumer failure")
+    assert caught.value.errno == errno.ENOSPC
+    assert str(caught.value).endswith("consumer failure")
+
+    fdopen = module.os.fdopen
+    class BrokenReader:
+        def __init__(self, stream):
+            self.stream = stream
+
+        def read(self, size=-1):
+            raise OSError(errno.EIO, "actual stream read failed")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.stream.close()
+    monkeypatch.setattr(module.os, "fdopen", lambda *args, **kwargs: BrokenReader(fdopen(*args, **kwargs)))
+    with adapter.read(path) as stream, pytest.raises(TransferRefusal, match="DESTINATION_IO_FAILED"):
+        stream.read(1)
+
+
+def test_new_markers_force_unique_external_xattr_blocks_for_supported_inode_sizes(destination):
+    adapter, root, _, module = destination
+    directory_token, file_token = "1" * 32, "2" * 32
+    adapter.create_directory("delivery", directory_token)
+    path = "delivery/.slice-" + file_token
+    adapter.create_file(path, file_token)
+    directory_marker = os.getxattr(root / "delivery", module.OWNER_XATTR)
+    file_marker = os.getxattr(root / path, module.OWNER_XATTR)
+    assert len(directory_marker) > 1024
+    assert len(file_marker) > 1024
+    assert directory_marker == module.owner_marker(directory_token)
+    assert file_marker == module.owner_marker(file_token)
+    assert directory_marker != file_marker
+    assert module.decode_owner_marker(directory_marker) == directory_token
+    assert module.decode_owner_marker(file_marker) == file_token
+    assert adapter.inspect(path).token == file_token
+
+
+def test_legacy_marker_decoder_is_explicit_and_rejects_malformed_new_values(destination):
+    _, _, _, module = destination
+    token = "2" * 32
+    assert module.decode_owner_marker(token.encode()) == token
+    assert module.decode_owner_marker(module.owner_marker(token)[:-1]) is None
+    assert module.decode_owner_marker(module.owner_marker(token) + b"foreign") is None
+    assert module.decode_owner_marker(b"not a token") is None
+
+
+class ReattachedTree:
+    """Same disposable inode, synthetic new st_dev; delegate actual fd confinement."""
+    def __init__(self, tree, *, inode_delta=0, birth_delta=0):
+        self.tree, self.inode_delta, self.birth_delta = tree, inode_delta, birth_delta
+
+    def __getattr__(self, name):
+        return getattr(self.tree, name)
+
+    def identity(self, fd):
+        device, inode, birth = self.tree.identity(fd)
+        return device + 17, inode + self.inode_delta, birth + self.birth_delta
+
+
+def test_certificates_survive_transient_device_number_change(destination):
+    adapter, _, store, module = destination
+    token, path = "2" * 32, ".slice-" + "2" * 32
+    adapter.create_directory("delivery", "1" * 32)
+    adapter.create_file(path, token)
+    replacement = module.UsbDestination(ReattachedTree(adapter.tree), adapter.binding, store, adapter.tx)
+    assert replacement.inspect("delivery").token == "1" * 32
+    assert replacement.inspect(path).token == token
+    replacement.append(path, token, b"resumed")
+    with replacement.read(path) as stream:
+        assert stream.read() == b"resumed"
+
+
+@pytest.mark.parametrize("change", [{"inode_delta": 1}, {"birth_delta": 1}])
+def test_certificate_root_inode_and_birth_still_bind_after_device_number_change(destination, change):
+    adapter, _, store, module = destination
+    with pytest.raises(TransferRefusal, match="DESTINATION_CHANGED"):
+        module.UsbDestination(ReattachedTree(adapter.tree, **change), adapter.binding, store, adapter.tx)
+
+
+@pytest.mark.parametrize("changed_index", [1, 2])
+def test_object_inode_or_birth_change_cannot_inherit_certificate(destination, changed_index):
+    adapter, _, store, module = destination
+    token, path = "2" * 32, ".slice-" + "2" * 32
+    adapter.create_file(path, token)
+    root_inode = adapter.tree.identity(adapter.tree.fd)[1]
+    class ChangedObjectTree(ReattachedTree):
+        def identity(self, fd):
+            value = list(super().identity(fd))
+            if value[1] != root_inode:
+                value[changed_index] += 1
+            return tuple(value)
+    replacement = module.UsbDestination(ChangedObjectTree(adapter.tree), adapter.binding, store, adapter.tx)
+    assert replacement.inspect(path).token is None
+    with pytest.raises(TransferRefusal, match="OUTPUT_COLLISION"):
+        replacement.append(path, token, b"not owned")
+
+
+def legacy_certificate_database(adapter):
+    with sqlite3.connect(adapter._database) as con:
+        for table in ("roots", "certificates"):
+            for rowid, encoded in con.execute(f"SELECT rowid,identity FROM {table}").fetchall():
+                value = json.loads(encoded)
+                con.execute(f"UPDATE {table} SET identity=? WHERE rowid=?",
+                            (json.dumps([99, *value[-2:]]), rowid))
+        con.execute("PRAGMA user_version=1")
+
+
+def test_legacy_certificates_migrate_atomically_and_recognize_legacy_markers(destination):
+    adapter, root, store, module = destination
+    token, path = "2" * 32, ".slice-" + "2" * 32
+    adapter.create_file(path, token)
+    os.setxattr(root / path, module.OWNER_XATTR, token.encode())
+    legacy_certificate_database(adapter)
+    replacement = module.UsbDestination(ReattachedTree(adapter.tree), adapter.binding, store, adapter.tx)
+    assert replacement.inspect(path).token == token
+    with sqlite3.connect(adapter._database) as con:
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 2
+        for table in ("roots", "certificates"):
+            assert all(len(json.loads(row[0])) == 2 for row in con.execute(f"SELECT identity FROM {table}"))
+
+
+@pytest.mark.parametrize("malformed", ["not-json", "[]", "[1,2]", "[1,2,3,4]", "[1,true,3]",
+                                       "[1,2,0]", "[1,0,3]", "[-1,2,3]", "[1,2,3.0]"])
+def test_malformed_legacy_certificate_rolls_back_every_migration_change(destination, malformed):
+    adapter, _, store, module = destination
+    adapter.create_file(".slice-" + "2" * 32, "2" * 32)
+    legacy_certificate_database(adapter)
+    with sqlite3.connect(adapter._database) as con:
+        con.execute("UPDATE certificates SET identity=?", (malformed,))
+        before = tuple(con.iterdump())
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        module.UsbDestination(ReattachedTree(adapter.tree), adapter.binding, store, adapter.tx)
+    with sqlite3.connect(adapter._database) as con:
+        assert tuple(con.iterdump()) == before
+
+
+def test_ambiguous_legacy_identity_collapse_rolls_back_migration(destination):
+    adapter, _, store, module = destination
+    adapter.create_file(".slice-" + "2" * 32, "2" * 32)
+    legacy_certificate_database(adapter)
+    with sqlite3.connect(adapter._database) as con:
+        row = list(con.execute("SELECT * FROM certificates").fetchone())
+        value = json.loads(row[7])
+        row[7] = json.dumps([100, *value[1:]])
+        con.execute("INSERT INTO certificates VALUES(?,?,?,?,?,?,?,?,?)", row)
+        before = tuple(con.iterdump())
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        module.UsbDestination(ReattachedTree(adapter.tree), adapter.binding, store, adapter.tx)
+    with sqlite3.connect(adapter._database) as con:
+        assert tuple(con.iterdump()) == before

--- a/tests/test_slice_direct_integration.py
+++ b/tests/test_slice_direct_integration.py
@@ -284,7 +284,8 @@ def test_local_archive_and_fresh_catalog_deliver_under_shared_fence_without_muta
         source_mount_id = source_tree.mount_id
     evidence = SimpleNamespace(fs_uuid="fs-a", serial="serial-a", total_bytes=1000,
                                device_id="synthetic-source", mount_id=source_mount_id, mount_path=str(mount))
-    observer = SimpleNamespace(observe=lambda *args, **kwargs: evidence)
+    observer = SimpleNamespace(observe=lambda *args, **kwargs: evidence,
+                               check_attachment=lambda tree, *a, **k: tree.check())
     reader = LocalArchiveReader({"drive-a": root}, observer=observer)
     opened = []
 

--- a/tests/test_slice_direct_integration.py
+++ b/tests/test_slice_direct_integration.py
@@ -1,0 +1,320 @@
+"""Real descriptor/certificate delivery with disposable state and synthetic hardware evidence.
+
+Free space is deterministic, but accounts for ALL physical descendant inode blocks, including
+unknown objects. Only the device identity and free-space observation are simulated; destination
+IO, xattrs, certificates, fsync, journal, authority and receipt verification are actual code.
+"""
+from contextlib import contextmanager
+from dataclasses import replace
+import errno
+import hashlib
+import json
+import os
+from pathlib import PurePosixPath
+from types import SimpleNamespace
+import uuid
+
+import pytest
+
+from modelark.slice import domain as d
+from modelark.slice import state as state_module
+from modelark.slice import transaction as t
+from modelark.slice.destination import UsbDestination
+from modelark.slice.linux import BoundTree
+from test_slice_transaction import DATA, Sources, proposal
+
+
+class PowerCut(BaseException):
+    pass
+
+
+def physical_descendants(root):
+    """Measure every inode, not only objects claiming ownership; hardlinks count once."""
+    seen, used = set(), 0
+    for parent, directories, files in os.walk(root, followlinks=False):
+        for name in (*directories, *files):
+            info = os.lstat(os.path.join(parent, name))
+            identity = (info.st_dev, info.st_ino)
+            if identity not in seen:
+                used += info.st_blocks * 512
+                seen.add(identity)
+    return used
+
+
+@pytest.fixture
+def direct(tmp_path, monkeypatch):
+    monkeypatch.setattr(state_module, "HOST_STATE_DIR", tmp_path / "private-host")
+    store = state_module.Store()
+    initial, _, snapshot = proposal()
+    device = "direct-test-" + uuid.uuid4().hex
+    preview = d.preview(replace(initial.spec, destination_id=device), snapshot)
+    approval = d.approve(preview, expected_seal=preview.seal, current_snapshot=snapshot)
+    binding = t.DestinationBinding(device, "disposable-fs", "synthetic-ext4-profile", 10_000_000)
+    plan = t.TransferPlan(preview, binding, metadata_reserve_bytes=1_000_000)
+    tx = store.create(plan, approval)
+    store.approve(tx, expected_seal=plan.seal)
+    root = tmp_path / "destination"
+    root.mkdir()
+    availability = {"attached": True}
+
+    def verify():
+        if not availability["attached"]:
+            raise t.TransferRefusal("WAITING_DESTINATION", "synthetic unplug")
+
+    @contextmanager
+    def adapter():
+        with BoundTree(root, verify=verify, writable=True) as tree:
+            destination = UsbDestination(tree, binding, store, env.tx)
+            def available():
+                root_delta = os.fstat(tree.fd).st_blocks * 512 - destination._root_blocks
+                return binding.available_bytes - physical_descendants(root) - root_delta
+            monkeypatch.setattr(destination, "_available", available)
+            yield destination
+
+    output = str(PurePosixPath(preview.spec.destination_root) /
+                 preview.closure[0].repo_id / preview.closure[0].rfilename)
+    env = SimpleNamespace(store=store, plan=plan, tx=tx, root=root, adapter=adapter,
+                          sources=Sources(snapshot, t), snapshot=snapshot, output=output,
+                          availability=availability)
+    return env
+
+
+def assert_delivery_complete(env, adapter):
+    assert env.store.status(env.tx).state == "complete"
+    with adapter.read(env.output) as stream:
+        assert stream.read() == DATA
+    receipt_path = str(PurePosixPath(env.plan.proposal.spec.destination_root) / ".modelark-slice-receipt.json")
+    with adapter.read(receipt_path) as stream:
+        receipt = json.load(stream)
+    assert receipt["transaction"] == env.tx
+    assert receipt["seal"] == env.plan.seal
+    assert receipt["status"] == "complete"
+    assert receipt["files"][0]["path"] == env.output
+    assert receipt["files"][0]["size"] == len(DATA)
+    assert not tuple(env.root.rglob(".slice-*"))
+
+
+def test_real_direct_delivery_from_empty_root_and_receipt_readback(direct):
+    with direct.adapter() as adapter:
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as session:
+            assert session.run().state == "complete"
+        assert_delivery_complete(direct, adapter)
+
+
+@pytest.mark.parametrize("point", ["control_created", "control_published", "directory_created",
+                                  "directory_parent_flushed", "temporary_created", "chunk_written",
+                                  "file_flushed", "file_prepared", "file_published", "file_complete",
+                                  "receipt_prepared", "receipt_published"])
+def test_certified_fault_boundaries_recover_with_reconstructed_adapter(direct, point):
+    reached = []
+    def crash(current):
+        if current == point:
+            reached.append(current)
+            raise PowerCut(point)
+    with direct.adapter() as adapter:
+        session = None
+        with pytest.raises(PowerCut):
+            try:
+                session = t.start(direct.store, direct.tx, adapter, direct.sources, fault=crash)
+                session.run()
+            finally:
+                if session is not None:
+                    session.lease.close()  # Simulate process fd loss, not graceful Stop.
+    assert reached == [point]
+    with direct.adapter() as adapter:
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as resumed:
+            assert resumed.run().state == "complete"
+        assert_delivery_complete(direct, adapter)
+
+
+def test_directory_pre_certificate_crash_refuses_without_adopting_or_deleting(direct, monkeypatch):
+    residue = None
+    with direct.adapter() as adapter:
+        certify = adapter._certify
+        def crash(fd, path, token, kind):
+            nonlocal residue
+            if kind == "directory":
+                residue = direct.root / path
+                raise PowerCut("uncertified directory")
+            return certify(fd, path, token, kind)
+        monkeypatch.setattr(adapter, "_certify", crash)
+        session = t.start(direct.store, direct.tx, adapter, direct.sources)
+        try:
+            with pytest.raises(PowerCut):
+                session.run()
+        finally:
+            session.lease.close()
+    before = residue.stat()
+    with direct.adapter() as adapter:
+        with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+            t.start(direct.store, direct.tx, adapter, direct.sources)
+    after = residue.stat()
+    assert (before.st_dev, before.st_ino) == (after.st_dev, after.st_ino)
+    assert residue.is_dir() and not tuple(residue.iterdir())
+
+
+def test_publication_hardlinks_count_once_during_restart(direct):
+    def crash(point):
+        if point == "file_published":
+            raise PowerCut(point)
+    with direct.adapter() as adapter:
+        session = t.start(direct.store, direct.tx, adapter, direct.sources, fault=crash)
+        try:
+            with pytest.raises(PowerCut):
+                session.run()
+        finally:
+            session.lease.close()
+        operation = next(payload for event, payload in direct.store.events(direct.tx)
+                         if event == "operation" and payload["kind"] == "file")
+        temporary = direct.root / operation["temporary"]
+        final = direct.root / direct.output
+        assert os.path.samefile(temporary, final)
+        assert final.stat().st_nlink == 2
+        accounted = t._allocated(direct.store, direct.tx, adapter)
+        assert accounted == physical_descendants(direct.root)
+        adapter.check(direct.plan.destination, accounted, direct.plan.required_bytes(direct.store.root))
+    with direct.adapter() as adapter:
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as session:
+            assert session.run().state == "complete"
+        assert_delivery_complete(direct, adapter)
+
+
+def test_stop_releases_attempt_and_explicit_resume_finishes_real_delivery(direct):
+    with direct.adapter() as adapter:
+        first = t.start(direct.store, direct.tx, adapter, direct.sources)
+        direct.store.request_stop(direct.tx)
+        assert first.step().state == "stopped"
+        assert not first.can_write
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as resumed:
+            assert resumed.run().state == "complete"
+        first.close()
+        assert_delivery_complete(direct, adapter)
+
+
+def test_attended_source_wait_then_resume_retains_destination_certificates(direct):
+    direct.sources.status = {source.drive.drive_label: "WAITING_SOURCE"
+                             for source in direct.plan.proposal.closure[0].sources}
+    with direct.adapter() as adapter:
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as session:
+            assert session.run().state == "waiting_source"
+            direct.sources.status.clear()
+            assert session.run().state == "complete"
+        assert_delivery_complete(direct, adapter)
+
+
+def test_attended_destination_wait_then_resume_retains_certified_work(direct):
+    with direct.adapter() as adapter:
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as session:
+            direct.availability["attached"] = False
+            assert session.run().state == "waiting_destination"
+            assert session.can_write  # The attempt is retained; the adapter refuses IO.
+            direct.availability["attached"] = True
+            assert session.run().state == "complete"
+        assert_delivery_complete(direct, adapter)
+
+
+def test_pre_certificate_file_crash_leaves_no_named_residue_and_restarts(direct, monkeypatch):
+    with direct.adapter() as adapter:
+        monkeypatch.setattr(adapter, "_certify", lambda *args: (_ for _ in ()).throw(PowerCut("file certificate")))
+        with pytest.raises(PowerCut):
+            t.start(direct.store, direct.tx, adapter, direct.sources)
+        assert not tuple(direct.root.iterdir())
+    with direct.adapter() as adapter:
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as session:
+            assert session.run().state == "complete"
+        assert_delivery_complete(direct, adapter)
+
+
+def test_synthetic_capacity_does_not_hide_unowned_allocation(direct):
+    with direct.adapter() as adapter:
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as session:
+            foreign = direct.root / "unowned"
+            foreign.write_bytes(b"foreign" * 4096)
+            with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_CHANGED"):
+                session.run()
+            assert foreign.read_bytes() == b"foreign" * 4096
+
+
+def test_actual_destination_write_error_ends_attempt_without_a_receipt(direct, monkeypatch):
+    from modelark.slice import destination as destination_module
+    with direct.adapter() as adapter:
+        with t.start(direct.store, direct.tx, adapter, direct.sources) as session:
+            def no_space(*args):
+                raise OSError(errno.ENOSPC, "synthetic physical destination full")
+            monkeypatch.setattr(destination_module.os, "write", no_space)
+            with pytest.raises(t.TransferRefusal, match="DESTINATION_IO_FAILED"):
+                session.run()
+            assert direct.store.status(direct.tx).state == "invalidated"
+            assert not session.can_write
+            assert not any(event == "receipt" for event, _ in direct.store.events(direct.tx))
+            assert not tuple(direct.root.rglob(".modelark-slice-receipt.json"))
+
+
+def test_local_archive_and_fresh_catalog_deliver_under_shared_fence_without_mutation(direct, tmp_path, monkeypatch):
+    from modelark import drive_fence
+    from modelark.core import db
+    from modelark.slice.catalog import read_catalog
+    from modelark.slice.local_source import LocalArchiveReader
+    from modelark.slice.sources import FencedSources
+    from test_slice_catalog import seed
+
+    monkeypatch.setattr(drive_fence, "_LOCK_DIR", tmp_path / "archive-fences")
+    monkeypatch.setattr(db, "connect", lambda *args, **kwargs: pytest.fail("no global catalog"))
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: pytest.fail("no retrieval or live hardware"))
+    catalog = tmp_path / "catalog.sqlite"
+    con = seed(catalog, d)
+    digest = hashlib.sha256(DATA).hexdigest()
+    con.execute("UPDATE files SET sha256=?", (digest,))
+    con.execute("UPDATE archived SET orig_sha256=?,annex_key=?", (digest, f"SHA256E-s12--{digest}"))
+    snapshot = read_catalog(catalog, direct.plan.proposal.spec)
+    preview = d.preview(direct.plan.proposal.spec, snapshot)
+    direct.plan = t.TransferPlan(preview, direct.plan.destination, metadata_reserve_bytes=1_000_000)
+    direct.tx = direct.store.create(direct.plan, d.approve(preview, expected_seal=preview.seal,
+                                                         current_snapshot=snapshot))
+    direct.store.approve(direct.tx, expected_seal=direct.plan.seal)
+    mount = tmp_path / "source-attachment"
+    root = mount / "modelark"
+    (root / ".git").mkdir(parents=True)
+    config = root / ".git/config"
+    config.write_text("[annex]\n uuid = annex-a\n")
+    (root / "org/model").mkdir(parents=True)
+    source_file = root / "org/model/model.safetensors"
+    source_file.write_bytes(DATA)
+    with BoundTree(root) as source_tree:
+        source_mount_id = source_tree.mount_id
+    evidence = SimpleNamespace(fs_uuid="fs-a", serial="serial-a", total_bytes=1000,
+                               device_id="synthetic-source", mount_id=source_mount_id, mount_path=str(mount))
+    observer = SimpleNamespace(observe=lambda *args, **kwargs: evidence)
+    reader = LocalArchiveReader({"drive-a": root}, observer=observer)
+    opened = []
+
+    class AssertFenceReader:
+        @contextmanager
+        def open(self, candidate):
+            key = (candidate.drive.identity_fingerprint, candidate.drive.identity_epoch)
+            with reader.open(candidate) as stream:
+                with pytest.raises(drive_fence.FenceUnavailable):
+                    with drive_fence.hold_drives_sorted([key], blocking=False):
+                        pytest.fail("archive reader did not retain the shared fence")
+                opened.append(candidate.drive.drive_label)
+                yield stream
+
+    sources = FencedSources(catalog, AssertFenceReader())
+    before_catalog = tuple(con.iterdump())
+    before_config = config.read_bytes()
+    before_source = source_file.stat()
+    try:
+        with direct.adapter() as adapter:
+            with t.start(direct.store, direct.tx, adapter, sources) as session:
+                assert session.run().state == "complete"
+            assert_delivery_complete(direct, adapter)
+        assert opened == ["drive-a"]
+        assert tuple(con.iterdump()) == before_catalog
+        assert config.read_bytes() == before_config
+        assert source_file.read_bytes() == DATA
+        assert source_file.stat().st_mtime_ns == before_source.st_mtime_ns
+        key = (snapshot.drives[0].identity_fingerprint, snapshot.drives[0].identity_epoch)
+        with drive_fence.hold_drives_sorted([key], blocking=False):
+            pass  # Reader close released the archive fence.
+    finally:
+        con.close()

--- a/tests/test_slice_fat32_layout.py
+++ b/tests/test_slice_fat32_layout.py
@@ -1,0 +1,190 @@
+"""Pure FAT32 candidate layout tests: not filesystem qualification or writer authority."""
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from modelark.slice import fat32_layout as fat, state
+from modelark.slice.transaction import TransferRefusal
+
+
+def admit(files=(("org/model/weights.bin", 12),), **changes):
+    options = dict(output_root="delivery", parent_path="/exports", control_size=1024,
+                   receipt_size=2048)
+    options.update(changes)
+    return fat.admit_layout(files, **options)
+
+
+def test_candidate_layout_contains_artifacts_metadata_directories_and_temporary_paths():
+    layout = admit()
+    assert layout.execution_ready is False
+    assert dict(layout.files) == {
+        "delivery/org/model/weights.bin": 12,
+        "delivery/.modelark-slice-owner": 1024,
+        "delivery/.modelark-slice-receipt.json": 2048,
+    }
+    assert set(layout.directories) == {"delivery", "delivery/org", "delivery/org/model"}
+    assert isinstance(layout.files, tuple)
+    assert isinstance(layout.directories, tuple)
+    assert isinstance(layout.temporary_paths, tuple)
+    assert "delivery/org/model/.slice-" + "0" * 32 in layout.temporary_paths
+    assert "delivery/.slice-" + "0" * 32 in layout.temporary_paths
+    with pytest.raises(FrozenInstanceError):
+        layout.files = ()
+
+
+def test_accepts_generators_and_safe_ascii_internal_spaces_without_filesystem_access():
+    files = ((name, size) for name, size in [("Org Name/Model-v1/weights_2.bin", 0)])
+    result = admit(files, parent_path="/does-not-exist/exports", output_root="Delivery 1")
+    assert ("Delivery 1/Org Name/Model-v1/weights_2.bin", 0) in result.files
+    assert not result.execution_ready
+
+
+@pytest.mark.parametrize("name", [
+    "", ".", "..", " trailing", "trailing ", "trailing.",
+    "a~1.bin", "a:b", "a\\b", "a*b", "a?b", 'a"b', "a<b", "a>b", "a|b",
+    "a\x00b", "a\x1fb", "a\x7fb", "a\tb", "a\nb", "café", "\udcff",
+    "CON", "con.bin", "PrN.dat", "AUX", "NUL.txt", "CLOCK$", "CLOCK$.bin",
+    "COM1", "com9.dat", "LPT1", "lPt9.bin", ".slice-anything", ".SLICE-abc",
+])
+def test_unsafe_candidate_component_refused_in_artifact_directory_leaf_and_output_root(name):
+    for path in ("org/" + name, name + "/weights.bin"):
+        with pytest.raises(TransferRefusal):
+            admit(((path, 12),))
+    with pytest.raises(TransferRefusal):
+        admit(output_root=name)
+
+
+@pytest.mark.parametrize("path", ["/absolute", "//double", "a//b", "a/./b", "a/../b", "a/",
+                                 "./a", "../a"])
+def test_artifact_paths_require_canonical_relative_components(path):
+    with pytest.raises(TransferRefusal):
+        admit(((path, 12),))
+
+
+@pytest.mark.parametrize("files", [None, (), [], "org/model/a.bin", b"bytes",
+                                  {"org/model/a.bin": 12}, (None,), (("a.bin",),),
+                                  (("a.bin", 12, "extra"),), ((None, 12),), ((123, 12),)])
+def test_empty_or_malformed_file_collections_are_not_candidate_layouts(files):
+    with pytest.raises(TransferRefusal):
+        admit(files)
+
+
+@pytest.mark.parametrize("root", [None, 123, "a/b", "/absolute", "a//b"])
+def test_output_root_must_be_one_component(root):
+    with pytest.raises(TransferRefusal):
+        admit(output_root=root)
+
+
+@pytest.mark.parametrize("parent", ["relative", "", "//exports", "/a/../b", "/a/./b",
+                                   "/a//b", "/exports/", "/bad\x00path", "/\udcff"])
+def test_parent_path_requires_canonical_absolute_utf8(parent):
+    with pytest.raises(TransferRefusal):
+        admit(parent_path=parent)
+
+
+def test_parent_path_is_not_subject_to_fat_artifact_ascii_restriction():
+    # This is the host path to an existing parent, not a created FAT filename.
+    assert not admit(parent_path="/media/utilisateur/clé").execution_ready
+    assert not admit(parent_path="/").execution_ready
+
+
+@pytest.mark.parametrize("files", [
+    (("org/model/a.bin", 1), ("org/model/A.bin", 1)),
+    (("org/model/a.bin", 1), ("ORG/model/b.bin", 1)),
+    (("org/model/a.bin", 1), ("org/Model/b.bin", 1)),
+    (("org/model", 1), ("org/model/a.bin", 1)),
+    (("org/MODEL", 1), ("org/model/a.bin", 1)),
+    (("org/model/a.bin", 1), ("org/model/a.bin", 1)),
+    ((".modelark-slice-owner", 1),),
+    ((".MODELARK-SLICE-OWNER", 1),),
+    ((".modelark-slice-receipt.json", 1),),
+    ((".MODELARK-SLICE-RECEIPT.JSON", 1),),
+    ((".modelark-slice-owner/a.bin", 1),),
+])
+def test_entire_tree_case_collisions_and_generated_metadata_collisions_refused(files):
+    with pytest.raises(TransferRefusal):
+        admit(files)
+    with pytest.raises(TransferRefusal):
+        admit(tuple(reversed(files)))
+
+
+def test_same_spelled_shared_directories_and_non_reserved_dos_lookalikes_are_allowed():
+    files = (("org/model/COM0.bin", 1), ("org/model/COM10.bin", 1),
+             ("org/model/LPT0.bin", 1), ("org/model/conversation.bin", 1))
+    assert len(admit(files).files) == len(files) + 2
+
+
+def test_maximum_file_size_includes_control_and_receipt_and_zero_byte_artifacts():
+    assert fat.MAX_FILE_BYTES == (1 << 32) - 1
+    layout = admit((("org/model/weights.bin", fat.MAX_FILE_BYTES),),
+                   control_size=fat.MAX_FILE_BYTES, receipt_size=fat.MAX_FILE_BYTES)
+    assert all(size == fat.MAX_FILE_BYTES for _, size in layout.files)
+    assert ("delivery/org/model/empty.bin", 0) in admit((("org/model/empty.bin", 0),)).files
+
+
+@pytest.mark.parametrize("size", [1 << 32, -1, True, False, 1.0, "12", None])
+def test_invalid_or_oversized_payload_and_metadata_sizes_refused(size):
+    with pytest.raises(TransferRefusal):
+        admit((("org/model/weights.bin", size),))
+    for field in ("control_size", "receipt_size"):
+        with pytest.raises(TransferRefusal):
+            admit(**{field: size})
+
+
+def test_component_limit_accepts_255_and_rejects_256_in_all_created_positions():
+    assert fat.MAX_COMPONENT == 255
+    assert admit((("a" * 255, 12),), output_root="b" * 255)
+    for path in ("a" * 256, "a" * 256 + "/weights.bin"):
+        with pytest.raises(TransferRefusal):
+            admit(((path, 12),))
+    with pytest.raises(TransferRefusal):
+        admit(output_root="b" * 256)
+
+
+def parent_with_length(length):
+    # Canonical absolute host components, each below NAME_MAX.
+    count, remainder = divmod(length, 201)
+    result = "/" + "/".join(["p" * 200] * count)
+    if remainder:
+        result += "/" + "q" * (remainder - 1) if count else "q" * (remainder - 1)
+    if result.endswith("/") and len(result) > 1:
+        result = result[:-1] + "q"
+    assert len(result) == length
+    return result
+
+
+def test_total_path_limit_accounts_for_generated_temporary_name_and_nul():
+    assert fat.MAX_PATH_BYTES == 4096
+    suffix = "/delivery/org/model/.slice-" + "0" * 32
+    parent = parent_with_length(fat.MAX_PATH_BYTES - 1 - len(suffix))
+    layout = admit((("org/model/w", 1),), parent_path=parent)
+    assert len(parent + "/" + max(layout.temporary_paths, key=len)) == 4095
+    # All final names still fit; the generated temporary name is what crosses PATH_MAX.
+    with pytest.raises(TransferRefusal):
+        admit((("org/model/w", 1),), parent_path=parent + "q")
+
+
+def test_total_path_limit_also_checks_final_names_longer_than_temporary_names():
+    leaf = "w" * fat.MAX_COMPONENT
+    suffix = "/delivery/org/model/" + leaf
+    parent = parent_with_length(fat.MAX_PATH_BYTES - 1 - len(suffix))
+    assert admit((("org/model/" + leaf, 1),), parent_path=parent)
+    with pytest.raises(TransferRefusal):
+        admit((("org/model/" + leaf, 1),), parent_path=parent + "q")
+
+
+def test_parent_path_limit_counts_utf8_bytes_not_characters():
+    suffix = "/delivery/org/model/.slice-" + "0" * 32
+    parent = parent_with_length(fat.MAX_PATH_BYTES - 1 - len(suffix))
+    # Replacing one ASCII character adds one UTF-8 byte without changing character count.
+    with pytest.raises(TransferRefusal):
+        admit((("org/model/w", 1),), parent_path=parent[:-1] + "é")
+
+
+def test_layout_observation_cannot_be_created_as_a_legacy_executable_plan(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "HOST_STATE_DIR", tmp_path / "private")
+    store = state.Store()
+    with pytest.raises(TransferRefusal, match="LEGACY_PLAN"):
+        store.create(admit(), None)
+    with store._connection(write=False) as con:
+        assert con.execute("SELECT COUNT(*) FROM transactions").fetchone()[0] == 0

--- a/tests/test_slice_fat32_observation.py
+++ b/tests/test_slice_fat32_observation.py
@@ -1,0 +1,342 @@
+"""Synthetic candidate admission; not kernel-vfat write qualification."""
+import copy
+import errno
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import fat32_observation as module
+from modelark.slice.host_observation import ProtectedTarget
+from modelark.slice.linux import BoundTree
+from modelark.slice.transaction import TransferRefusal
+
+
+@pytest.fixture
+def fat(tmp_path):
+    volume = tmp_path / 'FatVolume'
+    volume.mkdir(mode=0o700)
+    parent = volume / 'Exports'
+    parent.mkdir(mode=0o700)
+    with module.Fat32Tree(parent) as tree:
+        value = os.fstat(tree.fd)
+        key = f'{os.major(value.st_dev)}:{os.minor(value.st_dev)}'
+        mount_id = tree.mount_id
+    leaf = {'path': '/dev/testusb1', 'type': 'part', 'maj:min': key,
+            'fstype': 'vfat', 'fsver': 'FAT32', 'uuid': 'FAT-UUID', 'ro': False}
+    disk = {'path': '/dev/testusb', 'type': 'disk', 'maj:min': '238:0',
+            'serial': 'USB-SERIAL', 'wwn': 'USB-WWN', 'tran': 'usb', 'ro': False,
+            'children': [leaf]}
+    options = f'rw,uid={os.geteuid()},gid={os.getegid()},fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,utf8,shortname=mixed,errors=remount-ro'
+    state = {'payload': {'blockdevices': [disk]}, 'options': options, 'backing': (1, 2),
+             'roles': {}, 'extra_mounts': '', 'version': 'vfat', 'volume': volume}
+    def mounts():
+        return (f'1 0 239:1 / / rw - ext4 /dev/host rw\n'
+                f"{mount_id} 1 {key} / {volume} rw - {state['version']} /dev/testusb1 {state['options']}\n"
+                + state['extra_mounts'])
+    def resolver(path, **kwargs):
+        path = str(path)
+        target = state['roles'].get(path, path)
+        if target is None:
+            return None
+        own = target == str(volume) or target.startswith(str(volume) + '/')
+        return ProtectedTarget(path, target, key if own else '239:1', mount_id if own else 1, 10)
+    observer = module.Fat32FolderObserver(inventory=lambda: copy.deepcopy(state['payload']),
+        mounts=mounts, backing=lambda key: state['backing'], resolver=resolver)
+    return observer, parent, state, disk, leaf
+
+
+def test_read_only_fat32_intent_has_no_persistent_inode_identity(fat):
+    observer, parent, *_ = fat
+    before = tuple(parent.iterdir())
+    evidence = observer.observe(parent / 'Demo', archives=())
+    assert evidence.parent_parts == ('Exports',)
+    assert evidence.child_name == 'Demo'
+    assert evidence.filesystem_id == 'FAT-UUID'
+    assert evidence.backing_ids == tuple(sorted(set(evidence.backing_ids)))
+    assert {'serial:USB-SERIAL', 'wwn:USB-WWN', 'filesystem:FAT-UUID'} <= set(evidence.backing_ids)
+    assert not hasattr(evidence, 'parent_identity')
+    assert evidence.capacity.free_inodes is None
+    assert tuple(parent.iterdir()) == before
+
+
+def test_fat_tree_uses_live_inode_without_relaxing_native_birth_requirement(tmp_path, monkeypatch):
+    from modelark.slice import linux
+    actual = linux._statx
+    calls = []
+    def no_birth(fd, *, require_birth=True):
+        calls.append(require_birth)
+        if require_birth:
+            raise TransferRefusal('FILESYSTEM_UNSUPPORTED', 'birth unavailable')
+        value = actual(fd, require_birth=False)
+        value.mask &= ~0x800
+        return value
+    monkeypatch.setattr(linux, '_statx', no_birth)
+    monkeypatch.setattr(module, '_statx', no_birth)
+    with module.Fat32Tree(tmp_path) as tree:
+        tree.check()
+        assert len(tree.identity(tree.fd)) == 2
+        assert not any(calls)
+    with pytest.raises(TransferRefusal, match='birth unavailable'):
+        BoundTree(tmp_path)
+
+
+def test_replaced_preview_parent_may_be_freshly_bound_at_start(fat):
+    observer, parent, *_ = fat
+    evidence = observer.observe(parent / 'Demo', archives=())
+    parent.rename(parent.with_name('Previous'))
+    parent.mkdir(mode=0o700)
+    with module.Fat32Tree(parent) as tree:
+        assert observer.recheck(tree, evidence).filesystem_scope == evidence.filesystem_scope
+
+
+def test_replaced_live_parent_refuses(fat):
+    observer, parent, *_ = fat
+    evidence = observer.observe(parent / 'Demo', archives=())
+    with module.Fat32Tree(parent) as tree:
+        parent.rename(parent.with_name('Previous'))
+        parent.mkdir(mode=0o700)
+        with pytest.raises(TransferRefusal, match='changed'):
+            observer.recheck(tree, evidence)
+
+
+def test_closed_live_parent_cannot_be_recreated_from_evidence(fat):
+    observer, parent, *_ = fat
+    evidence = observer.observe(parent / 'Demo', archives=())
+    tree = module.Fat32Tree(parent)
+    tree.close()
+    with pytest.raises(TransferRefusal, match='closed'):
+        observer.recheck(tree, evidence)
+
+
+def test_unrelated_sibling_and_owned_child_do_not_change_live_intent(fat):
+    observer, parent, *_ = fat
+    evidence = observer.observe(parent / 'Demo', archives=())
+    with module.Fat32Tree(parent) as tree:
+        (parent / 'Sibling').write_text('retain')
+        (parent / 'Demo').mkdir(mode=0o700)
+        assert observer.recheck(tree, evidence).filesystem_scope == evidence.filesystem_scope
+
+
+@pytest.mark.parametrize('existing', ['Demo', 'demo', 'DEMO'])
+def test_existing_case_equivalent_child_refuses(fat, existing):
+    observer, parent, *_ = fat
+    (parent / existing).mkdir()
+    with pytest.raises(TransferRefusal, match='already exists'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+@pytest.mark.parametrize('name', ['ALIAS~1', 'éxport', 'bad.', 'CON', 'bad:name', '.slice-owner'])
+def test_unqualified_output_spelling_refuses(fat, name):
+    observer, parent, *_ = fat
+    with pytest.raises(TransferRefusal):
+        observer.observe(parent / name, archives=())
+
+
+def test_parent_canonical_case_ambiguity_refuses_even_on_synthetic_host(fat):
+    observer, parent, *_ = fat
+    parent.with_name('exports').mkdir()
+    with pytest.raises(TransferRefusal, match='alias or ambiguous case'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+def test_parent_short_alias_spelling_refuses(fat):
+    observer, parent, *_ = fat
+    alias = parent.with_name('EXPORT~1')
+    alias.mkdir()
+    with pytest.raises(TransferRefusal, match='component'):
+        observer.observe(alias / 'Demo', archives=())
+
+
+def test_parent_symlink_refuses(fat):
+    observer, parent, *_ = fat
+    alias = parent.with_name('Alias')
+    alias.symlink_to(parent, target_is_directory=True)
+    with pytest.raises(TransferRefusal):
+        observer.observe(alias / 'Demo', archives=())
+
+
+@pytest.mark.parametrize('option', ['nonumtail', 'codepage=850', 'shortname=lower', 'iocharset=koi8-r',
+                                  'iocharset=ascii', 'iocharset=utf8',
+                                  'showexec', 'check=r', 'utf8=0'])
+def test_unqualified_name_options_refuse(fat, option):
+    observer, parent, state, *_ = fat
+    key = option.split('=', 1)[0]
+    state['options'] = ','.join(value for value in state['options'].split(',') if value.split('=', 1)[0] != key)
+    state['options'] += ',' + option
+    with pytest.raises(TransferRefusal, match='qualified'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+def test_utf8_mount_flag_is_required_by_qualified_codec_profile(fat):
+    observer, parent, state, *_ = fat
+    state['options'] = ','.join(option for option in state['options'].split(',') if option != 'utf8')
+    with pytest.raises(TransferRefusal, match='utf8') as raised:
+        observer.observe(parent / 'Demo', archives=())
+    assert raised.value.code == 'FILESYSTEM_UNSUPPORTED'
+
+
+@pytest.mark.parametrize('option', ['uid=99999', 'dmask=0000', 'fmask=0002', 'dmask=bad'])
+def test_mount_permissions_refuse_without_changing_anything(fat, option):
+    observer, parent, state, *_ = fat
+    key = option.split('=', 1)[0]
+    state['options'] = ','.join(value for value in state['options'].split(',') if not value.startswith(key + '='))
+    state['options'] += ',' + option
+    with pytest.raises(TransferRefusal) as error:
+        observer.observe(parent / 'Demo', archives=())
+    assert error.value.code == 'DESTINATION_NOT_WRITABLE'
+    assert not (parent / 'Demo').exists()
+
+
+def test_effective_parent_nonowner_write_refuses_even_when_sticky(fat):
+    observer, parent, *_ = fat
+    parent.chmod(0o1777)
+    with pytest.raises(TransferRefusal, match='nonowner write'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+@pytest.mark.parametrize('version', [None, 'FAT12', 'FAT16', '32', 'exFAT'])
+def test_explicit_fat32_version_required(fat, version):
+    observer, parent, _, _, leaf = fat
+    leaf['fsver'] = version
+    with pytest.raises(TransferRefusal, match='FAT32 version'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+def test_non_vfat_kernel_mount_refuses(fat):
+    observer, parent, state, *_ = fat
+    state['version'] = 'fuseblk'
+    with pytest.raises(TransferRefusal, match='kernel vfat'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+def test_non_usb_destination_refuses(fat):
+    observer, parent, _, disk, _ = fat
+    disk['tran'] = 'nvme'
+    with pytest.raises(TransferRefusal, match='USB'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+def test_mapped_fat_destination_refuses(fat):
+    observer, parent, _, _, leaf = fat
+    leaf['type'] = 'crypt'
+    with pytest.raises(TransferRefusal, match='stacked'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+def test_archive_backing_excluded(fat):
+    observer, parent, *_ = fat
+    with pytest.raises(TransferRefusal, match='archive'):
+        observer.observe(parent / 'Demo', archives=(SimpleNamespace(fs_uuid='FAT-UUID'),))
+
+
+def test_protected_role_retarget_blocks_live_tree(fat):
+    observer, parent, state, *_ = fat
+    evidence = observer.observe(parent / 'Demo', archives=())
+    state['roles']['/var'] = str(parent)
+    with module.Fat32Tree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='protected'):
+            observer.recheck(tree, evidence)
+
+
+def test_mount_alias_refuses(fat):
+    observer, parent, state, _, leaf = fat
+    state['extra_mounts'] = f"9898 1 {leaf['maj:min']} / /alias rw - vfat /dev/testusb1 rw\n"
+    with pytest.raises(TransferRefusal, match='aliases'):
+        observer.observe(parent / 'Demo', archives=())
+
+
+def test_backing_loss_proves_wait_but_does_not_authorize_resume(fat):
+    observer, parent, *_ = fat
+    evidence = observer.observe(parent / 'Demo', archives=())
+    def gone(key):
+        raise FileNotFoundError(errno.ENOENT, 'gone')
+    observer._backing = gone
+    with module.Fat32Tree(parent) as tree:
+        with pytest.raises(TransferRefusal) as raised:
+            observer.recheck(tree, evidence)
+    assert raised.value.code == 'WAITING_DESTINATION'
+
+
+def test_inventory_order_cannot_change_stable_intent(fat):
+    observer, parent, state, disk, _ = fat
+    first = observer.observe(parent / 'Demo', archives=())
+    state['payload']['blockdevices'][0] = dict(reversed(tuple(disk.items())))
+    second = observer.observe(parent / 'Demo', archives=())
+    assert first.filesystem_scope == second.filesystem_scope
+    assert first.backing_ids == second.backing_ids
+
+
+def test_inventory_cli_requests_kernel_aliases_for_unrelated_mapped_host(fat, monkeypatch):
+    observer, parent, state, *_ = fat
+    root = {'path': '/dev/mapper/host-root', 'kname': '/dev/dm-1', 'type': 'lvm',
+            'maj:min': '239:1', 'pkname': '/dev/dm-0', 'fstype': 'ext4', 'uuid': 'HOST-FS', 'ro': False}
+    crypt = {'path': '/dev/mapper/host-crypt', 'kname': '/dev/dm-0', 'type': 'crypt',
+             'maj:min': '239:2', 'pkname': '/dev/host1', 'ro': False, 'children': [root]}
+    partition = {'path': '/dev/host1', 'kname': '/dev/host1', 'type': 'part',
+                 'maj:min': '239:3', 'pkname': '/dev/host', 'ro': False, 'children': [crypt]}
+    state['payload']['blockdevices'].append({'path': '/dev/host', 'kname': '/dev/host',
+        'type': 'disk', 'maj:min': '239:0', 'serial': 'HOST-SERIAL', 'tran': 'nvme',
+        'ro': False, 'children': [partition]})
+    calls = []
+    def inventory_command(argv, **kwargs):
+        assert argv[:5] == ['lsblk', '--json', '--bytes', '--paths', '--output']
+        assert {'KNAME', 'FSVER'} <= set(argv[5].split(','))
+        calls.append(argv)
+        return SimpleNamespace(stdout=json.dumps(state['payload']))
+    monkeypatch.setattr(module.subprocess, 'run', inventory_command)
+    observer._inventory = module._inventory
+    value = observer.observe(parent / 'Demo', archives=())
+    assert value.filesystem_id == 'FAT-UUID'
+    assert len(calls) == 2
+
+
+def test_serialized_observation_does_not_create_in_process_proof(fat):
+    observer, parent, *_ = fat
+    value = observer.observe(parent / 'Demo', archives=())
+    observer._observed.clear()
+    with module.Fat32Tree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='no matching'):
+            observer.recheck(tree, value)
+
+
+def test_new_archive_role_is_checked_at_recheck(fat):
+    observer, parent, *_ = fat
+    value = observer.observe(parent / 'Demo', archives=())
+    with module.Fat32Tree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='archive'):
+            observer.recheck(tree, value, archives=(SimpleNamespace(serial='USB-SERIAL'),))
+
+
+def test_permission_mask_change_during_live_attempt_is_revalidated(fat):
+    observer, parent, state, *_ = fat
+    value = observer.observe(parent / 'Demo', archives=())
+    state['options'] = state['options'].replace('dmask=0022', 'dmask=0000')
+    with module.Fat32Tree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='exclude group/other writes'):
+            observer.recheck(tree, value)
+
+
+def test_effective_permission_probe_failure_preserves_specific_refusal(fat, monkeypatch):
+    observer, parent, *_ = fat
+    def denied(fd):
+        raise PermissionError(errno.EACCES, 'denied')
+    monkeypatch.setattr(module, 'require_create_access', denied)
+    with pytest.raises(TransferRefusal) as raised:
+        observer.observe(parent / 'Demo', archives=())
+    assert raised.value.code == 'DESTINATION_NOT_WRITABLE'
+
+
+def test_mount_disappearance_latches_live_tree_until_closed(fat):
+    observer, parent, *_ = fat
+    value = observer.observe(parent / 'Demo', archives=())
+    with module.Fat32Tree(parent) as tree:
+        original = tree._mount_ids
+        tree._mount_ids = lambda: frozenset()
+        with pytest.raises(TransferRefusal) as raised:
+            observer.recheck(tree, value)
+        assert raised.value.code == 'WAITING_DESTINATION'
+        tree._mount_ids = original
+        with pytest.raises(TransferRefusal, match='attachment was lost'):
+            observer.recheck(tree, value)

--- a/tests/test_slice_fat32_observation.py
+++ b/tests/test_slice_fat32_observation.py
@@ -177,7 +177,9 @@ def test_utf8_mount_flag_is_required_by_qualified_codec_profile(fat):
     assert raised.value.code == 'FILESYSTEM_UNSUPPORTED'
 
 
-@pytest.mark.parametrize('option', ['uid=99999', 'dmask=0000', 'fmask=0002', 'dmask=bad'])
+@pytest.mark.parametrize('option', ['uid=99999', 'dmask=0000', 'fmask=0002', 'dmask=bad',
+                                  'fmask=0477', 'fmask=0277', 'dmask=0477',
+                                  'dmask=0277', 'dmask=0177'])
 def test_mount_permissions_refuse_without_changing_anything(fat, option):
     observer, parent, state, *_ = fat
     key = option.split('=', 1)[0]
@@ -186,6 +188,15 @@ def test_mount_permissions_refuse_without_changing_anything(fat, option):
     with pytest.raises(TransferRefusal) as error:
         observer.observe(parent / 'Demo', archives=())
     assert error.value.code == 'DESTINATION_NOT_WRITABLE'
+    assert not (parent / 'Demo').exists()
+
+
+@pytest.mark.parametrize('fmask,dmask', [('0077', '0077'), ('0177', '0077')])
+def test_masks_preserving_required_owner_permissions_are_admitted(fat, fmask, dmask):
+    observer, parent, state, *_ = fat
+    state['options'] = state['options'].replace('fmask=0022', 'fmask=' + fmask).replace(
+        'dmask=0022', 'dmask=' + dmask)
+    observer.observe(parent / 'Demo', archives=())
     assert not (parent / 'Demo').exists()
 
 
@@ -309,12 +320,14 @@ def test_new_archive_role_is_checked_at_recheck(fat):
             observer.recheck(tree, value, archives=(SimpleNamespace(serial='USB-SERIAL'),))
 
 
-def test_permission_mask_change_during_live_attempt_is_revalidated(fat):
+@pytest.mark.parametrize('key,mask,detail', [
+    ('dmask', '0000', 'exclude group/other writes'), ('fmask', '0477', 'preserve owner')])
+def test_permission_mask_change_during_live_attempt_is_revalidated(fat, key, mask, detail):
     observer, parent, state, *_ = fat
     value = observer.observe(parent / 'Demo', archives=())
-    state['options'] = state['options'].replace('dmask=0022', 'dmask=0000')
+    state['options'] = state['options'].replace(key + '=0022', key + '=' + mask)
     with module.Fat32Tree(parent) as tree:
-        with pytest.raises(TransferRefusal, match='exclude group/other writes'):
+        with pytest.raises(TransferRefusal, match=detail):
             observer.recheck(tree, value)
 
 

--- a/tests/test_slice_fat32_operator.py
+++ b/tests/test_slice_fat32_operator.py
@@ -1,0 +1,278 @@
+"""FAT assembly on synthetic evidence and disposable Linux directories, not kernel FAT qualification."""
+from dataclasses import replace
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import fat32_operator as fat, folder_operator as folder, operator, state, transaction as t
+from modelark.slice.fat32_observation import Fat32FolderEvidence, Fat32Tree
+from modelark.slice.folder_contract import CapacityObservation
+from test_slice_transaction import DATA, Sources, proposal
+
+
+@pytest.fixture
+def setup(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "HOST_STATE_DIR", tmp_path / "private")
+    parent = tmp_path / "exports"
+    parent.mkdir(mode=0o700)
+    _, _, snapshot = proposal()
+    fixture = SimpleNamespace(parent=parent, catalog=tmp_path / "catalog.sqlite", snapshot=snapshot,
+                              calls=[], backing=("filesystem:fixture-uuid", "serial:fixture-disk"),
+                              available=None, source_status={})
+
+    class Observer:
+        def observe(self, destination, *, archives, protected_paths=()):
+            destination = Path(destination)
+            fixture.calls.append((destination, protected_paths))
+            if destination.exists():
+                raise t.TransferRefusal("OUTPUT_COLLISION")
+            with Fat32Tree(destination.parent) as tree:
+                capacity = os.fstatvfs(tree.fd)
+                available = (capacity.f_bavail * capacity.f_frsize
+                             if fixture.available is None else fixture.available)
+                return Fat32FolderEvidence(str(destination.parent), str(destination), "fixture-uuid",
+                                           "fixture-scope:" + str(tmp_path), (), destination.name,
+                                           fixture.backing, tree.mount_id, "fixture-major-minor",
+                                           CapacityObservation(available, None), 255, capacity.f_frsize)
+
+        def recheck(self, tree, evidence, **kwargs):
+            tree.check()
+            available = (evidence.capacity.available_bytes
+                         if fixture.available is None else fixture.available)
+            return replace(evidence, capacity=CapacityObservation(available, None))
+
+    def sources(*args):
+        result = Sources(fixture.snapshot, t)
+        result.status.update(fixture.source_status)
+        return result
+
+    monkeypatch.setattr(folder, "_filesystem_type", lambda parent: "vfat")
+    monkeypatch.setattr(fat, "Fat32FolderObserver", Observer)
+    monkeypatch.setattr(fat, "read_catalog", lambda *args: fixture.snapshot)
+    monkeypatch.setattr(folder, "read_catalog", lambda *args: fixture.snapshot)
+    monkeypatch.setattr(operator, "read_catalog", lambda *args: fixture.snapshot)
+    monkeypatch.setattr(operator, "_archives", lambda *args: ())
+    monkeypatch.setattr(fat, "FencedSources", sources)
+    monkeypatch.setattr(folder, "NativeFolderObserver", lambda: pytest.fail("FAT plan entered native observer"))
+    monkeypatch.setattr(operator, "LinuxObserver", lambda: pytest.fail("FAT plan entered legacy USB observer"))
+    return fixture
+
+
+def preview(setup, child="delivery"):
+    return operator.preview(setup.catalog, setup.parent / child, ("org/model",), None)
+
+
+def approved(setup, child="delivery"):
+    result = preview(setup, child)
+    operator.approve(result["transaction_id"], result["seal"])
+    return result
+
+
+def test_preview_and_approve_only_write_private_state(setup):
+    result = approved(setup)
+    assert list(setup.parent.iterdir()) == []
+    assert result["ownership"] == "new-output-folder-only"
+    assert result["parent_continuity"] == "fresh-at-start-not-persistently-identified"
+    assert result["resume_policy"] == "new-root-after-any-ended-attempt"
+    assert result["capacity_policy"] == "advisory-shared-space-not-reserved"
+    assert result["executable"] is False
+    assert setup.calls
+    assert not state.Store().attempt_consumed(result["transaction_id"])
+
+
+@pytest.mark.parametrize("point", ["open", "recheck", "close"])
+def test_preview_io_failure_is_structured_without_output(setup, monkeypatch, point):
+    original = fat.Fat32Tree
+
+    class FailingTree(original):
+        def __init__(self, *args, **kwargs):
+            if point == "open":
+                raise OSError("synthetic preview reopen failure")
+            super().__init__(*args, **kwargs)
+
+        def __exit__(self, *args):
+            super().__exit__(*args)
+            if point == "close":
+                raise OSError("synthetic preview close failure")
+
+    monkeypatch.setattr(fat, "Fat32Tree", FailingTree)
+    if point == "recheck":
+        def fail(*args, **kwargs):
+            raise OSError("synthetic preview recheck failure")
+        monkeypatch.setattr(fat.Fat32FolderObserver, "recheck", fail)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_UNPROVEN"):
+        preview(setup)
+    assert not list(setup.parent.iterdir())
+
+
+def test_complete_export_receipt_and_control_stay_inside_child(setup, monkeypatch):
+    result = approved(setup)
+    (setup.parent / "unrelated").write_bytes(b"untouched")
+    done = operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    assert done["state"] == "complete" and done["ok"] and not done["can_write"]
+    assert done["new_root_required"] is False
+    child = setup.parent / "delivery"
+    assert (child / "org/model/model.safetensors").read_bytes() == DATA
+    assert (child / ".modelark-slice-owner").exists()
+    assert not (setup.parent / ".modelark-slice-owner").exists()
+    receipt = json.loads((child / ".modelark-slice-receipt.json").read_text())
+    assert receipt["status"] == "export-verified"
+    assert receipt["host_transaction_completion"] == "not-claimed"
+    assert (setup.parent / "unrelated").read_bytes() == b"untouched"
+    monkeypatch.setattr(fat, "Fat32FolderObserver", lambda: pytest.fail("completed Start observed destination"))
+    assert operator.start(result["transaction_id"], "/absent", {})["state"] == "complete"
+
+
+def test_unapproved_plan_refuses_before_observation(setup, monkeypatch):
+    result = preview(setup)
+    monkeypatch.setattr(fat, "Fat32FolderObserver", lambda: pytest.fail("unapproved Start observed destination"))
+    with pytest.raises(t.TransferRefusal, match="APPROVAL_MISSING"):
+        operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    assert not list(setup.parent.iterdir())
+
+
+def test_incorrect_seal_cannot_approve_or_create_output(setup):
+    result = preview(setup)
+    with pytest.raises(t.TransferRefusal, match="PREVIEW_STALE"):
+        operator.approve(result["transaction_id"], "0" * 64)
+    assert state.Store().status(result["transaction_id"]).state == "ready"
+    assert not list(setup.parent.iterdir())
+
+
+@pytest.mark.parametrize("substitution", ["path", "backing"])
+def test_start_refuses_unapproved_path_or_backing_without_consumption(setup, substitution):
+    result = approved(setup)
+    destination = setup.parent / "delivery"
+    if substitution == "path":
+        destination = setup.parent / "other"
+    else:
+        setup.backing = ("filesystem:fixture-uuid", "serial:different-disk")
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CHANGED"):
+        operator.start(result["transaction_id"], destination, {})
+    assert not state.Store().attempt_consumed(result["transaction_id"])
+    assert not list(setup.parent.iterdir())
+
+
+def test_parent_replacement_between_preview_and_start_is_allowed_with_same_path_backing(setup):
+    result = approved(setup)
+    old_identity = setup.parent.stat().st_ino
+    setup.parent.rename(setup.parent.with_name("old-exports"))
+    setup.parent.mkdir(mode=0o700)
+    assert setup.parent.stat().st_ino != old_identity
+    assert operator.start(result["transaction_id"], setup.parent / "delivery", {})["state"] == "complete"
+    assert not list(setup.parent.with_name("old-exports").iterdir())
+
+
+def test_new_root_collision_after_approval_is_preserved_without_attempt(setup):
+    result = approved(setup)
+    child = setup.parent / "delivery"
+    child.mkdir(mode=0o700)
+    (child / "foreign").write_bytes(b"keep")
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+        operator.start(result["transaction_id"], child, {})
+    assert (child / "foreign").read_bytes() == b"keep"
+    assert not state.Store().attempt_consumed(result["transaction_id"])
+
+
+def test_stop_requires_fresh_transaction_and_different_folder(setup, monkeypatch):
+    result = approved(setup)
+    original_run = t.Session.run
+    def stopped(session):
+        session.store.request_stop(session.transaction_id)
+        return original_run(session)
+    with monkeypatch.context() as patch:
+        patch.setattr(t.Session, "run", stopped)
+        outcome = operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    assert outcome["state"] == "stopped" and outcome["new_root_required"]
+    assert outcome["ok"]  # The graceful Stop request was acknowledged successfully.
+    with pytest.raises(t.TransferRefusal, match="FAT32_NEW_ROOT_REQUIRED"):
+        operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    new = approved(setup, "fresh-delivery")
+    assert operator.start(new["transaction_id"], setup.parent / "fresh-delivery", {})["state"] == "complete"
+    assert (setup.parent / "delivery/.modelark-slice-owner").exists()
+
+
+def test_keyboard_interrupt_reports_non_success_and_requires_new_root(setup, monkeypatch):
+    result = approved(setup)
+    def interrupted(session):
+        raise KeyboardInterrupt
+    monkeypatch.setattr(t.Session, "run", interrupted)
+    outcome = operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    assert not outcome["ok"] and not outcome["can_write"]
+    assert outcome["stop_requested"] and outcome["new_root_required"]
+    with pytest.raises(t.TransferRefusal, match="FAT32_NEW_ROOT_REQUIRED"):
+        operator.start(result["transaction_id"], setup.parent / "delivery", {})
+
+
+@pytest.mark.parametrize("point", ["directory_intent", "chunk_written"])
+@pytest.mark.parametrize("error", [KeyboardInterrupt, RuntimeError])
+def test_abort_inside_engine_records_ended_state_before_lease_drop(setup, monkeypatch, point, error):
+    result = approved(setup)
+    original_start = t.start
+    def abort(current):
+        if current == point:
+            raise error("synthetic engine abort")
+    monkeypatch.setattr(t, "start", lambda *args, **kwargs: original_start(*args, **kwargs, fault=abort))
+    if error is KeyboardInterrupt:
+        outcome = operator.start(result["transaction_id"], setup.parent / "delivery", {})
+        assert not outcome["ok"] and outcome["new_root_required"] and outcome["stop_requested"]
+    else:
+        with pytest.raises(RuntimeError, match="synthetic engine abort"):
+            operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    store = state.Store()
+    assert store.status(result["transaction_id"]).state == "stopped"
+    assert operator.status(result["transaction_id"])["state"] == "stopped"
+    if error is KeyboardInterrupt:
+        with store._connection(write=False) as con:
+            serial, acknowledged = con.execute(
+                "SELECT stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?",
+                (result["transaction_id"],)).fetchone()
+        assert serial == acknowledged and serial > 0
+    with pytest.raises(t.TransferRefusal, match="FAT32_NEW_ROOT_REQUIRED"):
+        operator.start(result["transaction_id"], setup.parent / "delivery", {})
+
+
+def test_consumed_intent_refuses_before_destination_observation(setup, monkeypatch):
+    result = approved(setup)
+    setup.source_status["drive-a"] = "WAITING_SOURCE"
+    outcome = operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    assert outcome["state"] == "waiting_source" and outcome["new_root_required"]
+    assert not outcome["ok"]
+    monkeypatch.setattr(fat, "Fat32FolderObserver", lambda: pytest.fail("consumed intent observed destination"))
+    with pytest.raises(t.TransferRefusal, match="FAT32_NEW_ROOT_REQUIRED"):
+        operator.start(result["transaction_id"], setup.parent / "delivery", {})
+
+
+def test_insufficient_fresh_capacity_before_claim_does_not_consume_attempt(setup):
+    result = approved(setup)
+    setup.available = 0
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_WAIT"):
+        operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    assert not state.Store().attempt_consumed(result["transaction_id"])
+    assert not (setup.parent / "delivery").exists()
+    setup.available = None
+    assert operator.start(result["transaction_id"], setup.parent / "delivery", {})["state"] == "complete"
+
+
+def test_capacity_wait_after_claim_consumes_attempt_and_returns_new_root_policy(setup, monkeypatch):
+    result = approved(setup)
+    def wait(*args):
+        raise t.TransferRefusal("DESTINATION_CAPACITY_WAIT")
+    monkeypatch.setattr(fat.Fat32Destination, "check", wait)
+    outcome = operator.start(result["transaction_id"], setup.parent / "delivery", {})
+    assert outcome["state"] == "waiting_destination" and outcome["new_root_required"]
+    assert not outcome["ok"] and not outcome["can_write"]
+    assert state.Store().attempt_consumed(result["transaction_id"])
+    assert not (setup.parent / "delivery").exists()
+
+
+def test_source_gap_returns_before_filesystem_hint_or_destination_observation(setup, monkeypatch):
+    setup.snapshot = replace(setup.snapshot, copies=())
+    monkeypatch.setattr(folder, "_filesystem_type", lambda *args: pytest.fail("source gap probed filesystem"))
+    monkeypatch.setattr(fat, "Fat32FolderObserver", lambda: pytest.fail("source gap observed destination"))
+    outcome = preview(setup)
+    assert outcome["state"] == "blocked" and not outcome["ok"] and outcome["gaps"]
+    assert not list(setup.parent.iterdir())

--- a/tests/test_slice_fat32_plan.py
+++ b/tests/test_slice_fat32_plan.py
@@ -1,0 +1,254 @@
+"""Pure FAT32 path/backing intent and reporting contracts; no device IO."""
+from dataclasses import asdict, replace
+import hashlib
+import json
+
+import pytest
+
+from modelark.slice import domain as d, fat32_layout as layout
+from modelark.slice.fat32_plan import Fat32Binding, Fat32Intent, Fat32Plan, binding_for, estimate_metadata
+from modelark.slice.folder_contract import CapacityObservation, FolderProfile, FolderTarget
+from modelark.slice.folder_plan import NativePlan
+from modelark.slice.transaction import TransferPlan, TransferRefusal
+from test_slice_domain import facts, spec
+from test_slice_folder_plan import plan as native_plan
+
+
+def intent(**changes):
+    values = dict(profile=FolderProfile.FAT32_SESSION, filesystem_scope="fat32-fs:disk:uuid",
+                  parent_parts=("exports",), child_name="delivery")
+    values.update(changes)
+    return Fat32Intent(**values)
+
+
+def plan(**changes):
+    binding = binding_for(intent(), "/catalog/catalog.sqlite", "/media/USB/exports", ("serial:disk",))
+    proposal = d.preview(replace(spec(d), destination_id=binding.device_id,
+                                 destination_root=binding.target.child_name), facts(d))
+    values = dict(proposal=proposal, destination=binding, catalog="/catalog/catalog.sqlite",
+                  parent_path="/media/USB/exports", backing_ids=("serial:disk",),
+                  capacity=CapacityObservation(1_000_000, None, 4096), metadata_reserve_bytes=256 * 1024)
+    values.update(changes)
+    return Fat32Plan(**values)
+
+
+def proposal_with_files(original, files):
+    closure = tuple(replace(original.proposal.closure[0], rfilename=name, size_bytes=size)
+                    for name, size in files)
+    changed = replace(original.proposal, closure=closure)
+    return replace(changed, seal=hashlib.sha256(changed.canonical_bytes()).hexdigest())
+
+
+def test_intent_roundtrip_is_path_backing_only_not_saved_live_ownership():
+    original = intent()
+    restored = Fat32Intent.from_json(original.to_json())
+    assert restored == original
+    assert restored.target_id == original.target_id
+    assert restored.parts == ("exports", "delivery")
+    assert not hasattr(restored, "parent_identity")
+    assert not hasattr(restored, "parent_token")
+    assert set(asdict(restored)) == {"profile", "filesystem_scope", "parent_parts", "child_name"}
+    assert json.loads(restored.to_json())["version"] == "modelark.slice.fat32-intent.v1"
+    assert intent(parent_parts=()).parts == ("delivery",)
+
+
+@pytest.mark.parametrize("changes", [{"filesystem_scope": "other-fs"}, {"parent_parts": ("other",)},
+                                      {"child_name": "other"}, {"child_name": "DELIVERY"}])
+def test_intent_seals_reviewed_spelling_and_scope(changes):
+    assert intent(**changes).target_id != intent().target_id
+
+
+def test_intent_copies_input_components():
+    components = ["exports"]
+    original = intent(parent_parts=components)
+    components.append("changed")
+    assert original.parent_parts == ("exports",)
+
+
+@pytest.mark.parametrize("value", ["a~1", "CON", "trailing.", "a/b", "café", "", None, ".."])
+def test_intended_fat_parent_and_child_components_use_candidate_grammar(value):
+    for changes in ({"parent_parts": (value,)}, {"child_name": value}):
+        with pytest.raises(TransferRefusal, match="DESTINATION_LAYOUT_UNSUPPORTED"):
+            intent(**changes)
+
+
+@pytest.mark.parametrize("changes", [
+    {"profile": FolderProfile.NATIVE_EXT4}, {"profile": "unknown"}, {"profile": None},
+    {"parent_parts": "exports"}, {"parent_parts": None}, {"filesystem_scope": ""},
+    {"filesystem_scope": " scope"}, {"filesystem_scope": "scope\0"},
+])
+def test_intent_invalid_shapes_refuse(changes):
+    with pytest.raises(TransferRefusal, match="FAT32_PLAN_INVALID"):
+        intent(**changes)
+
+
+@pytest.mark.parametrize("key,value", [("parent_identity", [1, 2]), ("parent_token", "a" * 32),
+                                      ("inode", 1), ("unknown", True)])
+def test_serialized_parent_identity_is_never_accepted_as_intent(key, value):
+    record = json.loads(intent().to_json())
+    record[key] = value
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        Fat32Intent.from_json(json.dumps(record))
+
+
+def test_plan_roundtrip_has_its_own_tag_and_session_only_policy():
+    original = plan()
+    restored = Fat32Plan.from_json(original.to_json())
+    assert restored == original
+    assert restored.to_json() == original.to_json()
+    assert restored.seal == original.seal
+    assert restored.version == "modelark.slice.fat32-transaction.v1"
+    assert restored.session_only and restored.is_folder
+    assert restored.control_path == "delivery/.modelark-slice-owner"
+    assert restored.destination.device_id == restored.destination.target.target_id
+    assert restored.destination.filesystem_id == restored.destination.target.filesystem_scope
+    assert restored.destination.mount_id == restored.destination.admission_id
+    assert not hasattr(restored.destination, "available_bytes")
+
+
+def test_observation_changes_do_not_change_intent_or_stable_admission():
+    original = plan()
+    changed = replace(original, capacity=CapacityObservation(0, 0, 8192))
+    assert changed.destination == original.destination
+    assert changed.seal != original.seal
+    assert changed.required_bytes("/private/state") == (
+        original.proposal.total_bytes + original.metadata_reserve_bytes + 8192)
+
+
+@pytest.mark.parametrize("field,value", [("catalog", "/other/catalog"),
+                                        ("parent_path", "/other/exports"),
+                                        ("backing_ids", ("serial:other",))])
+def test_admission_seals_all_stable_fields(field, value):
+    original = plan()
+    with pytest.raises(TransferRefusal, match="ADMISSION_CORRUPT"):
+        replace(original, **{field: value})
+    values = dict(target=original.destination.target, catalog=original.catalog,
+                  parent_path=original.parent_path, backing_ids=original.backing_ids)
+    values[field] = value
+    assert binding_for(**values) != original.destination
+
+
+def test_profiles_and_envelope_decoders_never_ducktype_each_other():
+    original = plan()
+    for decoder in (TransferPlan.from_json, NativePlan.from_json):
+        with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+            decoder(original.to_json())
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        Fat32Plan.from_json(native_plan().to_json())
+    legacy_fat = FolderTarget(FolderProfile.FAT32_SESSION, "scope", (), "a" * 32, "delivery")
+    with pytest.raises(TransferRefusal, match="FAT32_PLAN_INVALID"):
+        binding_for(legacy_fat, "/catalog", "/exports", ("serial:disk",))
+    with pytest.raises(TransferRefusal, match="FAT32_PLAN_INVALID"):
+        Fat32Binding(legacy_fat, "fat32-folder-v1:" + "a" * 64)
+
+
+@pytest.mark.parametrize("identifier", [None, "", "fat32-folder-v1:", "fat32-folder-v1:" + "A" * 64,
+                                       "native-folder-v1:" + "a" * 64])
+def test_binding_requires_exact_fat_tag(identifier):
+    with pytest.raises(TransferRefusal, match="FAT32_PLAN_INVALID"):
+        Fat32Binding(intent(), identifier)
+
+
+@pytest.mark.parametrize("changes", [{"proposal": None}, {"destination": None}, {"capacity": {}},
+                                      {"metadata_reserve_bytes": True}, {"metadata_reserve_bytes": -1},
+                                      {"metadata_reserve_bytes": 1.0}, {"version": "other"}])
+def test_plan_typed_fields_and_version_required(changes):
+    with pytest.raises(TransferRefusal, match="FAT32_PLAN_INVALID"):
+        plan(**changes)
+
+
+def test_closure_must_match_intent_and_be_verified_source_ready():
+    original = plan()
+    for changes in ({"destination_id": "other"}, {"destination_root": "other"}):
+        proposal = d.preview(replace(original.proposal.spec, **changes), facts(d))
+        with pytest.raises(TransferRefusal, match="DESTINATION_CHANGED"):
+            replace(original, proposal=proposal)
+    blocked = d.preview(original.proposal.spec, replace(facts(d), copies=()))
+    with pytest.raises(TransferRefusal, match="PREVIEW_BLOCKED"):
+        replace(original, proposal=blocked)
+    with pytest.raises(d.SliceRefusal, match="PREVIEW_TAMPERED"):
+        replace(original, proposal=replace(original.proposal, seal="b" * 64))
+
+
+@pytest.mark.parametrize("files", [(("a.bin", 1), ("A.bin", 1)), (("a", 1), ("a/b", 1)),
+                                   (("a~1.bin", 1),), (("CON.bin", 1),), (("café.bin", 1),),
+                                   (("large.bin", 1 << 32),)])
+def test_plan_admits_entire_fat_tree_not_only_binding(files):
+    original = plan()
+    with pytest.raises(TransferRefusal, match="DESTINATION_LAYOUT_UNSUPPORTED"):
+        replace(original, proposal=proposal_with_files(original, files))
+
+
+def test_exact_control_and_report_sizes_are_admitted(monkeypatch):
+    original = plan()
+    seen = []
+    original_admit = layout.admit_layout
+    def record(files, **options):
+        seen.append(options)
+        return original_admit(files, **options)
+    monkeypatch.setattr(layout, "admit_layout", record)
+    original.required_bytes("/private/state")
+    control_size, receipt_size = original._metadata_sizes("/private/state")
+    assert seen[-1]["control_size"] == control_size
+    assert seen[-1]["receipt_size"] == receipt_size
+    assert control_size > 0 and receipt_size > control_size
+    # Reduce the qualified bound to test oversized report rejection without a huge allocation.
+    monkeypatch.setattr(layout, "MAX_FILE_BYTES", receipt_size - 1)
+    with pytest.raises(TransferRefusal, match="DESTINATION_LAYOUT_UNSUPPORTED"):
+        original.required_bytes("/private/state")
+
+
+def test_metadata_reserve_required_and_estimate_covers_actual_report():
+    original = plan(capacity=CapacityObservation(0, None))
+    with pytest.raises(TransferRefusal, match="DESTINATION_CAPACITY_UNPROVEN"):
+        replace(original, metadata_reserve_bytes=1)
+    reserve = estimate_metadata(original.proposal, original.destination, original.catalog, original.parent_path,
+                                original.backing_ids, original.capacity, "/private/state")
+    estimated = replace(original, metadata_reserve_bytes=reserve)
+    assert reserve > sum(estimated._metadata_sizes("/private/state"))
+    assert estimated.required_bytes("/private/state") > estimated.capacity.available_bytes
+
+
+def test_report_does_not_certify_host_completion_its_own_flush_or_resume():
+    original = plan()
+    report = original.receipt("a" * 32, [])
+    assert report["status"] == "export-verified"
+    assert report["host_transaction_completion"] == "not-claimed"
+    assert report["receipt_persistence"] == "not-self-certified"
+    assert report["resume_policy"] == "new-root"
+    assert report["verification"]["layout"] == "live-session-authenticated"
+    assert report["verification"]["content"] == "sha256-original-bytes"
+    assert report["destination"] == asdict(original.destination)
+    assert "archive" not in report and "physical_verification" not in report
+
+
+@pytest.mark.parametrize("location", [(), ("destination",), ("destination", "target"), ("capacity",),
+                                     ("proposal",), ("proposal", "spec")])
+def test_unknown_mixed_fields_rejected(location):
+    record = json.loads(plan().to_json())
+    current = record
+    for part in location:
+        current = current[part]
+    current["parent_identity"] = "never-authority"
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        Fat32Plan.from_json(json.dumps(record))
+
+
+@pytest.mark.parametrize("location,key", [((), "version"), (("destination",), "target"),
+                                         (("destination", "target"), "profile"), (("capacity",), "free_inodes")])
+def test_missing_fields_rejected(location, key):
+    record = json.loads(plan().to_json())
+    current = record
+    for part in location:
+        current = current[part]
+    del current[key]
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        Fat32Plan.from_json(json.dumps(record))
+
+
+@pytest.mark.parametrize("decoder", [Fat32Intent.from_json, Fat32Plan.from_json])
+@pytest.mark.parametrize("payload", ["null", "[]", "{}", "bad-json", None,
+                                    '{"version":1,"version":2}', '{"version":Infinity}'])
+def test_malformed_or_duplicate_json_refuses(decoder, payload):
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        decoder(payload)

--- a/tests/test_slice_fat32_public_gate.py
+++ b/tests/test_slice_fat32_public_gate.py
@@ -1,0 +1,20 @@
+"""Sealed FAT plans route only to their dedicated public assembly."""
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import fat32_operator, operator, transaction as t
+
+
+@pytest.mark.parametrize("state", ["approved", "starting", "stopped", "waiting_destination"])
+def test_public_fat_start_routes_by_sealed_plan(monkeypatch, state):
+    plan = SimpleNamespace(session_only=True, is_folder=True)
+    store = SimpleNamespace(load=lambda tx: plan, status=lambda tx: t.Status(tx, state))
+    monkeypatch.setattr(operator, "_store", lambda: store)
+    calls = []
+    def start(*args):
+        calls.append(args)
+        return {"ok": True, "state": "observed"}
+    monkeypatch.setattr(fat32_operator, "start", start)
+    assert operator.start("tx", "/unused/not-opened", {}) == {"ok": True, "state": "observed"}
+    assert calls == [(store, "tx", plan, "/unused/not-opened", {})]

--- a/tests/test_slice_fat32_transactions.py
+++ b/tests/test_slice_fat32_transactions.py
@@ -1,0 +1,432 @@
+"""FAT session policy/port fault matrix on disposable Linux dirs, not FAT qualification."""
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+from dataclasses import replace
+import errno
+import json
+import os
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import domain as d, state, transaction as t
+from modelark.slice import fat32_destination as destination_module
+from modelark.slice.fat32_destination import Fat32Destination
+from modelark.slice.fat32_plan import Fat32Intent, Fat32Plan, binding_for, estimate_metadata
+from modelark.slice.folder_contract import CapacityObservation, FolderProfile
+from modelark.slice.linux import BoundTree
+from test_slice_transaction import DATA, Sources, proposal
+
+
+@pytest.mark.parametrize("observed,expected", [
+    ("WAITING_DESTINATION", "WAITING_DESTINATION"),
+    ("DESTINATION_CHANGED", "DESTINATION_CHANGED"),
+    ("DESTINATION_UNPROVEN", "DESTINATION_CAPACITY_WAIT"),
+    (None, "DESTINATION_CAPACITY_WAIT"),
+])
+def test_io_classification_rechecks_backing_not_only_parent(fat, observed, expected):
+    def recheck(tree):
+        tree.check()  # A removed backing device can leave the mount/path intact.
+        if observed is None:
+            raise OSError(errno.EIO, "backing probe unavailable")
+        raise t.TransferRefusal(observed, "synthetic backing evidence")
+    fat.case.adapter._recheck = recheck
+    refusal = fat.case.adapter._io_refusal(OSError(errno.ENOSPC, "original allocation failure"))
+    assert refusal.code == expected
+
+
+@pytest.mark.parametrize("point", ["_live", "_open"])
+def test_reader_setup_io_failure_is_structured(fat, monkeypatch, point):
+    with t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources):
+        def fail(*args):
+            raise OSError(errno.EIO, "synthetic reader setup failure")
+        monkeypatch.setattr(fat.case.adapter, point, fail)
+        with pytest.raises(t.TransferRefusal, match="DESTINATION_IO_FAILED"):
+            with fat.case.adapter.read(fat.case.plan.control_path):
+                pytest.fail("failed reader setup yielded a stream")
+
+
+@pytest.fixture
+def fat(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "HOST_STATE_DIR", tmp_path / "private")
+    parent = tmp_path / "shared"
+    parent.mkdir(mode=0o700)
+    sibling = parent / "unrelated"
+    sibling.write_bytes(b"existing sibling")
+    store = state.Store()
+    with ExitStack() as stack:
+        tree = stack.enter_context(BoundTree(parent, writable=True))
+
+        def create(*, child="delivery", parts=(), scope=None):
+            target = Fat32Intent(FolderProfile.FAT32_SESSION, scope or "test-filesystem:" + str(tmp_path),
+                                 parts, child)
+            catalog, backing = str(tmp_path / "catalog.sqlite"), ("serial:disk-a",)
+            binding = binding_for(target, catalog, str(parent), backing)
+            original, _, snapshot = proposal()
+            preview = d.preview(replace(original.spec, destination_id=target.target_id,
+                                        destination_root=child), snapshot)
+            capacity = CapacityObservation(64 * 1024 * 1024, None, 0)
+            reserve = estimate_metadata(preview, binding, catalog, str(parent), backing,
+                                        capacity, store.root)
+            plan = Fat32Plan(preview, binding, catalog, str(parent), backing, capacity, reserve)
+            approval = d.approve(preview, expected_seal=preview.seal, current_snapshot=snapshot)
+            tx = store.create(plan, approval)
+            store.approve(tx, expected_seal=plan.seal)
+            adapter = stack.enter_context(Fat32Destination(tree, binding, store, tx,
+                                                           recheck=lambda tree: None))
+            return SimpleNamespace(plan=plan, tx=tx, adapter=adapter, sources=Sources(snapshot, t))
+
+        yield SimpleNamespace(parent=parent, sibling=sibling, tree=tree, store=store,
+                              create=create, case=create())
+
+
+def run(fat, case=None, *, fault=None):
+    case = case or fat.case
+    with t.start(fat.store, case.tx, case.adapter, case.sources, fault=fault) as session:
+        return session.run()
+
+
+def consumed(fat):
+    with fat.store._connection(write=False) as con:
+        return con.execute("SELECT consumed_attempt FROM transactions WHERE id=?",
+                           (fat.case.tx,)).fetchone()[0]
+
+
+def assert_restart_refused(fat):
+    before = consumed(fat)
+    assert isinstance(before, str) and before
+    with pytest.raises(t.TransferRefusal, match="FAT32_NEW_ROOT_REQUIRED"):
+        t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources)
+    assert consumed(fat) == before
+
+
+def test_live_session_exports_verified_bytes_and_metadata_without_xattrs(fat, monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("FAT session must not depend on xattrs")
+    monkeypatch.setattr(os, "getxattr", forbidden)
+    monkeypatch.setattr(os, "setxattr", forbidden)
+    original = fat.case.sources.snapshot
+    assert run(fat).state == "complete"
+    child = fat.parent / "delivery"
+    assert (child / "org/model/model.safetensors").read_bytes() == DATA
+    receipt = json.loads((child / ".modelark-slice-receipt.json").read_text())
+    assert receipt == fat.store.receipt(fat.case.tx)
+    assert Fat32Plan.from_json(json.dumps(receipt["plan"])) == fat.case.plan
+    assert receipt["status"] == "export-verified"
+    assert receipt["resume_policy"] == "new-root"
+    assert receipt["host_transaction_completion"] == "not-claimed"
+    assert receipt["receipt_persistence"] == "not-self-certified"
+    assert not (fat.parent / ".modelark-slice-owner").exists()
+    assert fat.sibling.read_bytes() == b"existing sibling"
+    assert fat.case.sources.snapshot == original
+    assert consumed(fat)
+
+
+def test_unrelated_sibling_activity_does_not_break_session(fat):
+    def change_sibling(point):
+        if point == "chunk_written":
+            fat.sibling.write_bytes(b"unrelated" * 4096)
+            (fat.parent / "another-sibling").mkdir()
+    assert run(fat, fault=change_sibling).state == "complete"
+    assert fat.sibling.read_bytes() == b"unrelated" * 4096
+
+
+def test_stop_consumes_attempt_preserves_partial_tree_and_requires_new_root(fat):
+    def stop(point):
+        if point == "chunk_written":
+            fat.store.request_stop(fat.case.tx)
+    assert run(fat, fault=stop).state == "stopped"
+    partials = tuple((fat.parent / "delivery/org/model").glob(".slice-*"))
+    assert len(partials) == 1 and partials[0].read_bytes() == DATA
+    assert_restart_refused(fat)
+    sibling = fat.create(child="fresh-delivery")
+    assert run(fat, sibling).state == "complete"
+    assert partials[0].read_bytes() == DATA
+    assert fat.store.receipt(fat.case.tx) is None
+
+
+def test_fresh_store_and_port_cannot_recover_stopped_output_from_saved_intent(fat):
+    case = fat.case
+    with t.start(fat.store, case.tx, case.adapter, case.sources):
+        pass
+    before = consumed(fat)
+    fat.store = state.Store()
+    with Fat32Destination(fat.tree, case.plan.destination, fat.store, case.tx,
+                          recheck=lambda tree: None) as reopened:
+        case.adapter = reopened
+        assert_restart_refused(fat)
+    assert consumed(fat) == before
+
+
+def test_duplicate_start_observes_live_attempt_without_spending_or_closing_it(fat):
+    case = fat.case
+    with t.start(fat.store, case.tx, case.adapter, case.sources) as session:
+        before = consumed(fat)
+        duplicate = t.start(fat.store, case.tx, case.adapter, case.sources)
+        assert not duplicate.can_write
+        assert consumed(fat) == before
+        assert session.can_write
+        assert session.run().state == "complete"
+
+
+@pytest.mark.parametrize("source_code,expected_state", [("WAITING_SOURCE", "waiting_source"),
+                                                       ("SOURCE_CHANGED", "blocked_source")])
+def test_source_wait_or_block_ends_attempt_without_resume(fat, source_code, expected_state):
+    fat.case.sources.status["drive-a"] = source_code
+    with t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources) as session:
+        assert session.run().state == expected_state
+        assert not session.can_write
+    fat.case.sources.status.clear()
+    assert_restart_refused(fat)
+
+
+@pytest.mark.parametrize("code", ["WAITING_DESTINATION", "DESTINATION_CAPACITY_WAIT"])
+def test_destination_wait_ends_attempt_without_resume(fat, monkeypatch, code):
+    case = fat.case
+    with t.start(fat.store, case.tx, case.adapter, case.sources) as session:
+        original = case.adapter.check
+        def wait(*args, **kwargs):
+            raise t.TransferRefusal(code)
+        monkeypatch.setattr(case.adapter, "check", wait)
+        assert session.run().state == "waiting_destination"
+        assert not session.can_write
+        monkeypatch.setattr(case.adapter, "check", original)
+        with pytest.raises(t.TransferRefusal):
+            case.adapter.create_directory("delivery/late", "a" * 32)
+    assert_restart_refused(fat)
+
+
+@pytest.mark.parametrize("code", [errno.ENOSPC, errno.EDQUOT])
+def test_actual_partial_capacity_write_preserved_but_cannot_resume(fat, monkeypatch, code):
+    original_write = os.write
+    armed, partial = False, False
+    def fail_after_partial(fd, data):
+        nonlocal partial
+        if armed:
+            if not partial:
+                partial = True
+                return original_write(fd, data[:3])
+            raise OSError(code, "synthetic capacity failure")
+        return original_write(fd, data)
+    def arm(point):
+        nonlocal armed
+        if point == "temporary_created":
+            armed = True
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "write", fail_after_partial)
+        assert run(fat, fault=arm).state == "waiting_destination"
+    partials = tuple((fat.parent / "delivery/org/model").glob(".slice-*"))
+    assert len(partials) == 1 and partials[0].read_bytes() == DATA[:3]
+    assert_restart_refused(fat)
+    assert partials[0].read_bytes() == DATA[:3]
+
+
+def test_consumption_before_first_directory_survives_failed_admission(fat, monkeypatch):
+    original = fat.case.adapter.check
+    def wait(*args, **kwargs):
+        raise t.TransferRefusal("WAITING_DESTINATION")
+    monkeypatch.setattr(fat.case.adapter, "check", wait)
+    with pytest.raises(t.TransferRefusal, match="WAITING_DESTINATION"):
+        run(fat)
+    assert not (fat.parent / "delivery").exists()
+    monkeypatch.setattr(fat.case.adapter, "check", original)
+    assert_restart_refused(fat)
+
+
+FAULTS = ["reserved", "directory_intent", "directory_created", "directory_flushed",
+          "directory_parent_flushed", "directory_complete", "temporary_created", "chunk_written"]
+FAULTS += [kind + "_" + phase for kind in ("control", "file", "receipt")
+           for phase in ("intent", "flushed", "prepared", "published", "parent_flushed", "complete")]
+FAULTS += [kind + "_" + phase for kind in ("control", "receipt") for phase in ("created", "chunk_written")]
+
+
+@pytest.mark.parametrize("point", FAULTS)
+def test_every_post_claim_fault_leaves_consumed_nonresumable_attempt(fat, point):
+    reached = False
+    def crash(current):
+        nonlocal reached
+        if current == point:
+            reached = True
+            raise RuntimeError("synthetic fault: " + point)
+    with pytest.raises(RuntimeError, match="synthetic fault"):
+        run(fat, fault=crash)
+    assert reached
+    assert_restart_refused(fat)
+    assert fat.store.receipt(fat.case.tx) is None
+    assert fat.sibling.read_bytes() == b"existing sibling"
+
+
+def test_failure_before_claim_has_not_consumed_attempt(fat):
+    def crash(point):
+        if point == "reservation_committed":
+            raise RuntimeError("before claim")
+    with pytest.raises(RuntimeError, match="before claim"):
+        run(fat, fault=crash)
+    assert not consumed(fat)
+    assert not (fat.parent / "delivery").exists()
+    assert run(fat).state == "complete"
+
+
+@pytest.mark.parametrize("operation", ["receipt_journal", "host_complete"])
+def test_host_commit_failure_never_relabels_export_report_as_host_commit(fat, monkeypatch, operation):
+    original = fat.store.append if operation == "receipt_journal" else fat.store.complete
+    def fail(*args, **kwargs):
+        if operation == "host_complete" or args[1] == "receipt":
+            raise t.TransferRefusal("STATE_BUSY", "synthetic host commit refusal")
+        return original(*args, **kwargs)
+    monkeypatch.setattr(fat.store, "append" if operation == "receipt_journal" else "complete", fail)
+    with pytest.raises(t.TransferRefusal, match="STATE_BUSY"):
+        run(fat)
+    report = json.loads((fat.parent / "delivery/.modelark-slice-receipt.json").read_text())
+    assert report["status"] == "export-verified"
+    assert fat.store.status(fat.case.tx).state != "complete"
+    assert_restart_refused(fat)
+
+
+def test_old_port_cannot_mutate_after_session_close_even_if_port_context_is_open(fat):
+    case = fat.case
+    with t.start(fat.store, case.tx, case.adapter, case.sources):
+        pass
+    with pytest.raises(t.TransferRefusal):
+        case.adapter.create_directory("delivery/late", "a" * 32)
+    assert not (fat.parent / "delivery/late").exists()
+    assert_restart_refused(fat)
+
+
+def test_live_port_cannot_append_published_artifact(fat):
+    case = fat.case
+    with t.start(fat.store, case.tx, case.adapter, case.sources) as session:
+        assert session.step().state == "transferring"
+        final = "delivery/org/model/model.safetensors"
+        token = case.adapter.inspect(final).token
+        with pytest.raises(t.TransferRefusal):
+            case.adapter.append(final, token, b"must not append")
+        assert (fat.parent / final).read_bytes() == DATA
+
+
+def test_consumer_oserror_inside_read_context_is_not_reclassified(fat):
+    case = fat.case
+    failure = OSError(errno.EIO, "consumer-owned failure, not destination I/O")
+    with t.start(fat.store, case.tx, case.adapter, case.sources) as session:
+        assert session.step().state == "transferring"
+        with pytest.raises(OSError) as caught:
+            with case.adapter.read("delivery/org/model/model.safetensors") as stream:
+                assert stream.read() == DATA
+                raise failure
+        assert caught.value is failure
+        assert session.can_write
+
+
+def test_final_retained_close_error_prevents_host_completion(fat, monkeypatch):
+    case = fat.case
+    retained, closed = set(), []
+    original_close = os.close
+    failure = OSError(errno.EIO, "final retained close reported writeback failure")
+    failed = False
+
+    def arm(point):
+        if point == "receipt_complete":
+            retained.update(obj.fd for obj in case.adapter._objects.values())
+
+    def close(fd):
+        nonlocal failed
+        original_close(fd)
+        if fd in retained:
+            closed.append(fd)
+            if not failed:
+                failed = True
+                raise failure
+
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "close", close)
+        with pytest.raises((OSError, t.TransferRefusal)) as caught:
+            run(fat, fault=arm)
+    assert caught.value is failure or getattr(caught.value, "code", None) == "DESTINATION_IO_FAILED"
+    assert failed and set(closed) == retained and len(closed) == len(retained)
+    assert case.adapter._objects == {}
+    assert fat.store.status(case.tx).state != "complete"
+    report = json.loads((fat.parent / "delivery/.modelark-slice-receipt.json").read_text())
+    assert report["status"] == "export-verified"
+    assert report["host_transaction_completion"] == "not-claimed"
+    assert_restart_refused(fat)
+
+
+@pytest.mark.parametrize("primary_failure", [False, True])
+def test_failed_close_detaches_all_handles_and_cleanup_is_never_retried(fat, monkeypatch, primary_failure):
+    case = fat.case
+    session = t.start(fat.store, case.tx, case.adapter, case.sources)
+    retained = tuple(obj.fd for obj in case.adapter._objects.values())
+    assert len(retained) >= 2
+    original_close = os.close
+    closed = []
+    failure = OSError(errno.EIO, "close released its descriptor before reporting failure")
+
+    def close(fd):
+        if fd in retained:
+            closed.append(fd)
+            original_close(fd)
+            if fd == retained[0]:
+                raise failure
+        else:
+            original_close(fd)
+
+    try:
+        with monkeypatch.context() as patch:
+            patch.setattr(os, "close", close)
+            if primary_failure:
+                try:
+                    raise RuntimeError("primary transfer failure")
+                except RuntimeError:
+                    case.adapter.end_session()  # Cleanup must not replace the active failure.
+            else:
+                with pytest.raises(OSError) as caught:
+                    case.adapter.end_session()
+                assert caught.value is failure
+            assert closed == list(retained)
+            assert case.adapter._objects == {}
+            assert case.adapter.cleanup_errors == (failure,)
+            case.adapter.end_session()
+            assert closed == list(retained)  # Released descriptor numbers are never retried.
+    finally:
+        session.close()
+
+
+def test_retained_descriptor_budget_refuses_before_binding_or_destination_writes(fat, monkeypatch):
+    monkeypatch.setattr(destination_module.resource, "getrlimit", lambda resource: (1, 1))
+    case = fat.case
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_LAYOUT_UNSUPPORTED"):
+        Fat32Destination(fat.tree, case.plan.destination, fat.store, case.tx, recheck=lambda tree: None)
+    assert not consumed(fat)
+    assert not (fat.parent / "delivery").exists()
+    assert fat.sibling.read_bytes() == b"existing sibling"
+
+
+def reserve_race(store, first, second):
+    barrier = threading.Barrier(2)
+    def reserve(case):
+        barrier.wait()
+        try:
+            store.reserve(case.tx, case.plan.destination.device_id)
+            return "reserved"
+        except t.TransferRefusal as exc:
+            return exc.code
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        return sorted(pool.map(reserve, (first, second)))
+
+
+@pytest.mark.parametrize("child,parts", [("DELIVERY", ()), ("nested", ("DELIVERY",))])
+def test_case_equivalent_or_nested_claims_race_to_one_owner(fat, child, parts):
+    other = fat.create(child=child, parts=parts)
+    assert reserve_race(fat.store, fat.case, other) == ["DESTINATION_BUSY", "reserved"]
+
+
+def test_disjoint_sibling_claims_are_permitted_and_stopped_root_stays_claimed(fat):
+    other = fat.create(child="other-delivery")
+    assert reserve_race(fat.store, fat.case, other) == ["reserved", "reserved"]
+    with t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources):
+        pass
+    overlapping = fat.create(child="DELIVERY")
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_BUSY"):
+        fat.store.reserve(overlapping.tx, overlapping.plan.destination.device_id)
+    assert run(fat, other).state == "complete"

--- a/tests/test_slice_folder_contract.py
+++ b/tests/test_slice_folder_contract.py
@@ -1,0 +1,275 @@
+"""Pure folder contract gate: no filesystem adapter or writer is enabled here."""
+from dataclasses import replace
+import json
+
+import pytest
+
+from modelark.slice.folder_contract import (
+    CapacityObservation,
+    FolderProfile,
+    FolderReview,
+    FolderTarget,
+    overlaps,
+)
+from modelark.slice.transaction import TransferPlan, TransferRefusal
+
+
+def target(**changes):
+    values = dict(profile=FolderProfile.NATIVE_EXT4, filesystem_scope="trusted-fs-key",
+                  parent_parts=("home", "operator", "exports"),
+                  parent_identity=(41, 123456789), child_name="delivery")
+    values.update(changes)
+    return FolderTarget(**values)
+
+
+def review(**changes):
+    values = dict(target=target(), closure_seal="a" * 64,
+                  capacity=CapacityObservation(1_000_000, 100, 4096))
+    values.update(changes)
+    return FolderReview(**values)
+
+
+def test_profile_values_and_explicit_resume_claims():
+    assert FolderProfile.NATIVE_EXT4.value == "native-ext4-folder.v1"
+    assert FolderProfile.FAT32_SESSION.value == "fat32-folder-session.v1"
+    assert FolderProfile.NATIVE_EXT4.resume_policy == "authenticated"
+    assert FolderProfile.FAT32_SESSION.resume_policy == "new-root"
+    assert target(profile="native-ext4-folder.v1").profile is FolderProfile.NATIVE_EXT4
+    fat = target(profile="fat32-folder-session.v1", parent_identity="b" * 32)
+    assert fat.profile is FolderProfile.FAT32_SESSION
+    assert review(target=fat).execution_ready is False
+    assert review().execution_ready is False
+
+
+def test_target_roundtrip_stable_identity_and_filesystem_relative_parts():
+    original = target()
+    restored = FolderTarget.from_json(original.to_json())
+    assert restored == original
+    assert restored.to_json() == original.to_json()
+    assert restored.target_id == original.target_id
+    assert original.parts == ("home", "operator", "exports", "delivery")
+    assert json.loads(original.to_json())["version"] == "modelark.slice.folder-target.v1"
+    assert target(parent_parts=()).parts == ("delivery",)
+
+
+@pytest.mark.parametrize("changes", [
+    {"filesystem_scope": "other-fs"},
+    {"parent_parts": ("home", "different")},
+    {"parent_identity": (42, 123456789)},
+    {"parent_identity": (41, 123456790)},
+    {"child_name": "other"},
+    {"profile": FolderProfile.FAT32_SESSION, "parent_identity": "b" * 32},
+])
+def test_target_identity_binds_scope_path_parent_and_profile(changes):
+    assert target(**changes).target_id != target().target_id
+
+
+def test_capacity_is_approval_evidence_not_target_identity():
+    original = review()
+    for capacity in (CapacityObservation(999_999, 100, 4096),
+                     CapacityObservation(1_000_000, 99, 4096),
+                     CapacityObservation(1_000_000, 100, 8192),
+                     CapacityObservation(1_000_000, None, 4096)):
+        changed = replace(original, capacity=capacity)
+        assert changed.target.target_id == original.target.target_id
+        assert changed.seal != original.seal
+    assert replace(original, closure_seal="b" * 64).seal != original.seal
+
+
+def test_review_json_roundtrip_and_seal():
+    original = review()
+    restored = FolderReview.from_json(original.to_json())
+    assert restored == original
+    assert restored.to_json() == original.to_json()
+    assert restored.seal == original.seal
+    assert len(original.seal) == 64
+    assert all(c in "0123456789abcdef" for c in original.seal)
+    assert json.loads(original.to_json())["version"] == "modelark.slice.folder-review.v1"
+    assert restored.execution_ready is False
+
+
+def test_fat_session_identity_roundtrip_and_no_resume():
+    original = target(profile=FolderProfile.FAT32_SESSION, parent_identity="0123456789abcdef" * 2)
+    assert FolderTarget.from_json(original.to_json()) == original
+    assert FolderReview.from_json(review(target=original).to_json()).target == original
+    assert original.profile.resume_policy == "new-root"
+    assert replace(original, parent_identity="c" * 32).target_id != original.target_id
+
+
+@pytest.mark.parametrize("left,right,expected", [
+    (target(), target(), True),
+    (target(), target(parent_identity=(99, 99)), True),
+    (target(), target(child_name="sibling"), False),
+    (target(), target(child_name="delivery-more"), False),
+    (target(), target(filesystem_scope="different-fs"), False),
+    (target(), target(parent_parts=("home", "operator", "exports", "delivery"),
+                      child_name="nested"), True),
+    (target(), target(parent_parts=("home", "operator", "exports", "delivery-more"),
+                      child_name="nested"), False),
+    (target(parent_parts=(), child_name="home"), target(), True),
+])
+def test_overlap_uses_component_ancestry_not_ownership_certificate(left, right, expected):
+    assert overlaps(left, right) is expected
+    assert overlaps(right, left) is expected
+
+
+def test_same_filesystem_cannot_claim_conflicting_profiles():
+    native = target()
+    fat = target(profile=FolderProfile.FAT32_SESSION, parent_identity="b" * 32)
+    for first, second in ((native, fat), (fat, native)):
+        with pytest.raises(TransferRefusal) as exc:
+            overlaps(first, second)
+        assert exc.value.code == "FOLDER_CONTRACT_INVALID"
+    assert overlaps(native, replace(fat, filesystem_scope="other-fs")) is False
+
+
+def test_fat_exact_path_ancestry_conflicts_despite_session_token_change():
+    fat = target(profile=FolderProfile.FAT32_SESSION, parent_identity="b" * 32)
+    assert overlaps(fat, replace(fat, parent_identity="c" * 32)) is True
+    child = replace(fat, parent_parts=fat.parts, child_name="nested", parent_identity="c" * 32)
+    assert overlaps(fat, child) is True
+    assert overlaps(child, fat) is True
+
+
+@pytest.mark.parametrize("child_name", ["DELIVERY", "different", "DELIVE~1", "delivery-more"])
+def test_fat_disjointness_needs_qualified_case_and_short_alias_semantics(child_name):
+    fat = target(profile=FolderProfile.FAT32_SESSION, parent_identity="b" * 32)
+    for first, second in ((fat, replace(fat, child_name=child_name)),
+                          (replace(fat, child_name=child_name), fat)):
+        with pytest.raises(TransferRefusal) as exc:
+            overlaps(first, second)
+        assert exc.value.code == "FOLDER_CONTRACT_INVALID"
+
+
+@pytest.mark.parametrize("invalid", [None, {}, "folder-target-v1:anything"])
+def test_overlap_refuses_untyped_targets(invalid):
+    with pytest.raises(TransferRefusal):
+        overlaps(target(), invalid)
+    with pytest.raises(TransferRefusal):
+        overlaps(invalid, target())
+
+
+@pytest.mark.parametrize("field,value", [
+    ("filesystem_scope", ""), ("filesystem_scope", " "),
+    ("filesystem_scope", " key"), ("filesystem_scope", "key "),
+    ("filesystem_scope", None), ("filesystem_scope", 1),
+    ("profile", "ext4"), ("profile", "exfat-folder.v1"), ("profile", None),
+    ("parent_parts", "/home/exports"), ("parent_parts", None),
+    ("parent_parts", (".",)), ("parent_parts", ("..",)),
+    ("parent_parts", ("",)), ("parent_parts", ("a/b",)),
+    ("parent_parts", ("a\\b",)), ("parent_parts", ("a\x00b",)),
+    ("parent_parts", ("a:b",)), ("parent_parts", (1,)),
+    ("parent_parts", ("\udcff",)),
+    ("child_name", ""), ("child_name", "."), ("child_name", ".."),
+    ("child_name", "/absolute"), ("child_name", "a/b"),
+    ("child_name", "a\\b"), ("child_name", "a:b"),
+    ("child_name", "a\x00b"), ("child_name", "\udcff"),
+    ("child_name", None), ("child_name", 7),
+    ("parent_identity", None), ("parent_identity", "b" * 32),
+    ("parent_identity", (0, 1)), ("parent_identity", (1, 0)),
+    ("parent_identity", (-1, 1)), ("parent_identity", (1, -1)),
+    ("parent_identity", (True, 1)), ("parent_identity", (1, False)),
+    ("parent_identity", (1.0, 2)), ("parent_identity", (1,)),
+    ("parent_identity", (1, 2, 3)),
+])
+def test_malformed_target_constructor_refuses(field, value):
+    with pytest.raises(TransferRefusal):
+        target(**{field: value})
+
+
+@pytest.mark.parametrize("identity", [None, (1, 2), "", "a" * 31, "a" * 33,
+                                      "A" * 32, "g" * 32, "a" * 31 + " "])
+def test_fat_identity_requires_retained_session_token(identity):
+    with pytest.raises(TransferRefusal):
+        target(profile=FolderProfile.FAT32_SESSION, parent_identity=identity)
+
+
+@pytest.mark.parametrize("field", ["available_bytes", "free_inodes", "headroom_bytes"])
+@pytest.mark.parametrize("value", [-1, True, False, 1.5, "1", float("inf"), float("nan")])
+def test_capacity_rejects_nonnegative_integer_impostors(field, value):
+    kwargs = dict(available_bytes=100, free_inodes=5, headroom_bytes=0)
+    kwargs[field] = value
+    with pytest.raises(TransferRefusal):
+        CapacityObservation(**kwargs)
+
+
+def test_capacity_zero_and_unknown_inodes_are_observations_not_guarantees():
+    assert CapacityObservation(0, None).headroom_bytes == 0
+    assert review(capacity=CapacityObservation(0, 0)).execution_ready is False
+    for field in ("available_bytes", "headroom_bytes"):
+        kwargs = dict(available_bytes=100, free_inodes=None, headroom_bytes=0)
+        kwargs[field] = None
+        with pytest.raises(TransferRefusal):
+            CapacityObservation(**kwargs)
+
+
+@pytest.mark.parametrize("closure_seal", [None, "", "a" * 63, "a" * 65,
+                                          "A" * 64, "g" * 64, "a" * 63 + " "])
+def test_review_requires_exact_closure_seal(closure_seal):
+    with pytest.raises(TransferRefusal):
+        review(closure_seal=closure_seal)
+
+
+@pytest.mark.parametrize("changes", [{"target": None}, {"target": {}},
+                                      {"capacity": None}, {"capacity": {}}])
+def test_review_requires_typed_contract_objects(changes):
+    with pytest.raises(TransferRefusal):
+        review(**changes)
+
+
+@pytest.mark.parametrize("factory", [target, review])
+@pytest.mark.parametrize("mutation", ["unknown", "missing", "version", "duplicate"])
+def test_json_root_schema_is_closed(factory, mutation):
+    original = factory()
+    obj = json.loads(original.to_json())
+    if mutation == "unknown":
+        obj["execution_ready"] = True
+    elif mutation == "missing":
+        del obj["version"]
+    elif mutation == "version":
+        obj["version"] = "modelark.slice.future.v99"
+    if mutation == "duplicate":
+        payload = '{"version":' + json.dumps(obj["version"]) + ',' + original.to_json()[1:]
+    else:
+        payload = json.dumps(obj)
+    with pytest.raises(TransferRefusal):
+        type(original).from_json(payload)
+
+
+@pytest.mark.parametrize("payload", ["", "{", "null", "[]", "true", "1", '"text"',
+                                    '{"x":NaN}', '{"x":Infinity}', '{"x":-Infinity}'])
+@pytest.mark.parametrize("contract", [FolderTarget, FolderReview])
+def test_malformed_json_refuses_as_contract_error(contract, payload):
+    with pytest.raises(TransferRefusal):
+        contract.from_json(payload)
+
+
+@pytest.mark.parametrize("field", ["target", "capacity"])
+def test_review_nested_json_unknown_fields_refuse(field):
+    obj = json.loads(review().to_json())
+    obj[field]["unreviewed_extension"] = True
+    with pytest.raises(TransferRefusal):
+        FolderReview.from_json(json.dumps(obj))
+
+
+def test_review_nested_duplicate_fields_refuse():
+    obj = json.loads(review().to_json())
+    encoded_capacity = json.dumps(obj["capacity"])
+    obj["capacity"] = "capacity-placeholder"
+    duplicate_capacity = '{"available_bytes":0,' + encoded_capacity[1:]
+    payload = json.dumps(obj).replace('"capacity-placeholder"', duplicate_capacity)
+    with pytest.raises(TransferRefusal):
+        FolderReview.from_json(payload)
+
+
+def test_review_nonfinite_nested_capacity_refuses():
+    obj = json.loads(review().to_json())
+    obj["capacity"]["available_bytes"] = float("nan")
+    with pytest.raises(TransferRefusal):
+        FolderReview.from_json(json.dumps(obj))
+
+
+def test_folder_review_cannot_enter_legacy_transaction_execution():
+    with pytest.raises(TransferRefusal) as exc:
+        TransferPlan.from_json(review().to_json())
+    assert exc.value.code == "STATE_CORRUPT"

--- a/tests/test_slice_folder_isolation.py
+++ b/tests/test_slice_folder_isolation.py
@@ -1,0 +1,90 @@
+"""Folder contracts cannot acquire the legacy USB writer's authority."""
+import json
+
+import pytest
+
+from modelark.slice import operator, state, transaction as t
+from modelark.slice.folder_contract import CapacityObservation, FolderProfile, FolderReview, FolderTarget
+from test_slice_transaction import proposal
+
+
+def review():
+    return FolderReview(FolderTarget(FolderProfile.NATIVE_EXT4, "qualified-filesystem", ("exports",),
+                                     (123, 456), "demo"), "a" * 64, CapacityObservation(1000000, 20))
+
+
+def legacy(version="v3"):
+    p, approval, _ = proposal()
+    binding = t.DestinationBinding("test-device", "test-filesystem", "test-mount", 1000000)
+    plan = t.TransferPlan(p, binding, "modelark.slice.transaction." + version,
+                          65536 if version == "v3" else None)
+    return plan, approval
+
+
+@pytest.mark.parametrize("version,seal", [
+    ("v1", "93d75ef078d1bab667979b70a9d08312512c6618522c8dc71c3febad92dafede"),
+    ("v2", "9462a45754c8f32cbd5d1867e6079764e1c41701871f81e86a8dac9e2ac6481e"),
+    ("v3", "45aca766c2bad8f0cfaa6f2da3fc85d5fc3ff77f383396a0a61a7a8c3de67bf0"),
+])
+def test_legacy_seals_match_reviewed_6fd87c3_baseline(version, seal):
+    plan, _ = legacy(version)
+    assert plan.seal == seal
+    decoded = t.TransferPlan.from_json(plan.to_json())
+    assert decoded.to_json() == plan.to_json()
+    assert decoded.seal == seal
+    assert decoded.receipt("fixture", []) == plan.receipt("fixture", [])
+
+
+@pytest.mark.parametrize("addition", ["target", "capacity", "profile", "created_root", "execution_ready"])
+def test_legacy_decoder_rejects_mixed_folder_fields(addition):
+    plan, _ = legacy()
+    payload = json.loads(plan.to_json())
+    payload[addition] = None
+    with pytest.raises(t.TransferRefusal, match="STATE_CORRUPT"):
+        t.TransferPlan.from_json(json.dumps(payload))
+
+
+@pytest.mark.parametrize("payload", ["[]", "null", "42", '"legacy"', '{}'])
+def test_non_envelopes_fail_with_typed_refusal(payload):
+    with pytest.raises(t.TransferRefusal, match="STATE_CORRUPT"):
+        t.TransferPlan.from_json(payload)
+
+
+def test_folder_record_cannot_be_created_in_legacy_store(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "HOST_STATE_DIR", tmp_path / "host-state")
+    store = state.Store()
+    with pytest.raises(t.TransferRefusal, match="LEGACY_PLAN"):
+        store.create(review(), None)
+    with store._connection(write=False) as con:
+        assert con.execute("SELECT COUNT(*) FROM transactions").fetchone() == (0,)
+        assert con.execute("SELECT COUNT(*) FROM owners").fetchone() == (0,)
+        assert con.execute("PRAGMA user_version").fetchone() == (8,)
+
+
+def test_injected_folder_envelope_never_reaches_destination_or_lease(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "HOST_STATE_DIR", tmp_path / "host-state")
+    store = state.Store()
+    plan, approval = legacy()
+    tx = store.create(plan, approval)
+    record = review()
+    with store._connection() as con:
+        con.execute("UPDATE transactions SET plan=?,seal=?,state='approved' WHERE id=?",
+                    (record.to_json(), record.seal, tx))
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("folder record reached a legacy runtime boundary")
+
+    monkeypatch.setattr(operator, "_store", lambda: store)
+    monkeypatch.setattr(operator, "LinuxObserver", forbidden)
+    monkeypatch.setattr(operator, "BoundTree", forbidden)
+    monkeypatch.setattr(t, "_Lease", forbidden)
+    with pytest.raises(t.TransferRefusal, match="STATE_CORRUPT"):
+        operator.start(tx, "/must-not-open", {})
+    with store._connection(write=False) as con:
+        assert con.execute("SELECT COUNT(*) FROM owners").fetchone() == (0,)
+
+
+def test_folder_review_is_not_legacy_admission():
+    plan, _ = legacy()
+    with pytest.raises(t.TransferRefusal, match="ADMISSION_CORRUPT"):
+        state.Store._validate_admission(plan, json.loads(review().to_json()))

--- a/tests/test_slice_folder_observation.py
+++ b/tests/test_slice_folder_observation.py
@@ -198,6 +198,40 @@ def test_descriptor_acl_access_error_preserves_permission_meaning(native, monkey
     assert raised.value.code == 'DESTINATION_NOT_WRITABLE'
 
 
+def test_large_inherited_acl_refuses_before_creating_output(native):
+    observer, parent, state, *_ = native
+    entries = [(1, 7, 0xffffffff)] + [(2, 7, uid) for uid in range(100000, 100200)]
+    entries += [(4, 7, 0xffffffff), (16, 7, 0xffffffff), (32, 7, 0xffffffff)]
+    state['acl'] = struct.pack('<I', 2) + b''.join(struct.pack('<HHI', *entry) for entry in entries)
+    with pytest.raises(TransferRefusal, match='xattr') as raised:
+        observer.observe(parent / 'demo', archives=())
+    assert raised.value.code == 'DESTINATION_NOT_WRITABLE'
+    assert not (parent / 'demo').exists()
+
+
+@pytest.mark.parametrize('block_size,named_users,allowed', [
+    (1024, 0, False), (2048, 1, True), (2048, 100, False), (4096, 100, True)])
+def test_marker_and_acl_budget_uses_filesystem_block_size(native, monkeypatch,
+                                                        block_size, named_users, allowed):
+    observer, parent, state, *_ = native
+    if named_users:
+        entries = [(1, 7, 0xffffffff)] + [(2, 7, uid) for uid in range(100000, 100000 + named_users)]
+        entries += [(4, 7, 0xffffffff), (16, 7, 0xffffffff), (32, 7, 0xffffffff)]
+        state['acl'] = struct.pack('<I', 2) + b''.join(struct.pack('<HHI', *entry) for entry in entries)
+    original = os.fstatvfs
+    def observed(fd):
+        value = original(fd)
+        return SimpleNamespace(f_bsize=block_size, f_frsize=block_size, f_blocks=value.f_blocks,
+                               f_bavail=value.f_bavail, f_favail=value.f_favail, f_ffree=value.f_ffree)
+    monkeypatch.setattr(os, 'fstatvfs', observed)
+    if allowed:
+        observer.observe(parent / 'demo', archives=())
+    else:
+        with pytest.raises(TransferRefusal, match='xattr'):
+            observer.observe(parent / 'demo', archives=())
+    assert not (parent / 'demo').exists()
+
+
 def test_mapped_single_parent_storage_allowed(native):
     observer, parent, state, disk, leaf = native
     leaf['type'] = 'lvm'

--- a/tests/test_slice_folder_observation.py
+++ b/tests/test_slice_folder_observation.py
@@ -1,0 +1,352 @@
+"""Synthetic native admission only: these tests do not qualify real ext4 writes."""
+import copy
+import errno
+import os
+import struct
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import folder_observation as module
+from modelark.slice.linux import BoundTree
+from modelark.slice.transaction import TransferRefusal
+
+
+@pytest.fixture
+def native(tmp_path, monkeypatch):
+    parent = tmp_path / 'exports'
+    parent.mkdir(mode=0o700)
+    with BoundTree(parent) as tree:
+        info = os.fstat(tree.fd)
+        key = f'{os.major(info.st_dev)}:{os.minor(info.st_dev)}'
+        mount_id = tree.mount_id
+    leaf = {'path': '/dev/testdisk1', 'type': 'part', 'maj:min': key,
+            'fstype': 'ext4', 'uuid': 'NATIVE-FS', 'ro': False}
+    disk = {'path': '/dev/testdisk', 'type': 'disk', 'maj:min': '239:0',
+            'serial': 'HOST-SERIAL', 'wwn': 'HOST-WWN', 'ro': False,
+            'children': [leaf]}
+    state = {'payload': {'blockdevices': [disk]},
+             'mounts': f'{mount_id} 0 {key} / / rw - ext4 /dev/testdisk1 rw\n',
+             'backing': (17, 24), 'flags': 0, 'roles': {}, 'acl': None}
+    def resolve(path, **kwargs):
+        target = state['roles'].get(str(path), str(path))
+        if target is None:
+            return None
+        return module.resolve_protected_result(str(path), target, key, mount_id, 1)
+    # Keep role resolution descriptor metadata synthetic too; no actual host paths
+    # or user's state files need be opened by this fixture.
+    from modelark.slice.host_observation import ProtectedTarget
+    monkeypatch.setattr(module, 'resolve_protected_result', ProtectedTarget, raising=False)
+    def xattr(fd, name):
+        if name == 'system.posix_acl_default' and state['acl'] is not None:
+            return state['acl']
+        raise OSError(errno.ENODATA, 'absent')
+    monkeypatch.setattr(module.os, 'getxattr', xattr)
+    observer = module.NativeFolderObserver(inventory=lambda: copy.deepcopy(state['payload']),
+        mounts=lambda: state['mounts'], backing=lambda key: state['backing'],
+        resolver=resolve, flags=lambda fd: state['flags'])
+    return observer, parent, state, disk, leaf
+
+
+def test_system_backed_ext4_parent_observation_is_read_only(native):
+    observer, parent, _, _, _ = native
+    (parent / 'unrelated').write_text('keep')
+    before = set(parent.iterdir())
+    value = observer.observe(parent / 'demo', archives=())
+    assert value.parent_path == str(parent)
+    assert value.destination_path == str(parent / 'demo')
+    assert value.target.child_name == 'demo'
+    assert value.target.parent_parts == parent.parts[1:]
+    assert value.filesystem_id == 'NATIVE-FS'
+    assert 'wwn:HOST-WWN' in value.backing_ids
+    assert 'serial:HOST-SERIAL' in value.backing_ids
+    assert 'filesystem:NATIVE-FS' in value.backing_ids
+    assert value.capacity.available_bytes >= 0
+    assert set(parent.iterdir()) == before
+
+
+def test_shared_sibling_write_does_not_change_binding(native):
+    observer, parent, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    (parent / 'unrelated').write_bytes(bytes(4096))
+    with BoundTree(parent) as tree:
+        assert observer.recheck(tree, value).target == value.target
+
+
+def test_real_observer_evidence_enters_native_plan_binding_canonically(native):
+    from modelark.slice.folder_plan import binding_for
+    observer, parent, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    assert value.backing_ids == tuple(sorted(set(value.backing_ids)))
+    binding = binding_for(value.target, str(parent.parent / 'catalog.sqlite'),
+                          value.parent_path, value.backing_ids)
+    with BoundTree(parent) as tree:
+        refreshed = observer.recheck(tree, value)
+    assert refreshed.backing_ids == value.backing_ids
+    assert binding == binding_for(refreshed.target, str(parent.parent / 'catalog.sqlite'),
+                                  refreshed.parent_path, refreshed.backing_ids)
+
+
+def test_inventory_dictionary_order_does_not_change_admission_binding(native):
+    from modelark.slice.folder_plan import binding_for
+    observer, parent, state, disk, _ = native
+    first = observer.observe(parent / 'demo', archives=())
+    state['payload']['blockdevices'][0] = dict(reversed(tuple(disk.items())))
+    second = observer.observe(parent / 'demo', archives=())
+    assert first.target == second.target
+    assert first.backing_ids == second.backing_ids
+    assert binding_for(first.target, str(parent / 'catalog'), first.parent_path, first.backing_ids) == (
+        binding_for(second.target, str(parent / 'catalog'), second.parent_path, second.backing_ids))
+
+
+def test_owned_child_presence_does_not_prevent_recheck(native):
+    observer, parent, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    (parent / 'demo').mkdir()
+    with BoundTree(parent) as tree:
+        assert observer.recheck(tree, value).target == value.target
+    with pytest.raises(TransferRefusal, match='already exists'):
+        observer.observe(parent / 'demo', archives=())
+    assert observer.observe(parent / 'demo', archives=(), allow_existing=True).target == value.target
+
+
+@pytest.mark.parametrize('kind', ['file', 'directory', 'symlink'])
+def test_existing_child_is_never_adopted(native, kind):
+    observer, parent, *_ = native
+    child = parent / 'demo'
+    if kind == 'file':
+        child.write_text('untouched')
+    elif kind == 'directory':
+        child.mkdir()
+    else:
+        child.symlink_to(parent / 'missing')
+    with pytest.raises(TransferRefusal, match='already exists'):
+        observer.observe(child, archives=())
+
+
+def test_parent_symlink_refused(native):
+    observer, parent, *_ = native
+    link = parent.parent / 'link'
+    link.symlink_to(parent, target_is_directory=True)
+    with pytest.raises(TransferRefusal):
+        observer.observe(link / 'demo', archives=())
+
+
+def test_parent_replacement_refused(native):
+    observer, parent, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    with BoundTree(parent) as tree:
+        parent.rename(parent.with_name('old'))
+        parent.mkdir()
+        with pytest.raises(TransferRefusal, match='changed'):
+            observer.recheck(tree, value)
+
+
+def test_backing_replacement_refused(native):
+    observer, parent, state, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    state['backing'] = (18, 25)
+    with BoundTree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='backing changed'):
+            observer.recheck(tree, value)
+
+
+@pytest.mark.parametrize('flag', [0x800, 0x40000000, 0x100000, 0x10, 0x20, 0x10000000])
+def test_unqualified_directory_flags_refuse(native, flag):
+    observer, parent, state, *_ = native
+    state['flags'] = flag
+    with pytest.raises(TransferRefusal, match='flags'):
+        observer.observe(parent / 'demo', archives=())
+
+
+def test_indexed_parent_is_allowed(native):
+    observer, parent, state, *_ = native
+    state['flags'] = 0x1000
+    observer.observe(parent / 'demo', archives=())
+
+
+@pytest.mark.parametrize('permissions', [7, 5])
+def test_default_acl_requires_owner_rwx_but_accepts_nonowner_entries(native, permissions):
+    observer, parent, state, *_ = native
+    state['acl'] = struct.pack('<I', 2) + b''.join(struct.pack('<HHI', tag, perm, 0xffffffff)
+        for tag, perm in [(1, permissions), (4, 7), (16, 7), (32, 7)])
+    if permissions == 7:
+        observer.observe(parent / 'demo', archives=())
+    else:
+        with pytest.raises(TransferRefusal, match='owner rwx'):
+            observer.observe(parent / 'demo', archives=())
+
+
+@pytest.mark.parametrize('mode,allowed', [(0o777, False), (0o1777, True), (0o755, True)])
+def test_shared_parent_requires_sticky_protection(native, mode, allowed):
+    observer, parent, *_ = native
+    parent.chmod(mode)
+    if allowed:
+        observer.observe(parent / 'demo', archives=())
+    else:
+        with pytest.raises(TransferRefusal, match='sticky'):
+            observer.observe(parent / 'demo', archives=())
+
+
+def test_descriptor_acl_access_error_preserves_permission_meaning(native, monkeypatch):
+    observer, parent, *_ = native
+    def denied(fd):
+        raise PermissionError(errno.EACCES, 'denied')
+    monkeypatch.setattr(module, 'require_create_access', denied)
+    with pytest.raises(TransferRefusal) as raised:
+        observer.observe(parent / 'demo', archives=())
+    assert raised.value.code == 'DESTINATION_NOT_WRITABLE'
+
+
+def test_mapped_single_parent_storage_allowed(native):
+    observer, parent, state, disk, leaf = native
+    leaf['type'] = 'lvm'
+    leaf['path'] = '/dev/mapper/test'
+    disk['children'] = [{'path': '/dev/testdisk2', 'type': 'crypt', 'maj:min': '238:2',
+                         'uuid': 'CRYPT-FS', 'ro': False, 'children': [leaf]}]
+    value = observer.observe(parent / 'demo', archives=())
+    assert value.filesystem_id == 'NATIVE-FS'
+
+
+def test_ambiguous_mapped_parent_refused(native):
+    observer, parent, state, disk, leaf = native
+    state['payload']['blockdevices'].append({'path': '/dev/other', 'type': 'disk',
+        'maj:min': '237:0', 'serial': 'OTHER', 'ro': False, 'children': [copy.deepcopy(leaf)]})
+    with pytest.raises(TransferRefusal, match='ambiguous'):
+        observer.observe(parent / 'demo', archives=())
+
+
+@pytest.mark.parametrize('archive', [SimpleNamespace(fs_uuid='NATIVE-FS'),
+                                   SimpleNamespace(serial='HOST-SERIAL'), SimpleNamespace()])
+def test_registered_archive_is_excluded(native, archive):
+    observer, parent, *_ = native
+    with pytest.raises(TransferRefusal, match='archive'):
+        observer.observe(parent / 'demo', archives=(archive,))
+
+
+def test_archive_sibling_partition_is_excluded(native):
+    observer, parent, _, disk, _ = native
+    disk['children'].append({'path': '/dev/testdisk2', 'type': 'part', 'maj:min': '236:2',
+                             'uuid': 'ARCHIVE', 'ro': False})
+    with pytest.raises(TransferRefusal, match='archive'):
+        observer.observe(parent / 'demo', archives=(SimpleNamespace(fs_uuid='ARCHIVE'),))
+
+
+def test_protected_role_retarget_is_detected_without_mount_change(native):
+    observer, parent, state, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    state['roles']['/var'] = str(parent)
+    with BoundTree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='protected'):
+            observer.recheck(tree, value)
+
+
+def test_supplied_private_subtree_is_protected(native):
+    observer, parent, *_ = native
+    with pytest.raises(TransferRefusal, match='protected'):
+        observer.observe(parent / 'demo', archives=(), protected_paths=(parent,))
+
+
+def test_catalog_file_does_not_protect_its_whole_parent(native):
+    observer, parent, *_ = native
+    catalog = parent / 'catalog.sqlite'
+    catalog.write_text('fixture')
+    observer.observe(parent / 'demo', archives=(), protected_paths=(catalog,))
+    with pytest.raises(TransferRefusal, match='protected'):
+        observer.observe(catalog, archives=(), protected_paths=(catalog,))
+
+
+@pytest.mark.parametrize('fs', ['tmpfs', 'vfat', 'xfs', 'overlay', 'fuse'])
+def test_other_filesystem_refused_before_flags_probe(native, fs):
+    observer, parent, state, _, leaf = native
+    state['mounts'] = state['mounts'].replace(' - ext4 ', f' - {fs} ')
+    leaf['fstype'] = fs
+    with pytest.raises(TransferRefusal, match='ext4'):
+        observer.observe(parent / 'demo', archives=())
+
+
+def test_mount_alias_refused(native):
+    observer, parent, state, _, leaf = native
+    state['mounts'] += f"9292 1 {leaf['maj:min']} / /alias rw - ext4 /dev/testdisk1 rw\n"
+    with pytest.raises(TransferRefusal, match='aliases'):
+        observer.observe(parent / 'demo', archives=())
+
+
+def test_scope_shared_by_distinct_children(native):
+    observer, parent, state, *_ = native
+    first = observer.observe(parent / 'first', archives=())
+    second = observer.observe(parent / 'second', archives=())
+    assert first.target.filesystem_scope == second.target.filesystem_scope
+    assert first.target.target_id != second.target.target_id
+
+
+def test_serialized_evidence_does_not_recreate_observer_authority(native):
+    observer, parent, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    observer._observed.clear()
+    with BoundTree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='no matching'):
+            observer.recheck(tree, value)
+
+
+def test_mapped_recheck_refreshes_backing_ancestry(native):
+    observer, parent, state, disk, leaf = native
+    leaf['type'] = 'lvm'
+    value = observer.observe(parent / 'demo', archives=())
+    disk['serial'] = 'REPLACEMENT'
+    disk['wwn'] = 'REPLACEMENT-WWN'
+    with BoundTree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='binding changed'):
+            observer.recheck(tree, value)
+
+
+def test_changed_registered_archive_roles_are_revalidated(native):
+    observer, parent, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    with BoundTree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='archive'):
+            observer.recheck(tree, value, archives=(SimpleNamespace(fs_uuid='NATIVE-FS'),))
+
+
+def test_initial_observation_inventory_race_refused(native):
+    observer, parent, state, *_ = native
+    calls = []
+    def changing():
+        payload = copy.deepcopy(state['payload'])
+        if calls:
+            payload['blockdevices'][0]['serial'] = 'CHANGED'
+        calls.append(1)
+        return payload
+    observer._inventory = changing
+    with pytest.raises(TransferRefusal, match='changed during admission'):
+        observer.observe(parent / 'demo', archives=())
+    assert not (parent / 'demo').exists()
+
+
+def test_full_observe_keeps_semantic_refusal_code(native):
+    observer, parent, state, *_ = native
+    state['flags'] = 0x40000000
+    with pytest.raises(TransferRefusal) as raised:
+        observer.observe(parent / 'demo', archives=())
+    assert raised.value.code == 'FILESYSTEM_UNSUPPORTED'
+
+
+def test_recheck_flags_change_refused(native):
+    observer, parent, state, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    state['flags'] = 0x40000000
+    with BoundTree(parent) as tree:
+        with pytest.raises(TransferRefusal, match='flags'):
+            observer.recheck(tree, value)
+
+
+def test_missing_backing_during_recheck_proves_wait(native):
+    observer, parent, *_ = native
+    value = observer.observe(parent / 'demo', archives=())
+    def missing(key):
+        raise FileNotFoundError(errno.ENOENT, 'gone')
+    observer._backing = missing
+    with BoundTree(parent) as tree:
+        with pytest.raises(TransferRefusal) as raised:
+            observer.recheck(tree, value)
+    assert raised.value.code == 'WAITING_DESTINATION'

--- a/tests/test_slice_folder_operator.py
+++ b/tests/test_slice_folder_operator.py
@@ -1,0 +1,203 @@
+"""Native assembly using synthetic source evidence and disposable real filesystem IO."""
+from dataclasses import replace
+from pathlib import Path
+import os
+
+import pytest
+
+from modelark.slice import folder_operator as f, operator, state, transaction as t
+from modelark.slice.folder_contract import CapacityObservation, FolderProfile, FolderTarget
+from modelark.slice.folder_observation import NativeFolderEvidence
+from modelark.slice.linux import BoundTree
+from test_slice_transaction import proposal, Sources, DATA
+
+
+@pytest.fixture
+def setup(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "HOST_STATE_DIR", tmp_path / "private")
+    parent = tmp_path / "exports"
+    parent.mkdir(mode=0o700)
+    catalog = tmp_path / "catalog.sqlite"
+    _, _, snapshot = proposal()
+    calls = []
+
+    class Observer:
+        def observe(self, destination, *, archives, protected_paths=(), allow_existing=False):
+            destination = Path(destination)
+            calls.append((destination, allow_existing, protected_paths))
+            if destination.exists() and not allow_existing:
+                raise t.TransferRefusal("OUTPUT_COLLISION")
+            with BoundTree(destination.parent) as tree:
+                target = FolderTarget(FolderProfile.NATIVE_EXT4, "fixture-scope", (),
+                                      tree.identity(tree.fd)[1:], destination.name)
+                capacity = os.fstatvfs(tree.fd)
+                self.evidence = NativeFolderEvidence(target, str(parent), str(destination), "fixture-uuid",
+                                                     ("filesystem:fixture-uuid", "serial:fixture-disk"),
+                                                     tree.mount_id, "fixture-major-minor",
+                                                     CapacityObservation(capacity.f_bavail * capacity.f_frsize,
+                                                                         capacity.f_favail),
+                                                     255, capacity.f_frsize)
+                return self.evidence
+
+        def recheck(self, tree, evidence, **kwargs):
+            tree.check()
+            assert tree.identity(tree.fd)[1:] == evidence.target.parent_identity
+            return evidence
+
+    monkeypatch.setattr(f, "NativeFolderObserver", Observer)
+    monkeypatch.setattr(f, "read_catalog", lambda *a: snapshot)
+    monkeypatch.setattr(operator, "read_catalog", lambda *a: snapshot)
+    monkeypatch.setattr(operator, "_archives", lambda *a: ())
+    monkeypatch.setattr(f, "FencedSources", lambda *a: Sources(snapshot, t))
+    monkeypatch.setattr(operator, "LinuxObserver", lambda: pytest.fail("native plan entered USB observer"))
+    return parent, catalog, calls
+
+
+def approved(setup):
+    parent, catalog, _ = setup
+    result = operator.preview(catalog, parent / "delivery", ("org/model",), None)
+    operator.approve(result["transaction_id"], result["seal"])
+    return result
+
+
+def test_preview_and_approve_write_only_private_state(setup):
+    parent, _, calls = setup
+    result = approved(setup)
+    assert list(parent.iterdir()) == []
+    assert result["ownership"] == "new-output-folder-only"
+    assert result["capacity_policy"] == "advisory-shared-space-not-reserved"
+    assert result["resume_policy"] == "authenticated"
+    assert result["executable"] is False
+    assert calls and all(not item[1] for item in calls)
+
+
+@pytest.mark.parametrize("point", ["open", "recheck", "close"])
+def test_preview_io_failure_is_structured_without_output(setup, monkeypatch, point):
+    parent, catalog, _ = setup
+    original = f.BoundTree
+
+    class FailingTree(original):
+        def __init__(self, *args, **kwargs):
+            if point == "open":
+                raise OSError("synthetic preview reopen failure")
+            super().__init__(*args, **kwargs)
+
+        def __exit__(self, *args):
+            super().__exit__(*args)
+            if point == "close":
+                raise OSError("synthetic preview close failure")
+
+    monkeypatch.setattr(f, "BoundTree", FailingTree)
+    if point == "recheck":
+        def fail(*args, **kwargs):
+            raise OSError("synthetic preview recheck failure")
+        monkeypatch.setattr(f.NativeFolderObserver, "recheck", fail)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_UNPROVEN"):
+        operator.preview(catalog, parent / "delivery", ("org/model",), None)
+    assert not list(parent.iterdir())
+
+
+@pytest.mark.parametrize("free,code", [(1, "DESTINATION_CAPACITY_WAIT"),
+                                      (None, "DESTINATION_CAPACITY_UNPROVEN")])
+def test_preview_requires_remaining_inode_budget(setup, monkeypatch, free, code):
+    parent, catalog, _ = setup
+    original = f.NativeFolderObserver.recheck
+    def recheck(*args, **kwargs):
+        value = original(*args, **kwargs)
+        return replace(value, capacity=replace(value.capacity, free_inodes=free))
+    monkeypatch.setattr(f.NativeFolderObserver, "recheck", recheck)
+    with pytest.raises(t.TransferRefusal, match=code):
+        operator.preview(catalog, parent / "delivery", ("org/model",), None)
+    assert not list(parent.iterdir())
+
+
+def test_native_operator_roundtrip_and_completed_start_need_no_usb_observer(setup, monkeypatch):
+    parent, _, _ = setup
+    result = approved(setup)
+    (parent / "unrelated").write_bytes(b"untouched")
+    tx = result["transaction_id"]
+    done = operator.start(tx, parent / "delivery", {})
+    assert done["state"] == "complete" and not done["can_write"]
+    assert (parent / "delivery/org/model/model.safetensors").read_bytes() == DATA
+    assert (parent / "delivery/.modelark-slice-owner").exists()
+    assert not (parent / ".modelark-slice-owner").exists()
+    assert (parent / "unrelated").read_bytes() == b"untouched"
+    monkeypatch.setattr(f, "NativeFolderObserver", lambda: pytest.fail("completed Start observes destination"))
+    assert operator.start(tx, "/absent", {})["state"] == "complete"
+
+
+def test_unapproved_native_plan_refuses_before_observation(setup, monkeypatch):
+    parent, catalog, _ = setup
+    result = operator.preview(catalog, parent / "delivery", ("org/model",), None)
+    monkeypatch.setattr(f, "NativeFolderObserver", lambda: pytest.fail("unapproved Start observes destination"))
+    with pytest.raises(t.TransferRefusal, match="APPROVAL_MISSING"):
+        operator.start(result["transaction_id"], parent / "delivery", {})
+    assert not (parent / "delivery").exists()
+
+
+def test_start_wrong_folder_refuses_without_creation(setup):
+    parent, _, _ = setup
+    result = approved(setup)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CHANGED"):
+        operator.start(result["transaction_id"], parent / "other", {})
+    assert not list(parent.iterdir())
+
+
+def test_root_collision_after_approval_is_never_adopted(setup):
+    parent, _, _ = setup
+    result = approved(setup)
+    (parent / "delivery").mkdir()
+    (parent / "delivery/foreign").write_bytes(b"keep")
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+        operator.start(result["transaction_id"], parent / "delivery", {})
+    assert (parent / "delivery/foreign").read_bytes() == b"keep"
+    assert sorted(p.name for p in (parent / "delivery").iterdir()) == ["foreign"]
+
+
+def test_ctrl_c_acknowledges_before_lease_release_then_resumes(setup, monkeypatch):
+    parent, _, _ = setup
+    result = approved(setup)
+    tx = result["transaction_id"]
+    run = t.Session.run
+    raised = False
+
+    def interrupted(session):
+        nonlocal raised
+        if not raised:
+            raised = True
+            raise KeyboardInterrupt
+        return run(session)
+
+    monkeypatch.setattr(t.Session, "run", interrupted)
+    stopped = operator.start(tx, parent / "delivery", {})
+    assert stopped["state"] == "stopped" and stopped["stop_requested"]
+    assert operator.start(tx, parent / "delivery", {})["state"] == "complete"
+
+
+def test_capacity_after_approval_waits_without_creating_root(setup, monkeypatch):
+    parent, _, _ = setup
+    result = approved(setup)
+    original = f.NativeFolderDestination.check
+
+    def insufficient(*a):
+        raise t.TransferRefusal("DESTINATION_CAPACITY_WAIT")
+
+    monkeypatch.setattr(f.NativeFolderDestination, "check", insufficient)
+    waiting = operator.start(result["transaction_id"], parent / "delivery", {})
+    assert waiting["state"] == "waiting_destination" and not waiting["can_write"]
+    assert not (parent / "delivery").exists()
+    monkeypatch.setattr(f.NativeFolderDestination, "check", original)
+    assert operator.start(result["transaction_id"], parent / "delivery", {})["state"] == "complete"
+
+
+def test_native_full_layout_rejects_generated_name_and_path_limits(setup):
+    parent, _, _ = setup
+    result = approved(setup)
+    plan = state.Store().load(result["transaction_id"])
+    evidence = f.NativeFolderObserver().observe(parent / "another", archives=())
+    long_file = replace(plan.proposal.closure[0], rfilename="x" * 256)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_LAYOUT_UNSUPPORTED"):
+        f._layout(replace(plan.proposal, closure=(long_file,)), evidence)
+    reserved = replace(long_file, rfilename=".slice-user-data")
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_LAYOUT_UNSUPPORTED"):
+        f._layout(replace(plan.proposal, closure=(reserved,)), evidence)

--- a/tests/test_slice_folder_plan.py
+++ b/tests/test_slice_folder_plan.py
@@ -1,0 +1,210 @@
+"""Native plan serialization and shared-space evidence do not grant authority."""
+from dataclasses import asdict, replace
+import json
+
+import pytest
+
+from modelark.slice import domain as d
+from modelark.slice.folder_contract import CapacityObservation, FolderProfile, FolderTarget
+from modelark.slice.folder_plan import NativeBinding, NativePlan, binding_for, estimate_metadata
+from modelark.slice.transaction import TransferPlan, TransferRefusal
+from test_slice_domain import facts, spec
+
+
+def parts(**changes):
+    target = FolderTarget(FolderProfile.NATIVE_EXT4, "filesystem:disk:uuid", ("exports",),
+                          (42, 123456789), "delivery")
+    values = dict(target=target, catalog="/catalog/catalog.sqlite", parent_path="/exports",
+                  backing_ids=("serial:disk", "wwn:disk"), capacity=CapacityObservation(1_000_000, 100, 4096))
+    values.update(changes)
+    return values
+
+
+def plan(**changes):
+    values = parts()
+    binding = binding_for(values["target"], values["catalog"], values["parent_path"], values["backing_ids"])
+    proposal = d.preview(replace(spec(d), destination_id=binding.device_id,
+                                 destination_root=values["target"].child_name), facts(d))
+    kwargs = dict(proposal=proposal, destination=binding, catalog=values["catalog"],
+                  parent_path=values["parent_path"], backing_ids=values["backing_ids"],
+                  capacity=values["capacity"], metadata_reserve_bytes=256 * 1024)
+    kwargs.update(changes)
+    return NativePlan(**kwargs)
+
+
+def test_native_roundtrip_and_stable_versioned_seal():
+    original = plan()
+    restored = NativePlan.from_json(original.to_json())
+    assert restored == original
+    assert restored.to_json() == original.to_json()
+    assert restored.seal == original.seal
+    assert len(restored.seal) == 64
+    assert restored.is_folder is True
+    assert restored.control_path == "delivery/.modelark-slice-owner"
+    assert restored.version == "modelark.slice.native-transaction.v1"
+    assert restored.destination.device_id == restored.destination.target.target_id
+    assert restored.destination.filesystem_id == restored.destination.target.filesystem_scope
+    assert restored.destination.mount_id == restored.destination.admission_id
+    assert not hasattr(restored.destination, "available_bytes")
+
+
+def test_changed_advisory_space_changes_review_not_binding():
+    original = plan()
+    changed = replace(original, capacity=CapacityObservation(0, 0, 8192))
+    assert changed.destination == original.destination
+    assert changed.seal != original.seal
+    assert changed.required_bytes("/private/state") == (
+        changed.proposal.total_bytes + changed.metadata_reserve_bytes + 8192)
+    assert changed.required_bytes("/private/state") > changed.capacity.available_bytes
+
+
+@pytest.mark.parametrize("field,value", [
+    ("catalog", "/elsewhere/catalog.sqlite"), ("parent_path", "/elsewhere"),
+    ("backing_ids", ("serial:other",)),
+])
+def test_admission_seals_stable_policy_not_only_folder(field, value):
+    original = plan()
+    with pytest.raises(TransferRefusal, match="ADMISSION_CORRUPT"):
+        replace(original, **{field: value})
+    values = parts(**{field: value})
+    assert binding_for(values["target"], values["catalog"], values["parent_path"], values["backing_ids"]) != original.destination
+
+
+def test_legacy_decoder_refuses_native_and_native_refuses_legacy():
+    original = plan()
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        TransferPlan.from_json(original.to_json())
+    record = json.loads(original.to_json())
+    record["version"] = "modelark.slice.transaction.v3"
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        NativePlan.from_json(json.dumps(record))
+
+
+@pytest.mark.parametrize("value", ["native-folder-v1:", "native-folder-v1:" + "A" * 64,
+                                  "direct-v1:" + "a" * 64, None, 7])
+def test_binding_rejects_unknown_or_malformed_policy_id(value):
+    with pytest.raises(TransferRefusal, match="FOLDER_PLAN_INVALID"):
+        NativeBinding(parts()["target"], value)
+
+
+def test_fat_policy_cannot_enter_native_plan():
+    target = replace(parts()["target"], profile=FolderProfile.FAT32_SESSION, parent_identity="a" * 32)
+    with pytest.raises(TransferRefusal, match="FOLDER_PLAN_INVALID"):
+        binding_for(target, "/catalog", "/exports", ("serial:disk",))
+    with pytest.raises(TransferRefusal, match="FOLDER_PLAN_INVALID"):
+        NativeBinding(target, "native-folder-v1:" + "a" * 64)
+
+
+@pytest.mark.parametrize("value", ["relative", "", "/a/../b", "/a/./b", "/a//b", "//a/b",
+                                  "/a/", "/a\0b", "/a\udcff", None])
+@pytest.mark.parametrize("field", ["catalog", "parent_path"])
+def test_admission_requires_canonical_absolute_paths(field, value):
+    values = parts(**{field: value})
+    with pytest.raises(TransferRefusal, match="FOLDER_PLAN_INVALID"):
+        binding_for(values["target"], values["catalog"], values["parent_path"], values["backing_ids"])
+
+
+@pytest.mark.parametrize("values", [(), [], None, "serial:disk", ("b", "a"), ("a", "a"),
+                                    ("",), (" a",), ("a\0",), (1,)])
+def test_backing_scope_is_explicit_sorted_unique(values):
+    with pytest.raises(TransferRefusal, match="FOLDER_PLAN_INVALID"):
+        binding_for(parts()["target"], "/catalog", "/exports", values)
+
+
+def test_plan_closure_must_match_target_and_be_source_ready():
+    original = plan()
+    for change in ({"destination_id": "other"}, {"destination_root": "nested/delivery"}):
+        proposal = d.preview(replace(original.proposal.spec, **change), facts(d))
+        with pytest.raises(TransferRefusal, match="DESTINATION_CHANGED"):
+            replace(original, proposal=proposal)
+    proposal = d.preview(original.proposal.spec, replace(facts(d), copies=()))
+    with pytest.raises(TransferRefusal, match="PREVIEW_BLOCKED"):
+        replace(original, proposal=proposal)
+    with pytest.raises(d.SliceRefusal, match="PREVIEW_TAMPERED"):
+        replace(original, proposal=replace(original.proposal, seal="a" * 64))
+
+
+@pytest.mark.parametrize("changes", [
+    {"proposal": None}, {"destination": None}, {"capacity": {}},
+    {"metadata_reserve_bytes": -1}, {"metadata_reserve_bytes": True},
+    {"metadata_reserve_bytes": 1.0}, {"version": "anything"},
+])
+def test_typed_native_contract_required(changes):
+    with pytest.raises(TransferRefusal, match="FOLDER_PLAN_INVALID"):
+        plan(**changes)
+
+
+def test_metadata_budget_counts_control_and_maximal_receipt():
+    original = plan()
+    minimum = original._metadata_minimum("")
+    exact = replace(original, metadata_reserve_bytes=minimum)
+    # Serialized integer length can change the minimum; these bounds are far apart.
+    assert exact.required_bytes("") >= original.proposal.total_bytes + minimum
+    with pytest.raises(TransferRefusal, match="DESTINATION_CAPACITY_UNPROVEN"):
+        replace(original, metadata_reserve_bytes=1)
+    with pytest.raises(TransferRefusal, match="DESTINATION_CAPACITY_UNPROVEN"):
+        original.required_bytes("/" + "long-state-path" * 100_000)
+
+
+def test_metadata_estimate_covers_real_serialized_evidence_without_capacity_guarantee():
+    original = plan(capacity=CapacityObservation(0, None))
+    reserve = estimate_metadata(original.proposal, original.destination, original.catalog,
+                                original.parent_path, original.backing_ids, original.capacity, "/private/state")
+    estimated = replace(original, metadata_reserve_bytes=reserve)
+    assert estimated.required_bytes("/private/state") > estimated.capacity.available_bytes
+    assert reserve > estimated._metadata_minimum("/private/state")
+
+
+def test_receipt_distinguishes_folder_shared_space_and_verification_claims():
+    original = plan()
+    receipt = original.receipt("a" * 32, [])
+    assert receipt["version"] == original.version
+    assert receipt["topology"] == "folder"
+    assert receipt["resume_policy"] == "authenticated"
+    assert receipt["capacity_evidence"] == "advisory-shared-space-not-reserved"
+    assert receipt["profile"] == "native-ext4-folder.v1"
+    assert receipt["destination"] == asdict(original.destination)
+    assert receipt["verification"] == {"content": "sha256-original-bytes", "layout": "authenticated",
+                                       "result": "verified", "file_count": 0}
+    assert "archive" not in receipt and "physical_verification" not in receipt
+
+
+@pytest.mark.parametrize("location,key", [((), "version"), ((), "proposal"), (("destination",), "target"),
+                                         (("destination", "target"), "profile"), (("capacity",), "free_inodes")])
+def test_missing_fields_rejected(location, key):
+    record = json.loads(plan().to_json())
+    subrecord = record
+    for component in location:
+        subrecord = subrecord[component]
+    del subrecord[key]
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        NativePlan.from_json(json.dumps(record))
+
+
+@pytest.mark.parametrize("location", [(), ("destination",), ("destination", "target"), ("capacity",), ("proposal",)])
+def test_extra_or_mixed_envelope_fields_rejected(location):
+    record = json.loads(plan().to_json())
+    subrecord = record
+    for component in location:
+        subrecord = subrecord[component]
+    subrecord["legacy_extra"] = "not allowed"
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        NativePlan.from_json(json.dumps(record))
+
+
+@pytest.mark.parametrize("location", [(), ("copy",), ("drive",), ("anchor",)])
+def test_unknown_nested_source_fields_are_not_silently_discarded(location):
+    record = json.loads(plan().to_json())
+    source = record["proposal"]["closure"][0]["sources"][0]
+    for component in location:
+        source = source[component]
+    source["unsealed_extra"] = "unknown policy"
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        NativePlan.from_json(json.dumps(record))
+
+
+@pytest.mark.parametrize("payload", ["{}", "[]", "null", "no-json", '{"version":1,"version":2}',
+                                    '{"version":NaN}', None])
+def test_malformed_json_refuses(payload):
+    with pytest.raises(TransferRefusal, match="STATE_CORRUPT"):
+        NativePlan.from_json(payload)

--- a/tests/test_slice_folder_routing.py
+++ b/tests/test_slice_folder_routing.py
@@ -1,0 +1,38 @@
+"""Mount routing is only a hint; ambiguity never selects a weaker adapter."""
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import folder_operator as folder, transaction as t
+
+
+@pytest.mark.parametrize("parent,expected", [
+    ("/media/disk/exports", "vfat"),
+    ("/media/disk-other/exports", "ext4"),
+    ("/media/disk/nested/exports", "ext4"),
+])
+def test_routing_uses_deepest_component_ancestor(monkeypatch, parent, expected):
+    mounts = [SimpleNamespace(path=path, fs_type=kind) for path, kind in (
+        ("/", "ext4"), ("/media/disk", "vfat"), ("/media/disk/nested", "ext4"))]
+    monkeypatch.setattr(folder, "read_fs_text", lambda *args: "fixture")
+    monkeypatch.setattr(folder, "parse_mounts", lambda text: mounts)
+    assert folder._filesystem_type(Path(parent)) == expected
+
+
+@pytest.mark.parametrize("mounts", [[], [
+    SimpleNamespace(path="/", fs_type="ext4"), SimpleNamespace(path="/", fs_type="vfat"),
+]])
+def test_missing_or_ambiguous_mount_refuses(monkeypatch, mounts):
+    monkeypatch.setattr(folder, "read_fs_text", lambda *args: "fixture")
+    monkeypatch.setattr(folder, "parse_mounts", lambda text: mounts)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_UNPROVEN"):
+        folder._filesystem_type(Path("/exports"))
+
+
+def test_routing_io_failure_is_typed(monkeypatch):
+    def unavailable(*args):
+        raise OSError("mount inventory unavailable")
+    monkeypatch.setattr(folder, "read_fs_text", unavailable)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_UNPROVEN"):
+        folder._filesystem_type(Path("/exports"))

--- a/tests/test_slice_hardware.py
+++ b/tests/test_slice_hardware.py
@@ -1,0 +1,303 @@
+"""Read-only hardware eligibility using only synthetic inventories and disposable trees."""
+import copy
+import importlib
+import os
+
+import pytest
+
+from modelark.slice.linux import BoundTree
+from modelark.slice.transaction import TransferRefusal
+
+
+@pytest.fixture
+def hardware(tmp_path):
+    module = importlib.import_module("modelark.slice.hardware")
+    root = tmp_path / "usb"
+    root.mkdir()
+    with BoundTree(root) as tree:
+        major_minor = f"{os.major(os.fstat(tree.fd).st_dev)}:{os.minor(os.fstat(tree.fd).st_dev)}"
+        mount_id = tree.mount_id
+    leaf = {"name": "/dev/testusb1", "path": "/dev/testusb1", "type": "part", "pkname": "/dev/testusb",
+            "maj:min": major_minor, "size": 10**15, "fstype": "ext4", "uuid": "USB-FS", "ro": False}
+    usb = {"name": "/dev/testusb", "path": "/dev/testusb", "type": "disk", "maj:min": "240:0",
+           "size": 10**15, "serial": "USB-SERIAL", "wwn": "USB-WWN", "tran": "usb", "ro": False,
+           "children": [leaf]}
+    host = {"name": "/dev/testhost", "path": "/dev/testhost", "type": "disk", "maj:min": "241:0",
+            "size": 10**15, "serial": "HOST-SERIAL", "wwn": "HOST-WWN", "tran": "nvme", "ro": False,
+            "children": [{"name": "/dev/testhost1", "path": "/dev/testhost1", "type": "part",
+                          "pkname": "/dev/testhost", "maj:min": "241:1", "size": 10**15,
+                          "fstype": "ext4", "uuid": "HOST-FS", "ro": False}]}
+    inventory = {"blockdevices": [host, usb]}
+    mounts = ["1 0 241:1 / / rw,relatime - ext4 /dev/testhost1 rw",
+              f"{mount_id} 1 {major_minor} / {root} rw,relatime - ext4 /dev/testusb1 rw"]
+    state = {"inventory": inventory, "mounts": mounts, "swaps": "Filename\tType\tSize\tUsed\tPriority\n"}
+    observer = module.LinuxObserver(inventory=lambda: state["inventory"], mounts=lambda: "\n".join(state["mounts"]),
+                                    swaps=lambda: state["swaps"])
+    return observer, root, state, usb, leaf, module
+
+
+def test_direct_usb_evidence_binds_whole_disk_and_stable_capability_profile(hardware):
+    observer, root, _, _, _, _ = hardware
+    value = observer.observe(root, writable=True)
+    assert value.serial == "USB-SERIAL"
+    assert value.fs_uuid == "USB-FS"
+    assert value.mount_path == str(root)
+    assert value.fs_type == "ext4"
+    assert value.available_bytes > 0
+    assert value.block_size > 0
+    assert value.name_max > 0
+    capacity = os.statvfs(root)
+    assert value.total_bytes == capacity.f_blocks * capacity.f_frsize
+    assert value.device_size == 10**15
+    assert value.binding().device_id == value.device_id
+    assert value.binding().filesystem_id == "USB-FS"
+    assert value.binding().mount_id != str(value.mount_id)
+    assert value.device_id != value.fs_uuid
+
+
+@pytest.mark.parametrize("field,value", [("tran", "sata"), ("serial", None), ("ro", True)])
+def test_destination_requires_usb_identity_and_writability(hardware, field, value):
+    observer, root, _, disk, _, _ = hardware
+    disk[field] = value
+    if field == "serial":
+        disk["wwn"] = None
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_read_only_source_need_not_be_usb_and_may_be_xfs(hardware):
+    observer, root, state, disk, leaf, _ = hardware
+    disk["tran"] = "sata"
+    leaf["fstype"] = "xfs"
+    state["mounts"][1] = state["mounts"][1].replace(" - ext4 ", " - xfs ")
+    assert observer.observe(root).fs_type == "xfs"
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+@pytest.mark.parametrize("kind", ["crypt", "lvm", "raid1", "loop", "rom"])
+def test_stacked_or_unknown_target_devices_refuse(hardware, kind):
+    observer, root, _, _, leaf, _ = hardware
+    leaf["type"] = kind
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_unknown_or_mismatched_filesystem_refuses(hardware):
+    observer, root, _, _, leaf, _ = hardware
+    leaf["fstype"] = "vfat"
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+@pytest.mark.parametrize("protected", ["/", "/boot", "/home", "/var"])
+def test_system_filesystem_sibling_excludes_whole_disk(hardware, protected):
+    observer, root, state, disk, _, _ = hardware
+    disk["children"].append({"name": "/dev/testusb2", "path": "/dev/testusb2", "type": "part",
+                             "pkname": "/dev/testusb", "maj:min": "240:2", "size": 10**14,
+                             "fstype": "ext4", "uuid": "SIBLING-FS", "ro": False})
+    if protected == "/":
+        state["mounts"][0] = "1 0 240:2 / / rw - ext4 /dev/testusb2 rw"
+    else:
+        state["mounts"].append(f"912 1 240:2 / {protected} rw - ext4 /dev/testusb2 rw")
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_active_swap_sibling_excludes_whole_disk(hardware):
+    observer, root, state, disk, _, _ = hardware
+    disk["children"].append({"name": "/dev/testusb2", "path": "/dev/testusb2", "type": "part",
+                             "pkname": "/dev/testusb", "maj:min": "240:2", "size": 10**14,
+                             "fstype": "swap", "uuid": "SWAP-FS", "ro": False})
+    state["swaps"] += "/dev/testusb2 partition 4096 0 -2\n"
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+@pytest.mark.parametrize("archive", [{"fs_uuid": "USB-FS", "serial": None},
+                                     {"fs_uuid": "OFFLINE-FS", "serial": "USB-SERIAL"},
+                                     {"fs_uuid": "OFFLINE-FS", "serial": "USB-WWN"}])
+def test_all_registered_archive_identity_exclusions(hardware, archive):
+    observer, root, _, _, _, _ = hardware
+    from types import SimpleNamespace
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True, archives=(SimpleNamespace(**archive),))
+
+
+def test_duplicate_filesystem_uuid_refuses(hardware):
+    observer, root, state, _, leaf, _ = hardware
+    state["inventory"]["blockdevices"][0]["children"][0]["uuid"] = leaf["uuid"]
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_duplicate_whole_disk_identity_refuses(hardware):
+    observer, root, state, disk, _, _ = hardware
+    state["inventory"]["blockdevices"][0]["wwn"] = disk["wwn"]
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+@pytest.mark.parametrize("change", ["alias", "nested", "bind", "mount-id", "major-minor"])
+def test_mount_binding_must_be_unique_exact_and_descriptor_matched(hardware, change):
+    observer, root, state, _, leaf, _ = hardware
+    if change == "alias":
+        state["mounts"].append(f"991 1 {leaf['maj:min']} / /different rw - ext4 /dev/testusb1 rw")
+    elif change == "nested":
+        state["mounts"].append(f"991 1 242:1 / {root}/nested rw - ext4 /dev/foreign rw")
+    elif change == "bind":
+        parts = state["mounts"][1].split()
+        parts[3] = "/subdirectory"
+        state["mounts"][1] = " ".join(parts)
+    else:
+        parts = state["mounts"][1].split()
+        parts[0 if change == "mount-id" else 2] = "999999" if change == "mount-id" else "245:9"
+        state["mounts"][1] = " ".join(parts)
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_descendant_of_mount_root_is_not_a_dedicated_destination(hardware):
+    observer, root, _, _, _, _ = hardware
+    child = root / "child"
+    child.mkdir()
+    with pytest.raises(TransferRefusal):
+        observer.observe(child, writable=True)
+
+
+def test_archive_subdirectory_uses_covering_mount_for_read_only_evidence(hardware):
+    observer, root, _, _, _, _ = hardware
+    archive = root / "modelark"
+    archive.mkdir()
+    evidence = observer.observe(archive)
+    assert evidence.mount_path == str(root)
+    assert evidence.fs_uuid == "USB-FS"
+    with pytest.raises(TransferRefusal):
+        observer.observe(archive, writable=True)
+
+
+def test_archive_subdirectory_still_rejects_nested_mounts_and_system_disk(hardware):
+    observer, root, state, _, leaf, _ = hardware
+    archive = root / "modelark"
+    archive.mkdir()
+    state["mounts"].append(f"991 1 242:1 / {root}/other rw - ext4 /dev/foreign rw")
+    with pytest.raises(TransferRefusal):
+        observer.observe(archive)
+    state["mounts"].pop()
+    state["mounts"][0] = state["mounts"][0].replace("241:1", leaf["maj:min"])
+    with pytest.raises(TransferRefusal):
+        observer.observe(archive)
+
+
+def test_observations_do_not_mutate_supplied_inventory(hardware):
+    observer, root, state, _, _, _ = hardware
+    before = copy.deepcopy(state)
+    observer.observe(root, writable=True)
+    assert state == before
+
+
+def test_remount_attachment_changes_do_not_change_stable_binding(hardware):
+    observer, root, state, _, _, module = hardware
+    before = observer.observe(root, writable=True)
+    class ReattachedTree(BoundTree):
+        @property
+        def mount_id(self):
+            return self._actual_mount_id + 123
+
+        @mount_id.setter
+        def mount_id(self, value):
+            self._actual_mount_id = value
+
+        def check(self):
+            # Synthetic reattachment evidence: retain actual disposable identity; the
+            # fixture changes mountinfo's attachment number consistently with this view.
+            actual = self._actual_mount_id
+            self._actual_mount_id -= 123
+            try:
+                super().check()
+            finally:
+                self._actual_mount_id = actual
+    parts = state["mounts"][1].split()
+    parts[0] = str(int(parts[0]) + 123)
+    state["mounts"][1] = " ".join(parts)
+    after = module.LinuxObserver(inventory=lambda: state["inventory"], mounts=lambda: "\n".join(state["mounts"]),
+                                 swaps=lambda: state["swaps"], tree_factory=ReattachedTree).observe(root, writable=True)
+    assert after.mount_id == before.mount_id + 123
+    assert after.binding().mount_id == before.binding().mount_id
+    assert after.device_id == before.device_id
+
+
+def test_archive_uuid_on_unmounted_sibling_excludes_whole_disk(hardware):
+    from types import SimpleNamespace
+    observer, root, _, disk, _, _ = hardware
+    disk["children"].append({"name": "/dev/testusb2", "path": "/dev/testusb2", "type": "part",
+                             "pkname": "/dev/testusb", "maj:min": "240:2", "size": 10**14,
+                             "fstype": "ext4", "uuid": "ARCHIVE-FS", "ro": False})
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True, archives=(SimpleNamespace(fs_uuid="archive-fs", serial=None),))
+
+
+def test_swapfile_backing_disk_is_excluded(hardware):
+    observer, root, state, _, _, _ = hardware
+    state["swaps"] += f"{root}/swapfile file 4096 0 -2\n"
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_nested_system_filesystem_on_sibling_is_excluded(hardware):
+    observer, root, state, disk, _, _ = hardware
+    disk["children"].append({"name": "/dev/testusb2", "path": "/dev/testusb2", "type": "part",
+                             "pkname": "/dev/testusb", "maj:min": "240:2", "size": 10**14,
+                             "fstype": "ext4", "uuid": "VAR-FS", "ro": False})
+    state["mounts"].append("912 1 240:2 / /var/lib rw - ext4 /dev/testusb2 rw")
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_unknown_protected_backing_disk_refuses(hardware):
+    observer, root, state, _, _, _ = hardware
+    state["mounts"][0] = "1 0 245:1 / / rw - overlay overlay rw"
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+@pytest.mark.parametrize("inventory", [{}, {"blockdevices": []}, {"blockdevices": [None]}])
+def test_missing_or_malformed_inventory_refuses(hardware, inventory):
+    observer, root, state, _, _, _ = hardware
+    state["inventory"] = inventory
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_inventory_change_during_observation_refuses(hardware):
+    _, root, state, _, _, module = hardware
+    count = 0
+    def changes():
+        nonlocal count
+        count += 1
+        result = copy.deepcopy(state["inventory"])
+        if count > 1:
+            result["blockdevices"][1]["serial"] = "REPLACEMENT"
+        return result
+    observer = module.LinuxObserver(inventory=changes, mounts=lambda: "\n".join(state["mounts"]),
+                                    swaps=lambda: state["swaps"])
+    with pytest.raises(TransferRefusal):
+        observer.observe(root, writable=True)
+
+
+def test_construction_never_observes_live_hardware(monkeypatch, hardware):
+    *_, module = hardware
+    monkeypatch.setattr(module.subprocess, "run", lambda *args, **kwargs: pytest.fail("implicit hardware discovery"))
+    module.LinuxObserver()
+
+
+def test_lsblk_uses_explicit_read_only_json_columns(monkeypatch, hardware):
+    from types import SimpleNamespace
+    *_, module = hardware
+    def run(command, **kwargs):
+        assert command == ["lsblk", "--json", "--bytes", "--paths", "--output",
+                           "NAME,PATH,TYPE,PKNAME,MAJ:MIN,SIZE,FSTYPE,UUID,SERIAL,WWN,TRAN,RO"]
+        assert kwargs == {"check": True, "capture_output": True, "text": True}
+        return SimpleNamespace(stdout='{"blockdevices": []}')
+    monkeypatch.setattr(module.subprocess, "run", run)
+    assert module._inventory() == {"blockdevices": []}

--- a/tests/test_slice_hardware.py
+++ b/tests/test_slice_hardware.py
@@ -416,6 +416,95 @@ def test_user_xattr_read_probe_refuses_unsupported_namespace(hardware, monkeypat
         observer.observe(root, writable=True)
 
 
+def test_missing_effective_access_syscall_reports_unsupported_platform(hardware, monkeypatch):
+    import ctypes
+    import errno
+    from modelark.slice import linux
+    observer, root, *_ = hardware
+    libc = linux._libc()
+    class OlderKernel:
+        def __getattr__(self, name):
+            return getattr(libc, name)
+
+        def syscall(self, number, *args):
+            if number.value == 439:
+                ctypes.set_errno(errno.ENOSYS)
+                return -1
+            return libc.syscall(number, *args)
+    monkeypatch.setattr(linux, '_libc', OlderKernel)
+    with pytest.raises(TransferRefusal, match='FILESYSTEM_UNSUPPORTED.*faccessat2'):
+        observer.observe(root, writable=True)
+    assert not list(root.iterdir())
+
+
+@pytest.mark.parametrize('capability', ['openat2', 'statx'])
+def test_other_missing_confinement_syscalls_report_unsupported_platform(monkeypatch, capability):
+    import ctypes
+    import errno
+    from types import SimpleNamespace
+    from modelark.slice import linux
+    def unavailable(*args):
+        ctypes.set_errno(errno.ENOSYS)
+        return -1
+    monkeypatch.setattr(linux, '_libc', lambda: SimpleNamespace(syscall=unavailable, statx=unavailable))
+    with pytest.raises(TransferRefusal, match='FILESYSTEM_UNSUPPORTED.*' + capability):
+        if capability == 'openat2':
+            linux._openat2(-1, '.', os.O_RDONLY)
+        else:
+            linux._statx(-1)
+
+
+def _default_acl(named_users):
+    import struct
+    entries = [(1, 7, 0xffffffff)]
+    entries += [(2, 7, 100000 + i) for i in range(named_users)]
+    entries += [(4, 5, 0xffffffff), (16, 7, 0xffffffff), (32, 5, 0xffffffff)]
+    return struct.pack('<I', 2) + b''.join(struct.pack('<HHI', *entry) for entry in entries)
+
+
+@pytest.mark.parametrize('named_users', [1, 400])
+def test_inherited_default_acl_refuses_before_admission(hardware, named_users):
+    observer, root, *_ = hardware
+    acl = _default_acl(named_users)
+    os.setxattr(root, 'system.posix_acl_default', acl)
+    with pytest.raises(TransferRefusal, match='DESTINATION_CAPACITY_UNPROVEN.*default ACL'):
+        observer.observe(root, writable=True)
+    assert os.getxattr(root, 'system.posix_acl_default') == acl
+    assert not list(root.iterdir())
+    # Source-only observation must not apply destination inheritance policy.
+    assert observer.observe(root).fs_uuid == 'USB-FS'
+
+
+def test_default_acl_added_after_observation_refuses_hot_check(hardware):
+    observer, root, *_ = hardware
+    evidence = observer.observe(root, writable=True)
+    os.setxattr(root, 'system.posix_acl_default', _default_acl(1))
+    with BoundTree(root, writable=True) as tree:
+        with pytest.raises(TransferRefusal, match='DESTINATION_CAPACITY_UNPROVEN.*default ACL'):
+            observer.check_attachment(tree, evidence)
+
+
+def test_noninherited_access_acl_remains_supported(hardware):
+    observer, root, *_ = hardware
+    os.setxattr(root, 'system.posix_acl_access', _default_acl(1))
+    assert observer.observe(root, writable=True).fs_uuid == 'USB-FS'
+
+
+@pytest.mark.parametrize('number', [5, 13, 95])
+def test_unknown_default_acl_probe_failure_is_not_absence(hardware, monkeypatch, number):
+    observer, root, _, _, _, module = hardware
+    original = module.os.getxattr
+    def uncertain(fd, name):
+        if name == 'system.posix_acl_default':
+            raise OSError(number, 'default ACL cannot be inspected')
+        return original(fd, name)
+    monkeypatch.setattr(module.os, 'getxattr', uncertain)
+    code = 'DESTINATION_UNPROVEN' if number == 5 else 'DESTINATION_CAPACITY_UNPROVEN'
+    with pytest.raises(TransferRefusal, match=code + '.*default ACL'):
+        observer.observe(root, writable=True)
+    assert not list(root.iterdir())
+
+
 def test_unplug_between_backing_probe_and_descriptor_check_remains_waiting(hardware, monkeypatch):
     import errno
     observer, root, *_ = hardware

--- a/tests/test_slice_hardware.py
+++ b/tests/test_slice_hardware.py
@@ -521,10 +521,15 @@ def test_unplug_between_backing_probe_and_descriptor_check_remains_waiting(hardw
         assert tree._attachment_lost
 
 
-def test_unplug_during_full_refresh_io_remains_waiting(hardware):
+@pytest.mark.parametrize('spelling', ['canonical', 'parent', 'relative-parent'])
+def test_unplug_during_full_refresh_io_remains_waiting(hardware, monkeypatch, spelling):
     import errno
     observer, root, *_ = hardware
     observer.observe(root, writable=True)
+    supplied = root if spelling == 'canonical' else root / '..' / root.name
+    if spelling == 'relative-parent':
+        monkeypatch.chdir(root.parent)
+        supplied = root.name + '/../' + root.name
     def absent(key):
         raise FileNotFoundError(key)
     def unplug_during_bind(*args, **kwargs):
@@ -532,13 +537,18 @@ def test_unplug_during_full_refresh_io_remains_waiting(hardware):
         raise OSError(errno.EIO, 'device unplugged during full observation')
     observer._tree_factory = unplug_during_bind
     with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
-        observer.observe(root, writable=True)
+        observer.observe(supplied, writable=True)
 
 
-def test_unplug_during_full_refresh_xattr_proof_remains_waiting(hardware, monkeypatch):
+@pytest.mark.parametrize('spelling', ['canonical', 'parent', 'relative-parent'])
+def test_unplug_during_full_refresh_xattr_proof_remains_waiting(hardware, monkeypatch, spelling):
     import errno
     observer, root, _, _, _, module = hardware
     observer.observe(root, writable=True)
+    supplied = root if spelling == 'canonical' else root / '..' / root.name
+    if spelling == 'relative-parent':
+        monkeypatch.chdir(root.parent)
+        supplied = root.name + '/../' + root.name
     def absent(key):
         raise FileNotFoundError(key)
     def unplug_during_xattr(*args):
@@ -546,4 +556,4 @@ def test_unplug_during_full_refresh_xattr_proof_remains_waiting(hardware, monkey
         raise OSError(errno.EIO, 'device unplugged during namespace probe')
     monkeypatch.setattr(module.os, 'getxattr', unplug_during_xattr)
     with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
-        observer.observe(root, writable=True)
+        observer.observe(supplied, writable=True)

--- a/tests/test_slice_hardware.py
+++ b/tests/test_slice_hardware.py
@@ -10,8 +10,9 @@ from modelark.slice.transaction import TransferRefusal
 
 
 @pytest.fixture
-def hardware(tmp_path):
+def hardware(tmp_path, monkeypatch):
     module = importlib.import_module("modelark.slice.hardware")
+    monkeypatch.setattr(module, '_backing_identity', lambda key: (42, key))
     root = tmp_path / "usb"
     root.mkdir()
     with BoundTree(root) as tree:
@@ -301,3 +302,159 @@ def test_lsblk_uses_explicit_read_only_json_columns(monkeypatch, hardware):
         return SimpleNamespace(stdout='{"blockdevices": []}')
     monkeypatch.setattr(module.subprocess, "run", run)
     assert module._inventory() == {"blockdevices": []}
+
+
+def test_unrelated_mounted_loop_does_not_block_usb(hardware):
+    observer, root, state, _, _, _ = hardware
+    state['inventory']['blockdevices'].append({'name': '/dev/loop0', 'path': '/dev/loop0',
+                                              'type': 'loop', 'maj:min': '7:0'})
+    state['mounts'].append('901 1 7:0 / /snap/example ro - squashfs /dev/loop0 ro')
+    assert observer.observe(root, writable=True).fs_uuid == 'USB-FS'
+
+
+def test_still_mounted_device_missing_from_inventory_is_attended_loss(hardware):
+    observer, root, state, _, _, _ = hardware
+    state['inventory']['blockdevices'].pop()
+    with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
+        observer.observe(root, writable=True)
+
+
+@pytest.mark.parametrize('side', ['mount', 'super'])
+def test_disabled_user_xattrs_refuse_readonly_admission(hardware, side):
+    observer, root, state, _, _, _ = hardware
+    line = state['mounts'][1]
+    left, right = line.split(' - ')
+    if side == 'mount':
+        left = left.replace('rw,relatime', 'rw,relatime,nouser_xattr')
+    else:
+        right += ',nouser_xattr'
+    state['mounts'][1] = left + ' - ' + right
+    with pytest.raises(TransferRefusal, match='DESTINATION_NOT_WRITABLE'):
+        observer.observe(root, writable=True)
+    assert not list(root.iterdir())
+
+
+def test_operator_without_root_creation_permission_refuses_before_writes(hardware):
+    observer, root, *_ = hardware
+    root.chmod(0o555)
+    try:
+        with pytest.raises(TransferRefusal, match='DESTINATION_NOT_WRITABLE'):
+            observer.observe(root, writable=True)
+        assert not list(root.iterdir())
+    finally:
+        root.chmod(0o755)
+
+
+def test_chunk_checks_do_not_repeat_full_inventory(hardware):
+    observer, root, state, _, _, _ = hardware
+    calls = []
+    observer._inventory = lambda: calls.append('inventory') or state['inventory']
+    evidence = observer.observe(root, writable=True)
+    with BoundTree(root, writable=True) as tree:
+        for _ in range(20):
+            observer.check_attachment(tree, evidence)
+    assert calls == ['inventory', 'inventory']
+
+
+def test_backing_loss_is_sticky_even_while_mount_id_survives(hardware):
+    observer, root, *_ = hardware
+    evidence = observer.observe(root, writable=True)
+    original = observer._backing
+    def gone(key):
+        raise FileNotFoundError(key)
+    with BoundTree(root, writable=True) as tree:
+        observer._backing = gone
+        with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
+            observer.check_attachment(tree, evidence)
+        observer._backing = original
+        with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
+            observer.check_attachment(tree, evidence)
+    # Only a new retained attachment can continue after an explicit fresh observation.
+    fresh = observer.observe(root, writable=True)
+    with BoundTree(root, writable=True) as tree:
+        observer.check_attachment(tree, fresh)
+
+
+@pytest.mark.parametrize('change', ['sibling', 'swap', 'archive', 'readonly', 'backing'])
+def test_hot_checks_revalidate_changed_topology_or_roles(hardware, change):
+    from types import SimpleNamespace
+    observer, root, state, disk, _, _ = hardware
+    evidence = observer.observe(root, writable=True)
+    archives = ()
+    if change in {'sibling', 'swap'}:
+        disk['children'].append({'name': '/dev/testusb2', 'type': 'part', 'pkname': '/dev/testusb',
+                                 'maj:min': '240:2', 'uuid': 'other-fs'})
+        if change == 'sibling':
+            state['mounts'].append('901 1 240:2 / /other rw - ext4 /dev/testusb2 rw')
+        else:
+            state['swaps'] += '/dev/testusb2 partition 4096 0 -2\n'
+    elif change == 'archive':
+        archives = (SimpleNamespace(fs_uuid='USB-FS', serial=None),)
+    elif change == 'readonly':
+        state['mounts'][1] = state['mounts'][1].replace('rw', 'ro')
+    else:
+        observer._backing = lambda key: (99, key)
+    with BoundTree(root, writable=True) as tree, pytest.raises(TransferRefusal):
+        observer.check_attachment(tree, evidence, archives=archives)
+
+
+def test_protected_loop_backing_remains_unproven(hardware):
+    observer, root, state, *_ = hardware
+    state['inventory']['blockdevices'].append({'name': '/dev/loop0', 'type': 'loop', 'maj:min': '7:0'})
+    state['mounts'].append('901 1 7:0 / /var/lib/foreign ro - squashfs /dev/loop0 ro')
+    with pytest.raises(TransferRefusal, match='DESTINATION_UNPROVEN'):
+        observer.observe(root, writable=True)
+
+
+def test_user_xattr_read_probe_refuses_unsupported_namespace(hardware, monkeypatch):
+    import errno
+    observer, root, _, _, _, module = hardware
+    def unsupported(*args):
+        raise OSError(errno.EOPNOTSUPP, 'user namespace disabled')
+    monkeypatch.setattr(module.os, 'getxattr', unsupported)
+    with pytest.raises(TransferRefusal, match='DESTINATION_NOT_WRITABLE'):
+        observer.observe(root, writable=True)
+
+
+def test_unplug_between_backing_probe_and_descriptor_check_remains_waiting(hardware, monkeypatch):
+    import errno
+    observer, root, *_ = hardware
+    evidence = observer.observe(root, writable=True)
+    def absent(key):
+        raise FileNotFoundError(key)
+    with BoundTree(root, writable=True) as tree:
+        def unplug_during_check():
+            observer._backing = absent
+            raise OSError(errno.EIO, 'device unplugged during descriptor check')
+        monkeypatch.setattr(tree, 'check', unplug_during_check)
+        with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
+            observer.check_attachment(tree, evidence)
+        assert tree._attachment_lost
+
+
+def test_unplug_during_full_refresh_io_remains_waiting(hardware):
+    import errno
+    observer, root, *_ = hardware
+    observer.observe(root, writable=True)
+    def absent(key):
+        raise FileNotFoundError(key)
+    def unplug_during_bind(*args, **kwargs):
+        observer._backing = absent
+        raise OSError(errno.EIO, 'device unplugged during full observation')
+    observer._tree_factory = unplug_during_bind
+    with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
+        observer.observe(root, writable=True)
+
+
+def test_unplug_during_full_refresh_xattr_proof_remains_waiting(hardware, monkeypatch):
+    import errno
+    observer, root, _, _, _, module = hardware
+    observer.observe(root, writable=True)
+    def absent(key):
+        raise FileNotFoundError(key)
+    def unplug_during_xattr(*args):
+        observer._backing = absent
+        raise OSError(errno.EIO, 'device unplugged during namespace probe')
+    monkeypatch.setattr(module.os, 'getxattr', unplug_during_xattr)
+    with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
+        observer.observe(root, writable=True)

--- a/tests/test_slice_hardware.py
+++ b/tests/test_slice_hardware.py
@@ -32,6 +32,19 @@ def hardware(tmp_path, monkeypatch):
     mounts = ["1 0 241:1 / / rw,relatime - ext4 /dev/testhost1 rw",
               f"{mount_id} 1 {major_minor} / {root} rw,relatime - ext4 /dev/testusb1 rw"]
     state = {"inventory": inventory, "mounts": mounts, "swaps": "Filename\tType\tSize\tUsed\tPriority\n"}
+    def protected(path, *, directory=True, optional=False):
+        requested = str(path)
+        target = state.get('protected_targets', {}).get(requested, requested)
+        if target is None:
+            return None
+        covering = [mount for mount in module._mounts('\n'.join(state['mounts']))
+                    if target == mount.path or target.startswith(mount.path.rstrip('/') + '/')]
+        longest = max(len(mount.path) for mount in covering)
+        matching = [mount for mount in covering if len(mount.path) == longest]
+        assert len(matching) == 1, 'ambiguous synthetic protected fixture'
+        mount = matching[0]
+        return module.ProtectedTarget(requested, target, mount.major_minor, mount.mount_id, 1)
+    monkeypatch.setattr(module, 'resolve_protected', protected)
     observer = module.LinuxObserver(inventory=lambda: state["inventory"], mounts=lambda: "\n".join(state["mounts"]),
                                     swaps=lambda: state["swaps"])
     return observer, root, state, usb, leaf, module
@@ -54,6 +67,115 @@ def test_direct_usb_evidence_binds_whole_disk_and_stable_capability_profile(hard
     assert value.binding().filesystem_id == "USB-FS"
     assert value.binding().mount_id != str(value.mount_id)
     assert value.device_id != value.fs_uuid
+
+
+def test_resolved_home_target_on_destination_disk_is_excluded(hardware):
+    from types import SimpleNamespace
+    observer, root, _, _, leaf, _ = hardware
+    with BoundTree(root) as tree:
+        mount_id = tree.mount_id
+    def resolve(path, **kwargs):
+        if str(path) == '/home':
+            return SimpleNamespace(requested='/home', path=str(root), major_minor=leaf['maj:min'],
+                                   mount_id=mount_id, inode=1)
+        return SimpleNamespace(requested=str(path), path=str(path), major_minor='241:1', mount_id=1, inode=1)
+    observer._resolver = resolve
+    with pytest.raises(TransferRefusal, match='system or swap'):
+        observer.observe(root, writable=True)
+
+
+def test_hardware_mount_parser_preserves_unicode_whitespace_filename():
+    from modelark.slice.hardware import _mounts
+    mount = _mounts('1 0 8:1 / /media/a\u00a0b\u2028c rw - ext4 /dev/test rw\n')[0]
+    assert mount.path == '/media/a\u00a0b\u2028c'
+
+
+def test_resolved_protected_directory_excludes_nested_mounted_disk(hardware):
+    observer, root, state, disk, _, _ = hardware
+    state['protected_targets'] = {'/home': '/data/users'}
+    disk['children'].append({'name': '/dev/testusb2', 'path': '/dev/testusb2', 'type': 'part',
+                            'pkname': '/dev/testusb', 'maj:min': '240:2', 'size': 10**14,
+                            'fstype': 'ext4', 'uuid': 'NESTED-HOME-FS', 'ro': False})
+    state['mounts'].append('912 1 240:2 / /data/users/nested rw - ext4 /dev/testusb2 rw')
+    # Read-only eligibility has no blanket writable sibling exclusion: this
+    # rejection must come from the resolved protected directory's nested mount.
+    with pytest.raises(TransferRefusal, match='system or swap'):
+        observer.observe(root)
+
+
+def test_swapfile_symlink_target_excludes_its_actual_disk(hardware):
+    observer, root, state, *_ = hardware
+    name = '/swap\u00a0alias\u2028file'
+    state['swaps'] += name + '\tfile\t4096\t0\t-2\n'
+    state['protected_targets'] = {name: str(root / 'actual-swap')}
+    with pytest.raises(TransferRefusal, match='system or swap'):
+        observer.observe(root, writable=True)
+
+
+def test_optional_missing_protected_directory_is_recorded_and_revalidated(hardware):
+    observer, root, state, *_ = hardware
+    state['protected_targets'] = {'/home': None}
+    evidence = observer.observe(root, writable=True)
+    state['protected_targets']['/home'] = str(root)
+    with BoundTree(root, writable=True) as tree:
+        with pytest.raises(TransferRefusal, match='system or swap'):
+            observer.check_attachment(tree, evidence)
+
+
+def test_hot_check_revalidates_symlink_target_without_mount_inventory_change(hardware):
+    observer, root, state, *_ = hardware
+    state['protected_targets'] = {'/home': '/data/users'}
+    evidence = observer.observe(root, writable=True)
+    before = tuple(state['mounts'])
+    state['protected_targets']['/home'] = str(root)
+    with BoundTree(root, writable=True) as tree:
+        with pytest.raises(TransferRefusal, match='system or swap'):
+            observer.check_attachment(tree, evidence)
+    assert tuple(state['mounts']) == before
+
+
+@pytest.mark.parametrize('change', ['mount_id', 'major_minor'])
+def test_protected_descriptor_must_match_mount_snapshot(hardware, change):
+    from dataclasses import replace
+    observer, root, _, _, _, _ = hardware
+    original = observer._resolver
+    def resolve(path, **kwargs):
+        target = original(path, **kwargs)
+        if str(path) == '/home':
+            return replace(target, **{change: 991 if change == 'mount_id' else '999:9'})
+        return target
+    observer._resolver = resolve
+    with pytest.raises(TransferRefusal, match='protected descriptor'):
+        observer.observe(root, writable=True)
+
+
+def test_observation_revalidates_protected_target_before_caching(hardware):
+    observer, root, state, *_ = hardware
+    original = observer._resolver
+    calls = 0
+    def resolve(path, **kwargs):
+        nonlocal calls
+        if str(path) == '/home':
+            calls += 1
+            if calls == 2:
+                state['protected_targets'] = {'/home': str(root)}
+        return original(path, **kwargs)
+    observer._resolver = resolve
+    with pytest.raises(TransferRefusal, match='inventory changed'):
+        observer.observe(root, writable=True)
+    assert not observer._observed
+
+
+def test_dangling_protected_role_does_not_become_optional_absence(hardware):
+    observer, root, *_ = hardware
+    original = observer._resolver
+    def resolve(path, **kwargs):
+        if str(path) == '/home':
+            raise FileNotFoundError('dangling protected home')
+        return original(path, **kwargs)
+    observer._resolver = resolve
+    with pytest.raises(TransferRefusal, match='DESTINATION_UNPROVEN.*dangling'):
+        observer.observe(root, writable=True)
 
 
 @pytest.mark.parametrize("field,value", [("tran", "sata"), ("serial", None), ("ro", True)])
@@ -499,7 +621,7 @@ def test_unknown_default_acl_probe_failure_is_not_absence(hardware, monkeypatch,
             raise OSError(number, 'default ACL cannot be inspected')
         return original(fd, name)
     monkeypatch.setattr(module.os, 'getxattr', uncertain)
-    code = 'DESTINATION_UNPROVEN' if number == 5 else 'DESTINATION_CAPACITY_UNPROVEN'
+    code = 'DESTINATION_CAPACITY_UNPROVEN'
     with pytest.raises(TransferRefusal, match=code + '.*default ACL'):
         observer.observe(root, writable=True)
     assert not list(root.iterdir())

--- a/tests/test_slice_hardware.py
+++ b/tests/test_slice_hardware.py
@@ -419,7 +419,7 @@ def test_lsblk_uses_explicit_read_only_json_columns(monkeypatch, hardware):
     *_, module = hardware
     def run(command, **kwargs):
         assert command == ["lsblk", "--json", "--bytes", "--paths", "--output",
-                           "NAME,PATH,TYPE,PKNAME,MAJ:MIN,SIZE,FSTYPE,UUID,SERIAL,WWN,TRAN,RO"]
+                           "NAME,PATH,KNAME,TYPE,PKNAME,MAJ:MIN,SIZE,FSTYPE,UUID,SERIAL,WWN,TRAN,RO"]
         assert kwargs == {"check": True, "capture_output": True, "text": True}
         return SimpleNamespace(stdout='{"blockdevices": []}')
     monkeypatch.setattr(module.subprocess, "run", run)

--- a/tests/test_slice_host_observation.py
+++ b/tests/test_slice_host_observation.py
@@ -1,0 +1,150 @@
+"""Lossless procfs and descriptor-backed protected roles on disposable paths only."""
+import importlib
+import os
+
+import pytest
+
+
+def test_filesystem_text_preserves_non_utf8_bytes_without_text_decoding(tmp_path, monkeypatch):
+    host = importlib.import_module('modelark.slice.host_observation')
+    path = tmp_path / 'proc-fixture'
+    content = b'/mnt/nonutf-\xff\n'
+    path.write_bytes(content)
+    monkeypatch.setattr(type(path), 'read_text', lambda *args, **kwargs: pytest.fail('lossy text IO'))
+    assert os.fsencode(host.read_fs_text(path)) == content
+
+
+def test_proc_fields_and_records_preserve_unicode_whitespace_and_encoded_newlines():
+    host = importlib.import_module('modelark.slice.host_observation')
+    pathname = '/mnt/a\u00a0b\u2028c\u0085d\\012e'
+    text = f'12 1 8:1 / {pathname} rw - ext4 /dev/test rw\n'
+    mounts = host.parse_mounts(text)
+    assert len(mounts) == 1
+    assert mounts[0].path == '/mnt/a\u00a0b\u2028c\u0085d\ne'
+    assert host.proc_fields(pathname + '\tfile 4096 0 -2')[0] == pathname
+
+
+def test_mount_and_octal_decoding_round_trip_arbitrary_filename_bytes():
+    host = importlib.import_module('modelark.slice.host_observation')
+    raw = b'12 1 8:1 / /mnt/raw-\xff\\040space\\012line rw - ext4 /dev/test rw\n'
+    mount = host.parse_mounts(os.fsdecode(raw))[0]
+    assert os.fsencode(mount.path) == b'/mnt/raw-\xff space\nline'
+    assert os.fsencode(host.decode_proc_path('/mnt/\\377')) == b'/mnt/\xff'
+
+
+def test_protected_directory_resolves_symlink_and_binds_actual_descriptor(tmp_path):
+    host = importlib.import_module('modelark.slice.host_observation')
+    actual = tmp_path / 'actual-home'
+    actual.mkdir()
+    link = tmp_path / 'home'
+    link.symlink_to(actual, target_is_directory=True)
+    target = host.resolve_protected(link)
+    info = actual.stat()
+    assert target.path == str(actual)
+    assert target.major_minor == f'{os.major(info.st_dev)}:{os.minor(info.st_dev)}'
+    assert target.inode == info.st_ino
+    assert target.mount_id > 0
+
+
+def test_protected_file_resolves_parent_symlinks(tmp_path):
+    host = importlib.import_module('modelark.slice.host_observation')
+    actual = tmp_path / 'actual'
+    actual.mkdir()
+    (actual / 'swap').write_bytes(b'disposable')
+    link = tmp_path / 'alias'
+    link.symlink_to(actual, target_is_directory=True)
+    assert host.resolve_protected(link / 'swap', directory=False).path == str(actual / 'swap')
+
+
+def test_absent_optional_role_is_distinct_from_dangling_symlink(tmp_path):
+    host = importlib.import_module('modelark.slice.host_observation')
+    missing = tmp_path / 'absent'
+    assert host.resolve_protected(missing, optional=True) is None
+    link = tmp_path / 'home'
+    link.symlink_to(missing, target_is_directory=True)
+    with pytest.raises(OSError):
+        host.resolve_protected(link, optional=True)
+    with pytest.raises(OSError):
+        host.resolve_protected(link / 'nested', optional=True)
+
+
+def test_unresolvable_protected_role_is_not_treated_as_absent(tmp_path):
+    host = importlib.import_module('modelark.slice.host_observation')
+    link = tmp_path / 'loop'
+    link.symlink_to(link)
+    with pytest.raises(OSError):
+        host.resolve_protected(link, optional=True)
+
+
+def test_protected_target_change_during_descriptor_observation_refuses(tmp_path, monkeypatch):
+    host = importlib.import_module('modelark.slice.host_observation')
+    first, second = tmp_path / 'first', tmp_path / 'second'
+    first.mkdir()
+    second.mkdir()
+    link = tmp_path / 'home'
+    link.symlink_to(first, target_is_directory=True)
+    realpath = host.os.path.realpath
+    changed = False
+    def change(path, **kwargs):
+        nonlocal changed
+        if not changed:
+            changed = True
+            link.unlink()
+            link.symlink_to(second, target_is_directory=True)
+        return realpath(path, **kwargs)
+    monkeypatch.setattr(host.os.path, 'realpath', change)
+    with pytest.raises(host.TransferRefusal, match='DESTINATION_UNPROVEN'):
+        host.resolve_protected(link)
+
+
+def test_namespace_handle_roots_are_preserved_but_not_generalized():
+    from modelark.slice.host_observation import parse_mounts
+    from modelark.slice.transaction import TransferRefusal
+    import pytest
+    row = '51 1 0:4 net:[4026533226] /run/netns/example rw - nsfs nsfs rw\n'
+    assert parse_mounts(row)[0].root == 'net:[4026533226]'
+    with pytest.raises(TransferRefusal):
+        parse_mounts(row.replace(' - nsfs ', ' - ext4 '))
+    with pytest.raises(TransferRefusal):
+        parse_mounts(row.replace('net:[4026533226]', 'arbitrary'))
+
+
+@pytest.mark.parametrize('consumer', ['hardware', 'linux', 'capacity'])
+def test_all_mount_consumers_preserve_filesystem_bytes_and_unicode_records(monkeypatch, consumer):
+    from pathlib import Path
+    from types import SimpleNamespace
+    import stat
+    host = importlib.import_module('modelark.slice.host_observation')
+    module = importlib.import_module('modelark.slice.' + consumer)
+    pathname = b'/mnt/raw-\xff-' + '\u00a0\u2028\u0085'.encode() + b'\\012line'
+    raw = (b'12 1 8:1 / ' + pathname + b' rw - ext4 /dev/test rw\n'
+           b'13 1 0:4 net:[4026533226] /run/netns/example rw - nsfs nsfs rw\n')
+    original = Path.read_bytes
+    def read_bytes(path):
+        return raw if str(path) == '/proc/self/mountinfo' else original(path)
+    monkeypatch.setattr(Path, 'read_bytes', read_bytes)
+    seen = []
+    def parse(text):
+        mounts = host.parse_mounts(text)
+        seen.extend(mounts)
+        return mounts
+    monkeypatch.setattr(module, 'parse_mounts', parse)
+    if consumer == 'hardware':
+        observer = module.LinuxObserver(inventory=lambda: {}, swaps=lambda: '')
+        assert len(module._mounts(observer._mounts())) == 2
+    elif consumer == 'linux':
+        assert module._mount_ids() == frozenset({12, 13})
+    else:
+        # Only the mount feature-parser path is exercised: the block descriptor
+        # and superblock here are explicit synthetic evidence, not live devices.
+        fake_os = SimpleNamespace(
+            O_RDONLY=os.O_RDONLY, O_CLOEXEC=os.O_CLOEXEC, O_NONBLOCK=os.O_NONBLOCK,
+            major=lambda dev: 8, minor=lambda dev: 1,
+            open=lambda *args: 102, close=lambda fd: None, pread=lambda *args: b'synthetic',
+            fstat=lambda fd: SimpleNamespace(st_dev=7, st_rdev=7, st_mode=stat.S_IFBLK))
+        monkeypatch.setattr(module, 'os', fake_os)
+        monkeypatch.setattr(module, 'parse_superblock', lambda data, uuid: {'uuid': uuid})
+        assert module._volume(SimpleNamespace(fd=101, mount_id=12),
+                              SimpleNamespace(fs_uuid='TEST')) == {'uuid': 'TEST'}
+    assert os.fsencode(seen[0].path) == pathname.replace(b'\\012', b'\n')
+    assert seen[1].root == 'net:[4026533226]'

--- a/tests/test_slice_linux.py
+++ b/tests/test_slice_linux.py
@@ -14,6 +14,26 @@ def test_statx_buffer_matches_kernel_abi():
     assert _Statx.mount_id.offset == 144
 
 
+def test_role_mount_probe_does_not_weaken_owned_birth_requirement(monkeypatch):
+    from types import SimpleNamespace
+    from modelark.slice import linux
+    def statx(fd, path, flags, mask, output):
+        output._obj.mask = 0x1100
+        output._obj.ino = 1
+        output._obj.mount_id = 2
+        return 0
+    monkeypatch.setattr(linux, '_libc', lambda: SimpleNamespace(statx=statx))
+    assert linux._statx(3, require_birth=False).mount_id == 2
+    with pytest.raises(TransferRefusal, match='birth time'):
+        linux._statx(3)
+
+
+def test_protected_proc_role_can_be_classified_without_birth_evidence():
+    from modelark.slice.host_observation import resolve_protected
+    target = resolve_protected('/proc')
+    assert target.path == '/proc' and target.mount_id > 0 and target.inode > 0
+
+
 @pytest.mark.parametrize('original_kind', ['io', 'policy'])
 def test_failed_followup_mount_probe_preserves_original_error(tmp_path, monkeypatch, original_kind):
     from modelark.slice import linux

--- a/tests/test_slice_linux.py
+++ b/tests/test_slice_linux.py
@@ -1,5 +1,6 @@
 """Kernel confinement tests on disposable directories, not real mount/device probes."""
 import ctypes
+import errno
 import os
 
 import pytest
@@ -74,3 +75,81 @@ def test_verification_callback_runs_each_boundary(tmp_path):
         with tree.parent("new") as (fd, name):
             assert fd >= 0 and name == "new"
     assert len(seen) >= 2
+
+
+@pytest.mark.parametrize("path_state", ["uncovered", "missing"])
+def test_missing_pinned_mount_waits_without_touching_uncovered_root(tmp_path, path_state):
+    root = tmp_path / "root"
+    root.mkdir()
+    with BoundTree(root) as probe:
+        retained = probe.mount_id
+    mounts = {retained}
+    with BoundTree(root, mount_ids=lambda: mounts) as tree:
+        root.rename(tmp_path / "old")
+        if path_state == "uncovered":
+            root.mkdir()
+        mounts.clear()
+        with pytest.raises(TransferRefusal, match="WAITING_DESTINATION"):
+            tree.check()
+        with pytest.raises(TransferRefusal, match="WAITING_DESTINATION"):
+            tree.open("must-not-write", os.O_CREAT | os.O_WRONLY)
+        assert not (root / "must-not-write").exists()
+        assert not (tmp_path / "old/must-not-write").exists()
+
+
+def test_missing_attachment_never_reacquires_inside_old_bound_tree(tmp_path):
+    with BoundTree(tmp_path) as probe:
+        retained = probe.mount_id
+    mounts = {retained}
+    with BoundTree(tmp_path, mount_ids=lambda: mounts) as tree:
+        mounts.clear()
+        with pytest.raises(TransferRefusal, match="WAITING_DESTINATION"):
+            tree.check()
+        mounts.add(retained)
+        with pytest.raises(TransferRefusal, match="WAITING_DESTINATION"):
+            tree.check()
+
+
+@pytest.mark.parametrize("error", [errno.EIO, errno.ENODEV, errno.ENOENT])
+@pytest.mark.parametrize("disappears", [False, True])
+def test_root_io_errors_require_absence_proof_to_become_waiting(tmp_path, monkeypatch, error, disappears):
+    from modelark.slice import linux
+    with BoundTree(tmp_path) as probe:
+        retained = probe.mount_id
+    mounts = {retained}
+    with BoundTree(tmp_path, mount_ids=lambda: mounts) as tree:
+        def io_error(*args, **kwargs):
+            if disappears:
+                mounts.clear()
+            raise OSError(error, "synthetic root IO failure")
+        monkeypatch.setattr(linux, "_openat2", io_error)
+        if disappears:
+            with pytest.raises(TransferRefusal, match="WAITING_DESTINATION"):
+                tree.check()
+        elif error == errno.ENOENT:
+            with pytest.raises(TransferRefusal, match="DESTINATION_CHANGED"):
+                tree.check()
+        else:
+            with pytest.raises(OSError) as caught:
+                tree.check()
+            assert caught.value.errno == error
+
+
+def test_disappearance_during_verification_is_waiting_not_changed(tmp_path):
+    with BoundTree(tmp_path) as probe:
+        retained = probe.mount_id
+    mounts = {retained}
+    with BoundTree(tmp_path, mount_ids=lambda: mounts) as tree:
+        def verify():
+            mounts.clear()
+            raise TransferRefusal("DESTINATION_CHANGED", "observer saw uncovered host path")
+        tree.verify = verify
+        with pytest.raises(TransferRefusal, match="WAITING_DESTINATION"):
+            tree.check()
+
+
+def test_unknown_mount_inventory_never_counts_as_absence(tmp_path):
+    with BoundTree(tmp_path) as tree:
+        tree._mount_ids = lambda: None
+        with pytest.raises(TransferRefusal, match="DESTINATION_UNPROVEN"):
+            tree.check()

--- a/tests/test_slice_linux.py
+++ b/tests/test_slice_linux.py
@@ -1,0 +1,76 @@
+"""Kernel confinement tests on disposable directories, not real mount/device probes."""
+import ctypes
+import os
+
+import pytest
+
+from modelark.slice.linux import BoundTree, _Statx, link_fd, rename_noreplace
+from modelark.slice.transaction import TransferRefusal
+
+
+def test_statx_buffer_matches_kernel_abi():
+    assert ctypes.sizeof(_Statx) == 256
+    assert _Statx.mount_id.offset == 144
+
+
+def test_confined_read_and_stable_birth_identity(tmp_path):
+    (tmp_path / "file").write_bytes(b"original")
+    with BoundTree(tmp_path) as tree:
+        fd = tree.open("file", os.O_RDWR)
+        try:
+            before = tree.identity(fd)
+            os.write(fd, b"changed")
+            assert tree.identity(fd) == before
+            assert before[2] > 0
+        finally:
+            os.close(fd)
+
+
+@pytest.mark.parametrize("path", ["../escape", "/etc/passwd", "a/../file", "a//file", "", "."])
+def test_invalid_relative_paths_refuse(tmp_path, path):
+    with BoundTree(tmp_path) as tree, pytest.raises(TransferRefusal):
+        tree.open(path, os.O_RDONLY)
+
+
+def test_symlink_component_and_root_refuse(tmp_path):
+    (tmp_path / "link").symlink_to("/etc", target_is_directory=True)
+    with BoundTree(tmp_path) as tree, pytest.raises(OSError):
+        tree.open("link/passwd", os.O_RDONLY)
+    with pytest.raises(OSError):
+        BoundTree(tmp_path / "link")
+
+
+def test_root_replacement_is_detected(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    with BoundTree(root) as tree:
+        root.rename(tmp_path / "old")
+        root.mkdir()
+        with pytest.raises(TransferRefusal, match="DESTINATION_CHANGED"):
+            tree.check()
+
+
+def test_unnamed_file_link_and_no_replace(tmp_path):
+    with BoundTree(tmp_path) as tree:
+        fd = os.open(".", os.O_TMPFILE | os.O_RDWR, 0o600, dir_fd=tree.fd)
+        try:
+            os.write(fd, b"content")
+            link_fd(fd, tree.fd, "temporary")
+            with pytest.raises(FileExistsError):
+                link_fd(fd, tree.fd, "temporary")
+            rename_noreplace(tree.fd, "temporary", tree.fd, "final")
+            assert (tmp_path / "final").read_bytes() == b"content"
+            (tmp_path / "foreign").write_bytes(b"foreign")
+            with pytest.raises(FileExistsError):
+                rename_noreplace(tree.fd, "final", tree.fd, "foreign")
+        finally:
+            os.close(fd)
+
+
+def test_verification_callback_runs_each_boundary(tmp_path):
+    seen = []
+    with BoundTree(tmp_path, verify=lambda: seen.append(True)) as tree:
+        tree.check()
+        with tree.parent("new") as (fd, name):
+            assert fd >= 0 and name == "new"
+    assert len(seen) >= 2

--- a/tests/test_slice_linux.py
+++ b/tests/test_slice_linux.py
@@ -14,6 +14,27 @@ def test_statx_buffer_matches_kernel_abi():
     assert _Statx.mount_id.offset == 144
 
 
+@pytest.mark.parametrize('original_kind', ['io', 'policy'])
+def test_failed_followup_mount_probe_preserves_original_error(tmp_path, monkeypatch, original_kind):
+    from modelark.slice import linux
+    original = (OSError(errno.EIO, 'original root IO') if original_kind == 'io'
+                else TransferRefusal('DESTINATION_CHANGED', 'root was replaced'))
+    with BoundTree(tmp_path) as tree:
+        checks = []
+        def mounts():
+            checks.append(True)
+            if len(checks) > 1:
+                raise OSError(errno.EACCES, 'follow-up inventory denied')
+            return {tree.mount_id}
+        tree._mount_ids = mounts
+        def open_root(*args, **kwargs):
+            raise original
+        monkeypatch.setattr(linux, '_openat2', open_root)
+        with pytest.raises(type(original)) as caught:
+            tree.check()
+        assert caught.value is original
+
+
 def test_confined_read_and_stable_birth_identity(tmp_path):
     (tmp_path / "file").write_bytes(b"original")
     with BoundTree(tmp_path) as tree:

--- a/tests/test_slice_local_source.py
+++ b/tests/test_slice_local_source.py
@@ -52,7 +52,7 @@ def test_raw_original_bytes_without_any_subprocess(attachment, monkeypatch):
         assert stream.read(20) == b""
 
 
-@pytest.mark.parametrize("path_kind", ["relative", "tilde"])
+@pytest.mark.parametrize("path_kind", ["relative", "relative_parent", "nested_parent", "tilde"])
 def test_explicit_attachment_paths_are_expanded_before_observation(attachment, monkeypatch, path_kind):
     from pathlib import Path
     from modelark.slice.local_source import LocalArchiveReader
@@ -60,6 +60,12 @@ def test_explicit_attachment_paths_are_expanded_before_observation(attachment, m
     if path_kind == "relative":
         monkeypatch.chdir(root.parent.parent)
         supplied = "usb/modelark"
+    elif path_kind == "relative_parent":
+        monkeypatch.chdir(root.parent)
+        supplied = "../usb/modelark"
+    elif path_kind == "nested_parent":
+        monkeypatch.chdir(root.parent.parent)
+        supplied = "unused/../usb/modelark/../modelark"
     else:
         supplied = "~/usb/modelark"
         expanduser = Path.expanduser
@@ -76,6 +82,22 @@ def test_explicit_attachment_paths_are_expanded_before_observation(attachment, m
     with LocalArchiveReader({"drive-a": supplied}, observer=observer).open(candidate) as stream:
         assert stream.read(20) == b"originaldata"
     assert observed and all(path == root for path in observed)
+
+
+def test_lexical_parent_normalization_never_resolves_remaining_attachment_symlinks(attachment, monkeypatch):
+    from pathlib import Path
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, evidence = attachment
+    alias = root.parent.parent / "alias"
+    alias.symlink_to(root.parent, target_is_directory=True)
+    evidence.mount_path = str(alias)
+    monkeypatch.chdir(root.parent.parent)
+    monkeypatch.setattr(Path, "resolve", lambda *a, **k: pytest.fail("no symlink resolution"))
+    reader = LocalArchiveReader({"drive-a": "unused/../alias/modelark"}, observer=observer)
+    assert reader.attachments["drive-a"] == alias / "modelark"
+    with pytest.raises(TransferRefusal, match="SOURCE_PATH_UNSAFE"):
+        with reader.open(candidate):
+            pytest.fail("remaining attachment symlink followed")
 
 
 @pytest.mark.parametrize("chunk_size", [1, 6, 64])

--- a/tests/test_slice_local_source.py
+++ b/tests/test_slice_local_source.py
@@ -1,0 +1,205 @@
+"""Disposable source attachments only; readers never retrieve or repair archives."""
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import domain as d
+from modelark.slice.transaction import TransferRefusal
+from test_slice_domain import facts
+
+
+@pytest.fixture
+def attachment(tmp_path):
+    mount = tmp_path / "usb"
+    root = mount / "modelark"
+    (root / ".git").mkdir(parents=True)
+    (root / ".git/config").write_text("[annex]\n uuid = annex-a\n")
+    (root / "org/model").mkdir(parents=True)
+    (root / "org/model/model.safetensors").write_bytes(b"originaldata")
+    snapshot = facts(d)
+    candidate = d.SourceEvidence(snapshot.copies[0], snapshot.drives[0], snapshot.anchors[0],
+                                 "ingestion_computed")
+    evidence = SimpleNamespace(fs_uuid="fs-a", serial="serial-a", total_bytes=1000,
+                               device_id="usb", mount_id="123", mount_path=str(mount))
+
+    class Observer:
+        def observe(self, path, **kwargs):
+            return evidence
+
+    return root, candidate, Observer(), evidence
+
+
+def test_raw_original_bytes_without_any_subprocess(attachment, monkeypatch):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: pytest.fail("no subprocess"))
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(20) == b"originaldata"
+        assert stream.read(20) == b""
+
+
+def test_unattached_archive_is_waiting(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    _, candidate, observer, _ = attachment
+    with pytest.raises(TransferRefusal, match="WAITING_SOURCE"):
+        with LocalArchiveReader({}, observer=observer).open(candidate):
+            pytest.fail("unattached source opened")
+
+
+@pytest.mark.parametrize("field", ["fs_uuid", "serial", "total_bytes", "mount_id"])
+def test_identity_changes_refuse_before_next_read(attachment, field):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, evidence = attachment
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        setattr(evidence, field, 2000 if field == "total_bytes" else "changed")
+        with pytest.raises(TransferRefusal, match="SOURCE_CHANGED"):
+            stream.read(20)
+
+
+def test_annex_uuid_change_refused(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    (root / ".git/config").write_text("[annex]\n uuid = other\n")
+    with pytest.raises(TransferRefusal, match="SOURCE_CHANGED"):
+        with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate):
+            pytest.fail("wrong repository opened")
+
+
+def test_annex_link_confined_and_key_bound(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    key = candidate.copy.annex_key
+    obj = root / ".git/annex/objects/aaa/bbb" / key / key
+    obj.parent.mkdir(parents=True)
+    obj.write_bytes(b"originaldata")
+    (root / "org/model/model.safetensors").unlink()
+    (root / "org/model/model.safetensors").symlink_to("../../" + obj.relative_to(root).as_posix())
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(20) == b"originaldata"
+    obj.unlink()
+    with pytest.raises(TransferRefusal, match="SOURCE_MISSING"):
+        with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate):
+            pytest.fail("missing annex object retrieved")
+
+
+@pytest.mark.parametrize("target", ["../outside", "/etc/passwd", "other",
+                                    ".git/annex/objects/aaa/bbb/wrong/wrong"])
+def test_non_annex_symlinks_refused(attachment, target):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    (root / "org/model/model.safetensors").unlink()
+    (root / "org/model/model.safetensors").symlink_to(target)
+    with pytest.raises(TransferRefusal, match="SOURCE_PATH_UNSAFE"):
+        with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate):
+            pytest.fail("unsafe symlink opened")
+
+
+def test_parent_symlink_is_never_followed(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    (root / "org/model/alias").symlink_to(".")
+    candidate = replace(candidate, copy=replace(candidate.copy, stored_relpath="alias/model.safetensors"))
+    with pytest.raises(TransferRefusal, match="SOURCE_PATH_UNSAFE"):
+        with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate):
+            pytest.fail("parent symlink followed")
+
+
+def test_consumer_failure_is_not_translated_to_source(attachment):
+    import errno
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    with pytest.raises(OSError) as caught:
+        with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate):
+            raise OSError(errno.ENOSPC, "destination full")
+    assert caught.value.errno == errno.ENOSPC
+
+
+def test_archive_replacement_revokes_even_buffered_read(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(1) == b"o"
+        root.rename(root.with_name("old"))
+        root.mkdir()
+        with pytest.raises(TransferRefusal, match="SOURCE_CHANGED"):
+            stream.read(1)
+
+
+def test_compressed_annex_content_yields_original_bytes(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    from modelark.streamznn import _zipnn
+    import hashlib
+    root, candidate, observer, _ = attachment
+    data = bytes(128)
+    blob = bytes(_zipnn(dtype="bfloat16", threads=1).compress(bytearray(data)))
+    key = f"SHA256E-s{len(blob)}--{hashlib.sha256(blob).hexdigest()}.znn"
+    obj = root / ".git/annex/objects/aaa/bbb" / key / key
+    obj.parent.mkdir(parents=True)
+    obj.write_bytes(blob)
+    (root / "org/model/model.safetensors").unlink()
+    (root / "org/model/model.safetensors").symlink_to("../../" + obj.relative_to(root).as_posix())
+    candidate = replace(candidate, copy=replace(candidate.copy, compressed=True, annex_key=key,
+                                                orig_bytes=len(data), stored_bytes=len(blob)))
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(128) == data
+        assert stream.read(1) == b""
+
+
+def test_repo_relative_path_cannot_be_shadowed_by_archive_root(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    (root / "model.safetensors").write_bytes(b"wrongcontent")
+    (root / "different/model").mkdir(parents=True)
+    (root / "different/model/model.safetensors").write_bytes(b"anothermodel")
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(20) == b"originaldata"
+    (root / "org/model/model.safetensors").unlink()
+    with pytest.raises(TransferRefusal, match="SOURCE_MISSING"):
+        with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate):
+            pytest.fail("root-level file must not substitute for missing repository copy")
+
+
+def test_nested_stored_path_uses_repository_relative_annex_link(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    key = candidate.copy.annex_key
+    obj = root / ".git/annex/objects/aaa/bbb" / key / key
+    obj.parent.mkdir(parents=True)
+    obj.write_bytes(b"originaldata")
+    (root / "org/model/nested").mkdir()
+    (root / "org/model/nested/model.safetensors").symlink_to(
+        "../../../" + obj.relative_to(root).as_posix())
+    candidate = replace(candidate, copy=replace(candidate.copy, stored_relpath="nested/model.safetensors"))
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(20) == b"originaldata"
+
+
+@pytest.mark.parametrize("when", ["initial", "reading"])
+@pytest.mark.parametrize("code,expected", [
+    ("DESTINATION_UNPROVEN", "SOURCE_IDENTITY_UNPROVEN"),
+    ("DESTINATION_CHANGED", "SOURCE_CHANGED"),
+    ("DESTINATION_CAPACITY_UNPROVEN", "SOURCE_IDENTITY_UNPROVEN"),
+    ("FILESYSTEM_UNSUPPORTED", "SOURCE_IDENTITY_UNPROVEN"),
+])
+def test_shared_observer_refusals_are_source_side(attachment, monkeypatch, when, code, expected):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+
+    def refuse(path, **kwargs):
+        raise TransferRefusal(code, "synthetic observation refused")
+
+    reader = LocalArchiveReader({"drive-a": root}, observer=observer)
+    if when == "initial":
+        monkeypatch.setattr(observer, "observe", refuse)
+        with pytest.raises(TransferRefusal) as caught:
+            with reader.open(candidate):
+                pytest.fail("unproven source opened")
+    else:
+        with reader.open(candidate) as stream:
+            assert stream.read(1) == b"o"
+            monkeypatch.setattr(observer, "observe", refuse)
+            with pytest.raises(TransferRefusal) as caught:
+                stream.read(1)
+    assert caught.value.code == expected
+    assert caught.value.detail == "synthetic observation refused"

--- a/tests/test_slice_local_source.py
+++ b/tests/test_slice_local_source.py
@@ -4,6 +4,26 @@ from types import SimpleNamespace
 
 import pytest
 
+
+@pytest.mark.parametrize('consumer_error', [False, True])
+def test_source_cleanup_failure_never_masks_or_blames_consumer(consumer_error):
+    import errno
+    from modelark.slice.local_source import _SourceStack
+    from modelark.slice.transaction import TransferRefusal
+    original = OSError(errno.ENOSPC, 'destination consumer failure')
+    def close_source():
+        raise OSError(errno.EIO, 'source close failed')
+    expected = OSError if consumer_error else TransferRefusal
+    with pytest.raises(expected) as caught:
+        with _SourceStack('archive') as stack:
+            stack.callback(close_source)
+            if consumer_error:
+                raise original
+    if consumer_error:
+        assert caught.value is original
+    else:
+        assert caught.value.code == 'SOURCE_READ_FAILED'
+
 from modelark.slice import domain as d
 from modelark.slice.transaction import TransferRefusal
 from test_slice_domain import facts
@@ -39,6 +59,9 @@ def attachment(tmp_path):
             tree.check()
             if _identity(evidence) != self.identity:
                 raise TransferRefusal("SOURCE_CHANGED", "synthetic attachment proof changed")
+
+        def recheck_attachment(self, tree, observed):
+            tree.check()
 
     return root, candidate, Observer(), evidence
 

--- a/tests/test_slice_local_source.py
+++ b/tests/test_slice_local_source.py
@@ -27,8 +27,18 @@ def attachment(tmp_path):
                                device_id="usb", mount_id=mount_id, mount_path=str(mount))
 
     class Observer:
+        def __init__(self):
+            from modelark.slice.local_source import _identity
+            self.identity = _identity(evidence)
+
         def observe(self, path, **kwargs):
             return evidence
+
+        def check_attachment(self, tree, observed):
+            from modelark.slice.local_source import _identity
+            tree.check()
+            if _identity(evidence) != self.identity:
+                raise TransferRefusal("SOURCE_CHANGED", "synthetic attachment proof changed")
 
     return root, candidate, Observer(), evidence
 
@@ -40,6 +50,82 @@ def test_raw_original_bytes_without_any_subprocess(attachment, monkeypatch):
     with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
         assert stream.read(20) == b"originaldata"
         assert stream.read(20) == b""
+
+
+@pytest.mark.parametrize("path_kind", ["relative", "tilde"])
+def test_explicit_attachment_paths_are_expanded_before_observation(attachment, monkeypatch, path_kind):
+    from pathlib import Path
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, evidence = attachment
+    if path_kind == "relative":
+        monkeypatch.chdir(root.parent.parent)
+        supplied = "usb/modelark"
+    else:
+        supplied = "~/usb/modelark"
+        expanduser = Path.expanduser
+        # Resolve a synthetic home without modifying HOME or creating real home files.
+        monkeypatch.setattr(Path, "expanduser", lambda path:
+                            root if str(path) == supplied else expanduser(path))
+    observed = []
+
+    def observe(path, **kwargs):
+        observed.append(path)
+        return evidence
+
+    monkeypatch.setattr(observer, "observe", observe)
+    with LocalArchiveReader({"drive-a": supplied}, observer=observer).open(candidate) as stream:
+        assert stream.read(20) == b"originaldata"
+    assert observed and all(path == root for path in observed)
+
+
+@pytest.mark.parametrize("chunk_size", [1, 6, 64])
+def test_source_inventory_and_annex_proof_are_per_artifact_not_per_chunk(attachment, monkeypatch, chunk_size):
+    from modelark.slice import local_source
+    root, candidate, observer, evidence = attachment
+    observed, configs = [], []
+    annex_uuid = local_source._annex_uuid
+    monkeypatch.setattr(observer, "observe", lambda path, **kwargs: observed.append(path) or evidence)
+    monkeypatch.setattr(local_source, "_annex_uuid", lambda tree: configs.append(tree.path) or annex_uuid(tree))
+    with local_source.LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        pieces = []
+        while chunk := stream.read(chunk_size):
+            pieces.append(chunk)
+    assert b"".join(pieces) == b"originaldata"
+    assert len(observed) == 2
+    assert len(configs) == 1
+
+
+def test_changed_observation_during_artifact_open_is_refused(attachment, monkeypatch):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, evidence = attachment
+    calls = []
+
+    def observe(path, **kwargs):
+        calls.append(path)
+        if len(calls) == 2:
+            evidence.serial = "replaced-device"
+        return evidence
+
+    monkeypatch.setattr(observer, "observe", observe)
+    with pytest.raises(TransferRefusal, match="SOURCE_CHANGED"):
+        with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate):
+            pytest.fail("changed attachment yielded bytes")
+
+
+def test_multi_megabyte_source_has_constant_full_inventory_count(attachment, monkeypatch):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, evidence = attachment
+    payload = b"a" * (3 << 20)
+    (root / "org/model/model.safetensors").write_bytes(payload)
+    candidate = replace(candidate, copy=replace(candidate.copy, orig_bytes=len(payload), stored_bytes=len(payload)))
+    calls = []
+    monkeypatch.setattr(observer, "observe", lambda path, **kwargs: calls.append(path) or evidence)
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(1 << 20) == payload[:1 << 20]
+        assert stream.read(1 << 20) == payload[:1 << 20]
+        assert stream.read(1 << 20) == payload[:1 << 20]
+        assert stream.read(1 << 20) == b""
+    assert len(calls) == 2
 
 
 def test_source_observer_and_descriptor_must_be_same_attachment(attachment):
@@ -141,12 +227,30 @@ def test_archive_replacement_revokes_even_buffered_read(attachment):
 def test_disappeared_bound_mount_is_a_source_missing_refusal(attachment, monkeypatch):
     from modelark.slice import linux
     from modelark.slice.local_source import LocalArchiveReader
-    root, candidate, observer, _ = attachment
+    root, candidate, observer, evidence = attachment
     mounts = set(linux._mount_ids())
     monkeypatch.setattr(linux, "_mount_ids", lambda: mounts)
     with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
         assert stream.read(1) == b"o"
         mounts.clear()  # Synthetic disappearance; no real mounts are changed.
+        with pytest.raises(TransferRefusal, match="SOURCE_MISSING"):
+            stream.read(1)
+        mounts.add(evidence.mount_id)
+        with pytest.raises(TransferRefusal, match="SOURCE_MISSING"):
+            stream.read(1)  # A retained stale source cannot silently resume after reattachment.
+
+
+def test_lost_backing_device_refuses_even_when_mount_remains(attachment, monkeypatch):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(1) == b"o"
+
+        def gone(tree, observed):
+            tree.check()  # The directory and mount still exist in this schedule.
+            raise TransferRefusal("WAITING_DESTINATION", "backing USB device disappeared")
+
+        monkeypatch.setattr(observer, "check_attachment", gone)
         with pytest.raises(TransferRefusal, match="SOURCE_MISSING"):
             stream.read(1)
 
@@ -224,7 +328,7 @@ def test_shared_observer_refusals_are_source_side(attachment, monkeypatch, when,
     else:
         with reader.open(candidate) as stream:
             assert stream.read(1) == b"o"
-            monkeypatch.setattr(observer, "observe", refuse)
+            monkeypatch.setattr(observer, "check_attachment", lambda *args: refuse(None))
             with pytest.raises(TransferRefusal) as caught:
                 stream.read(1)
     assert caught.value.code == expected

--- a/tests/test_slice_local_source.py
+++ b/tests/test_slice_local_source.py
@@ -20,8 +20,11 @@ def attachment(tmp_path):
     snapshot = facts(d)
     candidate = d.SourceEvidence(snapshot.copies[0], snapshot.drives[0], snapshot.anchors[0],
                                  "ingestion_computed")
+    from modelark.slice.linux import BoundTree
+    with BoundTree(root) as tree:
+        mount_id = tree.mount_id
     evidence = SimpleNamespace(fs_uuid="fs-a", serial="serial-a", total_bytes=1000,
-                               device_id="usb", mount_id="123", mount_path=str(mount))
+                               device_id="usb", mount_id=mount_id, mount_path=str(mount))
 
     class Observer:
         def observe(self, path, **kwargs):
@@ -37,6 +40,15 @@ def test_raw_original_bytes_without_any_subprocess(attachment, monkeypatch):
     with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
         assert stream.read(20) == b"originaldata"
         assert stream.read(20) == b""
+
+
+def test_source_observer_and_descriptor_must_be_same_attachment(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, evidence = attachment
+    evidence.mount_id = -999
+    with pytest.raises(TransferRefusal, match='SOURCE_CHANGED'):
+        with LocalArchiveReader({'drive-a': root}, observer=observer).open(candidate):
+            pytest.fail('unrelated attachment evidence accepted')
 
 
 def test_unattached_archive_is_waiting(attachment):
@@ -126,6 +138,19 @@ def test_archive_replacement_revokes_even_buffered_read(attachment):
             stream.read(1)
 
 
+def test_disappeared_bound_mount_is_a_source_missing_refusal(attachment, monkeypatch):
+    from modelark.slice import linux
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    mounts = set(linux._mount_ids())
+    monkeypatch.setattr(linux, "_mount_ids", lambda: mounts)
+    with LocalArchiveReader({"drive-a": root}, observer=observer).open(candidate) as stream:
+        assert stream.read(1) == b"o"
+        mounts.clear()  # Synthetic disappearance; no real mounts are changed.
+        with pytest.raises(TransferRefusal, match="SOURCE_MISSING"):
+            stream.read(1)
+
+
 def test_compressed_annex_content_yields_original_bytes(attachment):
     from modelark.slice.local_source import LocalArchiveReader
     from modelark.streamznn import _zipnn
@@ -177,6 +202,7 @@ def test_nested_stored_path_uses_repository_relative_annex_link(attachment):
 
 @pytest.mark.parametrize("when", ["initial", "reading"])
 @pytest.mark.parametrize("code,expected", [
+    ("WAITING_DESTINATION", "SOURCE_MISSING"),
     ("DESTINATION_UNPROVEN", "SOURCE_IDENTITY_UNPROVEN"),
     ("DESTINATION_CHANGED", "SOURCE_CHANGED"),
     ("DESTINATION_CAPACITY_UNPROVEN", "SOURCE_IDENTITY_UNPROVEN"),

--- a/tests/test_slice_mapper_inventory.py
+++ b/tests/test_slice_mapper_inventory.py
@@ -1,0 +1,47 @@
+"""Kernel-name evidence resolves mapper PKNAME without relaxing ancestry checks."""
+from copy import deepcopy
+
+import pytest
+
+from modelark.slice.hardware import _Inventory
+from modelark.slice.transaction import TransferRefusal
+
+
+def mapped():
+    logical = {"path": "/dev/mapper/data-root", "kname": "/dev/dm-1", "maj:min": "253:1",
+               "type": "lvm", "pkname": "/dev/dm-0", "uuid": "ext4-root"}
+    encrypted = {"path": "/dev/mapper/cryptdata", "kname": "/dev/dm-0", "maj:min": "253:0",
+                 "type": "crypt", "pkname": "/dev/nvme0n1p3", "children": [logical]}
+    partition = {"path": "/dev/nvme0n1p3", "maj:min": "259:3", "type": "part",
+                 "pkname": "/dev/nvme0n1", "children": [encrypted]}
+    disk = {"path": "/dev/nvme0n1", "maj:min": "259:0", "type": "disk", "children": [partition]}
+    return {"blockdevices": [disk]}, encrypted, logical
+
+
+def test_explicit_kernel_alias_resolves_luks_lvm_backing():
+    payload, _, _ = mapped()
+    inventory = _Inventory(payload)
+    assert inventory.disk("253:1") == "259:0"
+    assert inventory.paths["/dev/dm-0"] == inventory.paths["/dev/mapper/cryptdata"]
+    with pytest.raises(TransferRefusal, match="stacked"):
+        inventory.disk("253:1", direct=True)  # Legacy USB policy still rejects mapping.
+
+
+@pytest.mark.parametrize("change", ["missing", "disagreement", "collision"])
+def test_missing_or_ambiguous_kernel_evidence_still_refuses(change):
+    payload, encrypted, logical = mapped()
+    if change == "missing":
+        encrypted.pop("kname")
+    elif change == "disagreement":
+        logical["pkname"] = "/dev/nvme0n1p3"
+    else:
+        logical["kname"] = encrypted["kname"]
+    with pytest.raises(TransferRefusal, match="ambiguous"):
+        _Inventory(payload)
+
+
+def test_multi_parent_tree_remains_unqualified():
+    payload, _, logical = mapped()
+    payload["blockdevices"].append(deepcopy(logical))
+    with pytest.raises(TransferRefusal, match="ambiguous"):
+        _Inventory(payload)

--- a/tests/test_slice_native_transactions.py
+++ b/tests/test_slice_native_transactions.py
@@ -1,0 +1,289 @@
+"""Real disposable folder ports and durable authority; no device observation or media."""
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+from dataclasses import replace
+import errno
+import json
+import os
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import domain as d
+from modelark.slice import state, transaction as t
+from modelark.slice.folder_contract import CapacityObservation, FolderProfile, FolderTarget
+from modelark.slice.folder_destination import NativeFolderDestination
+from modelark.slice.folder_plan import NativePlan, binding_for, estimate_metadata
+from modelark.slice.linux import BoundTree
+from test_slice_transaction import DATA, Sources, proposal
+
+
+@pytest.fixture
+def native(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "HOST_STATE_DIR", tmp_path / "private")
+    parent = tmp_path / "shared"
+    parent.mkdir(mode=0o700)
+    sibling = parent / "unrelated"
+    sibling.write_bytes(b"existing sibling")
+    store = state.Store()
+    with ExitStack() as stack:
+        tree = stack.enter_context(BoundTree(parent, writable=True))
+
+        def create(*, child="delivery", parts=(), identity=None, scope="test-filesystem",
+                   backing=("serial:disk-a",)):
+            target = FolderTarget(FolderProfile.NATIVE_EXT4, scope, parts,
+                                  identity or tree.identity(tree.fd)[1:], child)
+            catalog = str(tmp_path / "read-only-catalog.sqlite")
+            binding = binding_for(target, catalog, str(parent), backing)
+            original, _, snapshot = proposal()
+            preview = d.preview(replace(original.spec, destination_id=target.target_id,
+                                        destination_root=child), snapshot)
+            capacity = CapacityObservation(64 * 1024 * 1024, 10000, 0)
+            reserve = estimate_metadata(preview, binding, catalog, str(parent), backing,
+                                        capacity, store.root)
+            plan = NativePlan(preview, binding, catalog, str(parent), backing, capacity, reserve)
+            approval = d.approve(preview, expected_seal=preview.seal, current_snapshot=snapshot)
+            tx = store.create(plan, approval)
+            store.approve(tx, expected_seal=plan.seal)
+            adapter = NativeFolderDestination(tree, binding, store, tx, recheck=lambda tree: None)
+            return SimpleNamespace(plan=plan, tx=tx, adapter=adapter, sources=Sources(snapshot, t))
+
+        yield SimpleNamespace(parent=parent, sibling=sibling, store=store, tree=tree,
+                              create=create, case=create())
+
+
+def run(native, case=None, *, fault=None):
+    case = case or native.case
+    with t.start(native.store, case.tx, case.adapter, case.sources, fault=fault) as session:
+        return session.run()
+
+
+def stop_after_chunk(native):
+    def stop(point):
+        if point == "chunk_written":
+            native.store.request_stop(native.case.tx)
+    assert run(native, fault=stop).state == "stopped"
+
+
+def test_native_completion_keeps_control_receipt_and_verified_bytes_inside_child(native):
+    case = native.case
+    assert run(native).state == "complete"
+    child = native.parent / "delivery"
+    assert (child / "org/model/model.safetensors").read_bytes() == DATA
+    assert (child / ".modelark-slice-owner").is_file()
+    assert not (native.parent / ".modelark-slice-owner").exists()
+    receipt = json.loads((child / ".modelark-slice-receipt.json").read_text())
+    assert receipt == native.store.receipt(case.tx)
+    assert NativePlan.from_json(json.dumps(receipt["plan"])) == case.plan
+    assert receipt["topology"] == "folder"
+    assert receipt["resume_policy"] == "authenticated"
+    assert receipt["capacity_evidence"] == "advisory-shared-space-not-reserved"
+    assert receipt["verification"]["result"] == "verified"
+    assert native.sibling.read_bytes() == b"existing sibling"
+
+
+def test_sibling_bytes_and_parent_inode_growth_do_not_invalidate_transfer(native):
+    def unrelated_writes(point):
+        if point == "chunk_written":
+            native.sibling.write_bytes(b"new unrelated content" * 4096)
+            for number in range(100):
+                (native.parent / f"sibling-{number}").touch()
+    assert run(native, fault=unrelated_writes).state == "complete"
+    assert native.sibling.read_bytes().startswith(b"new unrelated content")
+    assert len(tuple(native.parent.glob("sibling-*"))) == 100
+
+
+def test_group_writable_parent_is_refused_before_output_creation(native):
+    native.parent.chmod(0o775)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_NOT_WRITABLE"):
+        run(native)
+    assert not (native.parent / "delivery").exists()
+    assert native.sibling.read_bytes() == b"existing sibling"
+    assert native.store.receipt(native.case.tx) is None
+
+
+def test_native_stop_and_fresh_adapter_resume_same_certified_root(native):
+    stop_after_chunk(native)
+    child = native.parent / "delivery"
+    identity = child.stat().st_ino
+    assert not (child / "org/model/model.safetensors").exists()
+    assert tuple((child / "org/model").glob(".slice-*"))
+    case = native.case
+    case.adapter = NativeFolderDestination(native.tree, case.plan.destination, native.store,
+                                           case.tx, recheck=lambda tree: None)
+    assert run(native).state == "complete"
+    assert child.stat().st_ino == identity
+    assert (child / "org/model/model.safetensors").read_bytes() == DATA
+
+
+def test_known_inode_shortfall_refuses_before_root_creation_and_can_retry(native, monkeypatch):
+    original = os.fstatvfs
+    def scarce(fd):
+        observed = original(fd)
+        return SimpleNamespace(f_bavail=observed.f_bavail, f_frsize=observed.f_frsize,
+                               f_favail=1, f_ffree=1)
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "fstatvfs", scarce)
+        with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_WAIT"):
+            run(native)
+    assert not (native.parent / "delivery").exists()
+    assert run(native).state == "complete"
+
+
+def test_remaining_inode_budget_deduplicates_publication_links_and_allows_zero_at_finish(native, monkeypatch):
+    def stop_published(point):
+        if point == "file_published":
+            native.store.request_stop(native.case.tx)
+    assert run(native, fault=stop_published).state == "stopped"
+    final = native.parent / "delivery/org/model/model.safetensors"
+    temporary = next(final.parent.glob(".slice-*"))
+    assert final.stat().st_ino == temporary.stat().st_ino
+    original = os.fstatvfs
+    available = 0  # Receipt is the one remaining inode, despite two payload links.
+    def observed(fd):
+        value = original(fd)
+        return SimpleNamespace(f_bavail=value.f_bavail, f_frsize=value.f_frsize,
+                               f_favail=available, f_ffree=available)
+    monkeypatch.setattr(os, "fstatvfs", observed)
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_WAIT"):
+        run(native)
+    available = 1
+    def last_inode(point):
+        nonlocal available
+        if point == "receipt_created":
+            available = 0
+    assert run(native, fault=last_inode).state == "complete"
+    assert available == 0
+
+
+@pytest.mark.parametrize("replace_root", [False, True])
+def test_missing_or_replaced_certified_root_is_never_recreated_or_adopted(native, replace_root):
+    stop_after_chunk(native)
+    child = native.parent / "delivery"
+    child.rename(native.parent / "retained-original")
+    if replace_root:
+        child.mkdir()
+        (child / "foreign").write_bytes(b"do not touch")
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CHANGED|OUTPUT_COLLISION"):
+        run(native)
+    assert native.store.receipt(native.case.tx) is None
+    if replace_root:
+        assert tuple(path.name for path in child.iterdir()) == ("foreign",)
+        assert (child / "foreign").read_bytes() == b"do not touch"
+    else:
+        assert not child.exists()
+
+
+@pytest.mark.parametrize("method,args", [
+    ("inspect", ("unrelated",)),
+    ("create_directory", ("elsewhere", "a" * 32)),
+    ("create_file", (".slice-" + "a" * 32, "a" * 32)),
+    ("append", (".slice-" + "a" * 32, "a" * 32, b"foreign")),
+    ("discard_temporary", (".slice-" + "a" * 32, "a" * 32)),
+    ("read", ("unrelated",)),
+    ("flush", ("unrelated",)),
+    ("list_paths", ("unrelated",)),
+])
+def test_native_port_rejects_paths_outside_approved_child(native, method, args):
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+        value = getattr(native.case.adapter, method)(*args)
+        if method == "read":
+            with value:
+                pass
+    assert native.sibling.read_bytes() == b"existing sibling"
+    assert tuple(path.name for path in native.parent.iterdir()) == ("unrelated",)
+
+
+def test_native_publication_rejects_foreign_final_path(native):
+    adapter = native.case.adapter
+    adapter.create_directory("delivery", "b" * 32)
+    temporary = "delivery/.slice-" + "a" * 32
+    adapter.create_file(temporary, "a" * 32)
+    adapter.append(temporary, "a" * 32, DATA)
+    with pytest.raises(t.TransferRefusal, match="OUTPUT_COLLISION"):
+        adapter.publish(temporary, "unrelated", "a" * 32)
+    assert native.sibling.read_bytes() == b"existing sibling"
+    assert (native.parent / temporary).read_bytes() == DATA
+
+
+@pytest.mark.parametrize("code", [errno.ENOSPC, errno.EDQUOT])
+def test_partial_capacity_failure_ends_attempt_and_fresh_start_recovers(native, monkeypatch, code):
+    original_write = os.write
+    armed = False
+    partial = False
+
+    def fail_after_partial(fd, data):
+        nonlocal partial
+        if armed:
+            if not partial:
+                partial = True
+                return original_write(fd, data[:3])
+            raise OSError(code, "synthetic exhausted shared capacity")
+        return original_write(fd, data)
+
+    def arm(point):
+        nonlocal armed
+        if point == "temporary_created":
+            armed = True
+
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "write", fail_after_partial)
+        case = native.case
+        with t.start(native.store, case.tx, case.adapter, case.sources, fault=arm) as session:
+            assert session.run().state == "waiting_destination"
+            assert not session.can_write
+            with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+                session.step()
+    temporary = tuple((native.parent / "delivery/org/model").glob(".slice-*"))
+    assert len(temporary) == 1 and temporary[0].read_bytes() == DATA[:3]
+    assert native.store.receipt(native.case.tx) is None
+    assert run(native).state == "complete"
+    assert (native.parent / "delivery/org/model/model.safetensors").read_bytes() == DATA
+
+
+def reserve_concurrently(store, cases):
+    barrier = threading.Barrier(2)
+
+    def reserve(case):
+        barrier.wait()
+        try:
+            store.reserve(case.tx, case.plan.destination.device_id)
+            return "reserved"
+        except t.TransferRefusal as exc:
+            return exc.code
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        return sorted(pool.map(reserve, cases))
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_simultaneous_overlapping_native_claims_have_one_durable_winner(native, nested):
+    first = native.case
+    second = native.create(parts=("delivery",), child="nested") if nested else native.create()
+    assert reserve_concurrently(native.store, (first, second)) == ["DESTINATION_BUSY", "reserved"]
+    with native.store._connection(write=False) as con:
+        assert con.execute("SELECT COUNT(*) FROM owners").fetchone()[0] == 1
+
+
+def test_simultaneous_sibling_claims_are_both_permitted(native):
+    first, second = native.case, native.create(child="delivery-other")
+    assert reserve_concurrently(native.store, (first, second)) == ["reserved", "reserved"]
+    assert native.store.owner(first.plan.destination.device_id) == first.tx
+    assert native.store.owner(second.plan.destination.device_id) == second.tx
+    assert run(native, first).state == "complete"
+    assert run(native, second).state == "complete"
+
+
+@pytest.mark.parametrize("legacy_identity", ["serial:disk-a", "serial:DISK-A"])
+def test_simultaneous_native_and_legacy_drive_claims_exclude_each_other(native, legacy_identity):
+    original, _, snapshot = proposal()
+    preview = d.preview(replace(original.spec, destination_id=legacy_identity), snapshot)
+    binding = t.DestinationBinding(legacy_identity, "test-filesystem", "legacy-mount", 10_000_000)
+    plan = t.TransferPlan(preview, binding, metadata_reserve_bytes=65536)
+    approval = d.approve(preview, expected_seal=preview.seal, current_snapshot=snapshot)
+    tx = native.store.create(plan, approval)
+    native.store.approve(tx, expected_seal=plan.seal)
+    legacy = SimpleNamespace(plan=plan, tx=tx)
+    assert reserve_concurrently(native.store, (native.case, legacy)) == ["DESTINATION_BUSY", "reserved"]
+    assert not (native.parent / "delivery").exists()

--- a/tests/test_slice_native_transactions.py
+++ b/tests/test_slice_native_transactions.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 import errno
 import json
 import os
+import struct
 import threading
 from types import SimpleNamespace
 
@@ -103,6 +104,25 @@ def test_group_writable_parent_is_refused_before_output_creation(native):
     assert native.store.receipt(native.case.tx) is None
 
 
+@pytest.mark.parametrize('named_users', [1, 200])
+def test_real_default_acl_marker_budget_is_checked_before_mkdir(native, named_users):
+    entries = [(1, 7, 0xffffffff)] + [(2, 7, uid) for uid in range(100000, 100000 + named_users)]
+    entries += [(4, 7, 0xffffffff), (16, 7, 0xffffffff), (32, 7, 0xffffffff)]
+    acl = struct.pack('<I', 2) + b''.join(struct.pack('<HHI', *entry) for entry in entries)
+    os.setxattr(native.parent, 'system.posix_acl_default', acl)
+    if named_users == 1:
+        assert run(native).state == 'complete'
+    else:
+        # The ACL itself is accepted by this real kernel/filesystem. Admission
+        # must account for both child ACLs plus the ownership marker before mkdir.
+        with pytest.raises(t.TransferRefusal, match='xattr') as raised:
+            run(native)
+        assert raised.value.code == 'DESTINATION_NOT_WRITABLE'
+        assert not (native.parent / 'delivery').exists()
+    assert os.getxattr(native.parent, 'system.posix_acl_default') == acl
+    assert native.sibling.read_bytes() == b'existing sibling'
+
+
 def test_native_stop_and_fresh_adapter_resume_same_certified_root(native):
     stop_after_chunk(native)
     child = native.parent / "delivery"
@@ -122,6 +142,7 @@ def test_known_inode_shortfall_refuses_before_root_creation_and_can_retry(native
     def scarce(fd):
         observed = original(fd)
         return SimpleNamespace(f_bavail=observed.f_bavail, f_frsize=observed.f_frsize,
+                               f_bsize=observed.f_bsize,
                                f_favail=1, f_ffree=1)
     with monkeypatch.context() as patch:
         patch.setattr(os, "fstatvfs", scarce)
@@ -144,6 +165,7 @@ def test_remaining_inode_budget_deduplicates_publication_links_and_allows_zero_a
     def observed(fd):
         value = original(fd)
         return SimpleNamespace(f_bavail=value.f_bavail, f_frsize=value.f_frsize,
+                               f_bsize=value.f_bsize,
                                f_favail=available, f_ffree=available)
     monkeypatch.setattr(os, "fstatvfs", observed)
     with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_WAIT"):

--- a/tests/test_slice_operator.py
+++ b/tests/test_slice_operator.py
@@ -320,19 +320,22 @@ def test_boundary_capacity_refusal_precedes_destination_mutation_gate(operator, 
     adapter._attachment_path, adapter._catalog = "/destination", "/sealed/catalog"
     adapter._proposal, adapter._caps = object(), {"policy": "sealed"}
     binding = t.DestinationBinding("device", "filesystem", "binding", 1000)
+    adapter._budget = None
+    adapter._evidence = SimpleNamespace(device_id='device', fs_uuid='filesystem')
     adapter._observer = SimpleNamespace(observe=lambda *a, **k:
-                                       SimpleNamespace(device_id="device", fs_uuid="filesystem"))
+                                       SimpleNamespace(device_id="device", fs_uuid="filesystem"),
+                                       check_attachment=lambda tree, *a, **k: tree.check())
     monkeypatch.setattr(operator, "_archives", lambda path: checked.append(path) or ())
     monkeypatch.setattr(operator.UsbDestination, "check", lambda *a: pytest.fail("capacity refusal ignored"))
 
-    def refuse(tree, evidence, proposal, caps, *, adapter):
+    def refuse(tree, evidence, proposal, caps, *, adapter, refresh_volume):
         assert caps == {"policy": "sealed"}
         raise t.TransferRefusal("DESTINATION_CAPACITY_CHANGED")
 
     monkeypatch.setattr(operator, "_capacity", lambda: SimpleNamespace(verify=refuse))
     with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_CHANGED"):
         adapter.check(binding, 0, 100)
-    assert checked == ["tree", "/sealed/catalog"]
+    assert checked == ["/sealed/catalog", "tree"]
 
 
 @pytest.mark.parametrize("error", [ValueError("unsafe state"), OSError("state inaccessible")])
@@ -370,7 +373,8 @@ def test_already_typed_bootstrap_refusal_is_preserved(operator, monkeypatch):
     assert caught.value.code == "STATE_BUSY"
 
 
-def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, monkeypatch, tmp_path):
+@pytest.mark.parametrize('mode', ['small', 'large', 'unplug'])
+def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, monkeypatch, tmp_path, mode):
     """Only hardware/free-space observations are fake; all assembly and IO are real."""
     import os
     import uuid
@@ -380,12 +384,17 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     from test_slice_catalog import seed
     from test_slice_direct_integration import physical_descendants
     from test_slice_transaction import DATA
+    if mode != 'small':
+        DATA = b'x' * (2 * 1024 * 1024 + 17)
 
     catalog = tmp_path / "explicit-catalog.sqlite"
     con = seed(catalog, d)
     digest = hashlib.sha256(DATA).hexdigest()
     con.execute("UPDATE files SET sha256=?", (digest,))
     con.execute("UPDATE archived SET orig_sha256=?,annex_key=?", (digest, f"SHA256E-s12--{digest}"))
+    con.execute('UPDATE files SET size_bytes=?', (len(DATA),))
+    con.execute('UPDATE archived SET orig_bytes=?,stored_bytes=?,annex_key=?',
+                (len(DATA), len(DATA), f'SHA256E-s{len(DATA)}--{digest}'))
     con.execute("INSERT INTO drives(drive_label,fs_uuid,serial) VALUES('unselected','other-fs','other-disk')")
     before = tuple(con.iterdump())
     con.close()
@@ -397,9 +406,10 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     destination = tmp_path / "usb"
     destination.mkdir()
     initial_root_blocks = destination.stat().st_blocks * 512
-    baseline, initial_inodes = 10_000_000, 1_000_000
+    baseline, initial_inodes = 100_000_000, 1_000_000
     device = "operator-integration-" + uuid.uuid4().hex
     observations = []
+    connected = [True]
 
     def availability(tree):
         identities = set()
@@ -412,6 +422,13 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
                 initial_inodes - len(identities))
 
     class Observer:
+        def check_attachment(self, tree, evidence, **kwargs):
+            if tree.path == destination and not connected[0]:
+                # Model physical backing disappearance while the mount ID remains present.
+                tree._attachment_lost = True
+                raise t.TransferRefusal('WAITING_DESTINATION')
+            tree.check()
+
         def observe(self, path, *, writable=False, archives=()):
             from pathlib import Path
             path = Path(path)
@@ -425,9 +442,9 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
             observations.append(tuple(a.fs_uuid for a in archives))
             with BoundTree(destination) as observed_tree:
                 mount_id = observed_tree.mount_id
-            return DeviceEvidence(device, "destination-fs", "destination-serial", 20_000_000,
+            return DeviceEvidence(device, "destination-fs", "destination-serial", 200_000_000,
                                   str(destination), mount_id, "ext4", availability(None)[0],
-                                  4096, 255, 20_000_000, "synthetic-stable-hardware-profile")
+                                  4096, 255, 200_000_000, "synthetic-stable-hardware-profile")
 
     monkeypatch.setattr(operator, "LinuxObserver", Observer)
     monkeypatch.setattr(capacity, "_volume", lambda *a: {"uuid": "destination-fs", "block_size": 4096})
@@ -436,18 +453,34 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     monkeypatch.setattr(operator.UsbDestination, "_available", lambda self: availability(self.tree)[0])
     monkeypatch.setattr(db, "connect", lambda *a, **k: pytest.fail("global catalog opened"))
     monkeypatch.setattr("subprocess.run", lambda *a, **k: pytest.fail("retrieval/real observer invoked"))
+    original_write = operator.UsbDestination.append
+    def unplug_after_payload(self, path, token, data):
+        result = original_write(self, path, token, data)
+        if data == DATA[:len(data)]:
+            connected[0] = False
+        return result
+    if mode == 'unplug':
+        monkeypatch.setattr(operator.UsbDestination, 'append', unplug_after_payload)
 
     reviewed = operator.preview(catalog, destination, ["org/model"], "delivery")
     tx = reviewed["transaction_id"]
     assert reviewed["state"] == "ready" and not list(destination.iterdir())
     assert operator.approve(tx, reviewed["seal"])["state"] == "approved"
     result = operator.start(tx, destination, {"drive-a": archive})
+    if mode == 'unplug':
+        assert result['state'] == 'waiting_destination'
+        assert store.status(tx).state == 'waiting_destination'
+        assert not (destination / 'delivery/.modelark-slice-receipt.json').exists()
+        connected[0] = True
+        monkeypatch.setattr(operator.UsbDestination, 'append', original_write)
+        result = operator.start(tx, destination, {'drive-a': archive})
     assert result["state"] == "complete" and result["can_write"] is False
     assert (destination / "delivery/org/model/model.safetensors").read_bytes() == DATA
     receipt = json.loads((destination / "delivery/.modelark-slice-receipt.json").read_text())
     assert receipt["status"] == "complete" and receipt["transaction"] == tx
     assert receipt["seal"] == reviewed["seal"]
     assert all(set(uuids) == {"fs-a", "other-fs"} for uuids in observations)
+    assert len(observations) <= (30 if mode == 'unplug' else 16)
     assert not tuple(destination.rglob(".slice-*"))
     import sqlite3
     with sqlite3.connect(catalog.as_uri() + "?mode=ro", uri=True) as con:

--- a/tests/test_slice_operator.py
+++ b/tests/test_slice_operator.py
@@ -373,7 +373,7 @@ def test_already_typed_bootstrap_refusal_is_preserved(operator, monkeypatch):
     assert caught.value.code == "STATE_BUSY"
 
 
-@pytest.mark.parametrize('mode', ['small', 'large', 'unplug', 'acl-unplug'])
+@pytest.mark.parametrize('mode', ['small', 'parent', 'large', 'unplug', 'acl-unplug'])
 def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, monkeypatch, tmp_path, mode):
     """Only hardware/free-space observations are fake; all assembly and IO are real."""
     import os
@@ -384,7 +384,7 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     from test_slice_catalog import seed
     from test_slice_direct_integration import physical_descendants
     from test_slice_transaction import DATA
-    if mode != 'small':
+    if mode not in {'small', 'parent'}:
         DATA = b'x' * (2 * 1024 * 1024 + 17)
 
     catalog = tmp_path / "explicit-catalog.sqlite"
@@ -472,11 +472,12 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     if mode == 'acl-unplug':
         monkeypatch.setattr(os, 'getxattr', unplug_during_owned_directory_acl)
 
-    reviewed = operator.preview(catalog, destination, ["org/model"], "delivery")
+    supplied_destination = destination / '..' / destination.name if mode == 'parent' else destination
+    reviewed = operator.preview(catalog, supplied_destination, ["org/model"], "delivery")
     tx = reviewed["transaction_id"]
     assert reviewed["state"] == "ready" and not list(destination.iterdir())
     assert operator.approve(tx, reviewed["seal"])["state"] == "approved"
-    result = operator.start(tx, destination, {"drive-a": archive})
+    result = operator.start(tx, supplied_destination, {"drive-a": archive})
     if mode in {'unplug', 'acl-unplug'}:
         assert result['state'] == 'waiting_destination'
         assert store.status(tx).state == 'waiting_destination'

--- a/tests/test_slice_operator.py
+++ b/tests/test_slice_operator.py
@@ -373,7 +373,7 @@ def test_already_typed_bootstrap_refusal_is_preserved(operator, monkeypatch):
     assert caught.value.code == "STATE_BUSY"
 
 
-@pytest.mark.parametrize('mode', ['small', 'large', 'unplug'])
+@pytest.mark.parametrize('mode', ['small', 'large', 'unplug', 'acl-unplug'])
 def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, monkeypatch, tmp_path, mode):
     """Only hardware/free-space observations are fake; all assembly and IO are real."""
     import os
@@ -461,18 +461,29 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
         return result
     if mode == 'unplug':
         monkeypatch.setattr(operator.UsbDestination, 'append', unplug_after_payload)
+    original_getxattr = os.getxattr
+    def unplug_during_owned_directory_acl(fd, name, *args, **kwargs):
+        import errno
+        if (name == 'system.posix_acl_default'
+                and os.fstat(fd).st_ino != destination.stat().st_ino):
+            connected[0] = False
+            raise OSError(errno.EIO, 'unplug during owned-directory ACL proof')
+        return original_getxattr(fd, name, *args, **kwargs)
+    if mode == 'acl-unplug':
+        monkeypatch.setattr(os, 'getxattr', unplug_during_owned_directory_acl)
 
     reviewed = operator.preview(catalog, destination, ["org/model"], "delivery")
     tx = reviewed["transaction_id"]
     assert reviewed["state"] == "ready" and not list(destination.iterdir())
     assert operator.approve(tx, reviewed["seal"])["state"] == "approved"
     result = operator.start(tx, destination, {"drive-a": archive})
-    if mode == 'unplug':
+    if mode in {'unplug', 'acl-unplug'}:
         assert result['state'] == 'waiting_destination'
         assert store.status(tx).state == 'waiting_destination'
         assert not (destination / 'delivery/.modelark-slice-receipt.json').exists()
         connected[0] = True
         monkeypatch.setattr(operator.UsbDestination, 'append', original_write)
+        monkeypatch.setattr(os, 'getxattr', original_getxattr)
         result = operator.start(tx, destination, {'drive-a': archive})
     assert result["state"] == "complete" and result["can_write"] is False
     assert (destination / "delivery/org/model/model.safetensors").read_bytes() == DATA
@@ -480,7 +491,7 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     assert receipt["status"] == "complete" and receipt["transaction"] == tx
     assert receipt["seal"] == reviewed["seal"]
     assert all(set(uuids) == {"fs-a", "other-fs"} for uuids in observations)
-    assert len(observations) <= (30 if mode == 'unplug' else 16)
+    assert len(observations) <= (30 if mode in {'unplug', 'acl-unplug'} else 16)
     assert not tuple(destination.rglob(".slice-*"))
     import sqlite3
     with sqlite3.connect(catalog.as_uri() + "?mode=ro", uri=True) as con:

--- a/tests/test_slice_operator.py
+++ b/tests/test_slice_operator.py
@@ -63,7 +63,7 @@ def test_v5_migration_preserves_legacy_transaction_without_inventing_admission(s
     with pytest.raises(t.TransferRefusal, match="ADMISSION_MISSING"):
         upgraded.load_admission(tx)
     with upgraded._connection(write=False) as con:
-        assert con.execute("PRAGMA user_version").fetchone()[0] == 6
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 8
 
 
 @pytest.fixture

--- a/tests/test_slice_operator.py
+++ b/tests/test_slice_operator.py
@@ -1,0 +1,454 @@
+"""Explicit operator assembly against disposable state and mocked hardware only."""
+from contextlib import contextmanager
+from dataclasses import replace
+import hashlib
+import importlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice import domain as d
+from modelark.slice import state as s
+from modelark.slice import transaction as t
+from modelark.slice.linux import BoundTree
+from test_slice_transaction import Destination, Sources, proposal
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(s, "HOST_STATE_DIR", tmp_path / "private-state")
+    return s.Store()
+
+
+def sealed(store, admission=True):
+    p, approval, snapshot = proposal()
+    record = {"version": "modelark.slice.direct.v1", "catalog": "/explicit/catalog.sqlite",
+              "capacity": {"profile": "test-profile"}}
+    mount = "direct-v1:" + hashlib.sha256(d._json(record)).hexdigest()
+    binding = t.DestinationBinding("test-device", "test-filesystem", mount, 1_000_000)
+    plan = t.TransferPlan(p, binding, metadata_reserve_bytes=100_000)
+    tx = store.create(plan, approval, admission=record if admission else None)
+    return tx, plan, snapshot, record
+
+
+def test_admission_is_atomic_sealed_private_record(store):
+    tx, plan, _, admission = sealed(store)
+    assert store.load_admission(tx) == admission
+    with store._connection() as con:
+        con.execute("UPDATE transactions SET admission=? WHERE id=?",
+                    (json.dumps({**admission, "catalog": "/other/catalog"}), tx))
+    with pytest.raises(t.TransferRefusal, match="ADMISSION_CORRUPT"):
+        store.load_admission(tx)
+    assert store.load(tx).seal == plan.seal
+
+
+def test_invalid_admission_never_inserts_transaction(store):
+    tx, plan, snapshot, admission = sealed(store)
+    approval = d.approve(plan.proposal, expected_seal=plan.proposal.seal, current_snapshot=snapshot)
+    with pytest.raises(t.TransferRefusal, match="ADMISSION_CORRUPT"):
+        store.create(plan, approval, admission={**admission, "catalog": "/other/catalog"})
+    with store._connection(write=False) as con:
+        assert con.execute("SELECT id FROM transactions").fetchall() == [(tx,)]
+
+
+def test_v5_migration_preserves_legacy_transaction_without_inventing_admission(store):
+    tx, plan, _, _ = sealed(store, admission=False)
+    with store._connection() as con:
+        con.execute("ALTER TABLE transactions DROP COLUMN admission")
+        con.execute("PRAGMA user_version=5")
+    upgraded = s.Store()
+    assert upgraded.load(tx).seal == plan.seal
+    with pytest.raises(t.TransferRefusal, match="ADMISSION_MISSING"):
+        upgraded.load_admission(tx)
+    with upgraded._connection(write=False) as con:
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 6
+
+
+@pytest.fixture
+def operator(monkeypatch):
+    module = importlib.import_module("modelark.slice.operator")
+    monkeypatch.setattr(module, "LinuxObserver", lambda: pytest.fail("unexpected hardware observation"))
+    return module
+
+
+def test_start_requires_approval_before_observing_destination(store, operator):
+    tx, _, _, _ = sealed(store)
+    with pytest.raises(t.TransferRefusal, match="APPROVAL_MISSING"):
+        operator.start(tx, "/never-observe", {})
+
+
+def test_completed_status_needs_no_destination(store, operator):
+    tx, _, _, _ = sealed(store)
+    with store._connection() as con:
+        con.execute("UPDATE transactions SET state='complete' WHERE id=?", (tx,))
+    result = operator.start(tx, "/absent-device", {})
+    assert result["state"] == "complete" and result["can_write"] is False
+
+
+@pytest.mark.parametrize("state", ["failed", "invalidated"])
+def test_terminal_transaction_refuses_before_destination_observation(store, operator, state):
+    tx, _, _, _ = sealed(store)
+    with store._connection() as con:
+        con.execute("UPDATE transactions SET state=? WHERE id=?", (state, tx))
+    with pytest.raises(t.TransferRefusal, match="NOT_RESUMABLE"):
+        operator.start(tx, "/never-observe", {})
+
+
+def test_operator_refuses_legacy_internal_transaction(store, operator):
+    tx, plan, _, _ = sealed(store, admission=False)
+    store.approve(tx, expected_seal=plan.seal)
+    with pytest.raises(t.TransferRefusal, match="ADMISSION_MISSING"):
+        operator.start(tx, "/never-observe", {})
+
+
+def test_approve_rechecks_exact_sealed_catalog(store, operator, monkeypatch):
+    tx, plan, snapshot, record = sealed(store)
+    calls = []
+    monkeypatch.setattr(operator, "read_catalog", lambda path, spec: calls.append((path, spec)) or snapshot)
+    result = operator.approve(tx, plan.seal)
+    assert result["state"] == "approved"
+    assert calls == [(record["catalog"], plan.proposal.spec)]
+
+
+def test_stale_approval_never_changes_state(store, operator, monkeypatch):
+    tx, plan, snapshot, _ = sealed(store)
+    changed = replace(snapshot, copies=())
+    monkeypatch.setattr(operator, "read_catalog", lambda *a: changed)
+    with pytest.raises(d.SliceRefusal, match="PREVIEW_STALE"):
+        operator.approve(tx, plan.seal)
+    assert store.status(tx).state == "ready"
+
+
+def test_preview_gaps_need_no_hardware_or_store(tmp_path, operator, monkeypatch):
+    _, _, snapshot = proposal()
+    monkeypatch.setattr(operator, "read_catalog", lambda *a: replace(snapshot, copies=()))
+    monkeypatch.setattr(operator, "Store", lambda: pytest.fail("blocked preview created Store"))
+    result = operator.preview(tmp_path / "catalog", "/never-observe", ["org/model"], "output")
+    assert result["ok"] is False and result["executable"] is False
+    assert result["gaps"] and "transaction_id" not in result
+
+
+def test_status_and_stop_are_private_only(store, operator):
+    tx, _, _, _ = sealed(store)
+    assert operator.status(tx)["state"] == "ready"
+    result = operator.stop(tx)
+    assert result["stop_requested"] is True
+    assert store.stop_requested(tx)
+
+
+@pytest.fixture
+def assembled(store, operator, monkeypatch, tmp_path):
+    tx, plan, snapshot, admission = sealed(store)
+    store.approve(tx, expected_seal=plan.seal)
+    destination = Destination(tmp_path / "destination", t)
+    destination.binding = plan.destination
+    sources = Sources(snapshot, t)
+    calls = []
+    archives = (SimpleNamespace(fs_uuid="unselected-archive", serial="other-disk"),)
+    monkeypatch.setattr(operator, "_archives", lambda path: calls.append(("registry", path)) or archives)
+    evidence = SimpleNamespace(device_id="test-device", fs_uuid="test-filesystem", available_bytes=1_000_000)
+
+    class Observer:
+        def observe(self, path, **kwargs):
+            calls.append(("observe", kwargs))
+            return evidence
+
+    monkeypatch.setattr(operator, "LinuxObserver", Observer)
+    monkeypatch.setattr(operator, "_CheckedDestination", lambda *a: destination)
+    monkeypatch.setattr(operator, "FencedSources", lambda catalog, reader:
+                        calls.append(("sources", catalog, reader.attachments)) or sources)
+    return operator, tx, store, plan, destination, sources, admission, calls
+
+
+def test_start_uses_sealed_catalog_and_all_registry_exclusions(assembled):
+    operator, tx, _, _, destination, _, admission, calls = assembled
+    result = operator.start(tx, destination.root, {"drive-a": "/explicit/modelark"})
+    assert result["state"] == "complete" and result["can_write"] is False
+    assert calls[0] == ("registry", admission["catalog"])
+    observed = next(value for name, value in calls if name == "observe")
+    assert observed["writable"] is True
+    assert observed["archives"][0].fs_uuid == "unselected-archive"
+    assert next(call for call in calls if call[0] == "sources")[1] == admission["catalog"]
+
+
+def test_unsealed_attachment_label_never_observes(assembled):
+    operator, tx, _, _, destination, _, _, calls = assembled
+    with pytest.raises(t.TransferRefusal, match="SOURCE_ATTACHMENT_UNSEALED"):
+        operator.start(tx, destination.root, {"unreviewed-drive": "/path"})
+    assert calls == []
+
+
+def test_source_wait_closes_attempt_without_losing_wait_state(assembled):
+    operator, tx, store, _, destination, sources, _, _ = assembled
+    sources.status["drive-a"] = "WAITING_SOURCE"
+    result = operator.start(tx, destination.root, {})
+    assert result["state"] == "waiting_source" and result["ok"] is False
+    assert store.status(tx).state == "waiting_source"
+    assert store.current_attempt(destination.binding.device_id) is not None
+    # A fresh kernel lease proves the synchronous waiter released its process exclusion.
+    lease = t._Lease(destination.binding.device_id)
+    lease.close()
+
+
+def test_ctrl_c_during_start_acknowledges_without_destination_writes(assembled, monkeypatch):
+    operator, tx, store, _, destination, _, _, _ = assembled
+    real_start = t.start
+    calls = 0
+
+    def interrupted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            def fault(point):
+                if point == "reserved":
+                    raise KeyboardInterrupt
+            return real_start(*args, fault=fault)
+        return real_start(*args, **kwargs)
+
+    monkeypatch.setattr(t, "start", interrupted)
+    result = operator.start(tx, destination.root, {})
+    assert result["state"] == "stopped" and result["stop_requested"] is True
+    assert store.status(tx).state == "stopped"
+    assert not list(destination.root.iterdir())
+
+
+def test_ctrl_c_during_transfer_acknowledges_stop_and_releases(assembled, monkeypatch):
+    operator, tx, store, _, destination, sources, _, _ = assembled
+
+    @contextmanager
+    def interrupted(source):
+        raise KeyboardInterrupt
+        yield  # pragma: no cover - makes this an actual context manager
+
+    monkeypatch.setattr(sources, "open", interrupted)
+    result = operator.start(tx, destination.root, {})
+    assert result["state"] == "stopped" and result["stop_requested"] is True
+    assert store.status(tx).state == "stopped"
+    lease = t._Lease(destination.binding.device_id)
+    lease.close()
+
+
+def test_missing_destination_does_not_claim_attempt(assembled):
+    operator, tx, store, _, destination, _, _, _ = assembled
+    destination.root.rmdir()
+    with pytest.raises(t.TransferRefusal, match="WAITING_DESTINATION"):
+        operator.start(tx, destination.root, {})
+    assert store.status(tx).state == "approved"
+    assert store.current_attempt(destination.binding.device_id) is None
+
+
+def test_ready_preview_persists_admission_without_output_writes(store, operator, monkeypatch, tmp_path):
+    _, _, snapshot = proposal()
+    path = tmp_path / "destination"
+    path.mkdir()
+    monkeypatch.setattr(operator, "read_catalog", lambda *a: snapshot)
+    archive = SimpleNamespace(fs_uuid="all-registered", serial="other")
+    monkeypatch.setattr(operator, "_archives", lambda path: (archive,))
+    observations = []
+    evidence = SimpleNamespace(device_id="test-device", fs_uuid="test-filesystem", available_bytes=1_000_000)
+
+    class Observer:
+        def observe(self, path, **kwargs):
+            observations.append(kwargs)
+            return evidence
+
+    monkeypatch.setattr(operator, "LinuxObserver", Observer)
+    verified = []
+    policy = SimpleNamespace(capture=lambda *a: {"profile": "qualified"},
+                             metadata_reserve_bytes=lambda *a: 100_000,
+                             verify=lambda *a, **k: verified.append(a))
+    monkeypatch.setattr(operator, "_capacity", lambda: policy)
+    result = operator.preview(tmp_path / "explicit-catalog", path, ["org/model"], "delivery")
+    assert result["state"] == "ready" and result["executable"] is False
+    tx = result["transaction_id"]
+    assert store.status(tx).state == "ready"
+    assert store.load_admission(tx)["catalog"] == str(tmp_path / "explicit-catalog")
+    assert all(item["archives"] == (archive,) for item in observations)
+    assert verified and not list(path.iterdir())
+
+    def inaccessible():
+        raise OSError("private state became inaccessible")
+
+    monkeypatch.setattr(operator, "Store", inaccessible)
+    with pytest.raises(t.TransferRefusal, match="STATE_UNAVAILABLE"):
+        operator.preview(tmp_path / "explicit-catalog", path, ["org/model"], "delivery")
+    assert not list(path.iterdir())
+
+
+def test_capacity_refusal_does_not_create_transaction(store, operator, monkeypatch, tmp_path):
+    _, _, snapshot = proposal()
+    path = tmp_path / "destination"
+    path.mkdir()
+    monkeypatch.setattr(operator, "read_catalog", lambda *a: snapshot)
+    monkeypatch.setattr(operator, "_archives", lambda path: ())
+    evidence = SimpleNamespace(device_id="test-device", fs_uuid="test-filesystem", available_bytes=1_000_000)
+    monkeypatch.setattr(operator, "LinuxObserver", lambda: SimpleNamespace(observe=lambda *a, **k: evidence))
+
+    def refuse(*args):
+        raise t.TransferRefusal("DESTINATION_CAPACITY_UNPROVEN")
+
+    monkeypatch.setattr(operator, "_capacity", lambda: SimpleNamespace(capture=refuse))
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_UNPROVEN"):
+        operator.preview(tmp_path / "explicit-catalog", path, ["org/model"], "delivery")
+    with store._connection(write=False) as con:
+        assert con.execute("SELECT COUNT(*) FROM transactions").fetchone()[0] == 0
+    assert not list(path.iterdir())
+
+
+def test_registry_reader_uses_all_drives_and_never_creates_missing_catalog(operator, tmp_path):
+    import sqlite3
+    path = tmp_path / "catalog.sqlite"
+    with pytest.raises(d.SliceRefusal, match="CATALOG_UNAVAILABLE"):
+        operator._archives(path)
+    assert not path.exists()
+    with sqlite3.connect(path) as con:
+        con.execute("CREATE TABLE drives(drive_label TEXT,fs_uuid TEXT,serial TEXT)")
+        con.executemany("INSERT INTO drives VALUES(?,?,?)", [("a", "uuid-a", "serial-a"),
+                                                            ("b", "uuid-b", "serial-b")])
+        con.execute("PRAGMA user_version=7")
+    before = path.read_bytes()
+    assert [(a.fs_uuid, a.serial) for a in operator._archives(path)] == [
+        ("uuid-a", "serial-a"), ("uuid-b", "serial-b")]
+    assert path.read_bytes() == before
+
+
+def test_boundary_capacity_refusal_precedes_destination_mutation_gate(operator, monkeypatch):
+    adapter = object.__new__(operator._CheckedDestination)
+    checked = []
+    adapter.tree = SimpleNamespace(check=lambda: checked.append("tree"))
+    adapter._attachment_path, adapter._catalog = "/destination", "/sealed/catalog"
+    adapter._proposal, adapter._caps = object(), {"policy": "sealed"}
+    binding = t.DestinationBinding("device", "filesystem", "binding", 1000)
+    adapter._observer = SimpleNamespace(observe=lambda *a, **k:
+                                       SimpleNamespace(device_id="device", fs_uuid="filesystem"))
+    monkeypatch.setattr(operator, "_archives", lambda path: checked.append(path) or ())
+    monkeypatch.setattr(operator.UsbDestination, "check", lambda *a: pytest.fail("capacity refusal ignored"))
+
+    def refuse(tree, evidence, proposal, caps, *, adapter):
+        assert caps == {"policy": "sealed"}
+        raise t.TransferRefusal("DESTINATION_CAPACITY_CHANGED")
+
+    monkeypatch.setattr(operator, "_capacity", lambda: SimpleNamespace(verify=refuse))
+    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_CHANGED"):
+        adapter.check(binding, 0, 100)
+    assert checked == ["tree", "/sealed/catalog"]
+
+
+@pytest.mark.parametrize("error", [ValueError("unsafe state"), OSError("state inaccessible")])
+@pytest.mark.parametrize("operation,args", [("status", ("tx",)), ("approve", ("tx", "seal")),
+                                           ("start", ("tx", "/never-observe", {})), ("stop", ("tx",))])
+def test_private_store_bootstrap_failure_is_typed_before_device(operator, monkeypatch, error, operation, args):
+    def fail():
+        raise error
+
+    monkeypatch.setattr(operator, "Store", fail)
+    with pytest.raises(t.TransferRefusal) as caught:
+        getattr(operator, operation)(*args)
+    assert caught.value.code == "STATE_UNAVAILABLE"
+    assert str(error) in caught.value.detail
+
+
+def test_corrupt_sqlite_bootstrap_is_typed(operator, monkeypatch):
+    import sqlite3
+
+    def fail():
+        raise sqlite3.DatabaseError("file is not a database")
+
+    monkeypatch.setattr(operator, "Store", fail)
+    with pytest.raises(t.TransferRefusal, match="STATE_UNAVAILABLE"):
+        operator.status("tx")
+
+
+def test_already_typed_bootstrap_refusal_is_preserved(operator, monkeypatch):
+    def fail():
+        raise t.TransferRefusal("STATE_BUSY", "private writer")
+
+    monkeypatch.setattr(operator, "Store", fail)
+    with pytest.raises(t.TransferRefusal) as caught:
+        operator.status("tx")
+    assert caught.value.code == "STATE_BUSY"
+
+
+def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, monkeypatch, tmp_path):
+    """Only hardware/free-space observations are fake; all assembly and IO are real."""
+    import os
+    import uuid
+    from modelark.core import db
+    from modelark.slice import capacity, operator
+    from modelark.slice.hardware import DeviceEvidence
+    from test_slice_catalog import seed
+    from test_slice_direct_integration import physical_descendants
+    from test_slice_transaction import DATA
+
+    catalog = tmp_path / "explicit-catalog.sqlite"
+    con = seed(catalog, d)
+    digest = hashlib.sha256(DATA).hexdigest()
+    con.execute("UPDATE files SET sha256=?", (digest,))
+    con.execute("UPDATE archived SET orig_sha256=?,annex_key=?", (digest, f"SHA256E-s12--{digest}"))
+    con.execute("INSERT INTO drives(drive_label,fs_uuid,serial) VALUES('unselected','other-fs','other-disk')")
+    before = tuple(con.iterdump())
+    con.close()
+    archive = tmp_path / "source-mount/modelark"
+    (archive / ".git").mkdir(parents=True)
+    (archive / ".git/config").write_text("[annex]\n uuid=annex-a\n")
+    (archive / "org/model").mkdir(parents=True)
+    (archive / "org/model/model.safetensors").write_bytes(DATA)
+    destination = tmp_path / "usb"
+    destination.mkdir()
+    initial_root_blocks = destination.stat().st_blocks * 512
+    baseline, initial_inodes = 10_000_000, 1_000_000
+    device = "operator-integration-" + uuid.uuid4().hex
+    observations = []
+
+    def availability(tree):
+        identities = set()
+        for parent, directories, files in os.walk(destination):
+            for name in (*directories, *files):
+                value = os.lstat(os.path.join(parent, name))
+                identities.add((value.st_dev, value.st_ino))
+        root_delta = destination.stat().st_blocks * 512 - initial_root_blocks
+        return (baseline - physical_descendants(destination) - root_delta,
+                initial_inodes - len(identities))
+
+    class Observer:
+        def observe(self, path, *, writable=False, archives=()):
+            from pathlib import Path
+            path = Path(path)
+            if path == archive:
+                with BoundTree(archive) as source_tree:
+                    source_mount_id = source_tree.mount_id
+                return SimpleNamespace(fs_uuid="fs-a", serial="serial-a", total_bytes=1000,
+                                       device_id="source-disk", mount_id=source_mount_id,
+                                       mount_path=str(archive.parent))
+            assert path == destination and writable
+            observations.append(tuple(a.fs_uuid for a in archives))
+            with BoundTree(destination) as observed_tree:
+                mount_id = observed_tree.mount_id
+            return DeviceEvidence(device, "destination-fs", "destination-serial", 20_000_000,
+                                  str(destination), mount_id, "ext4", availability(None)[0],
+                                  4096, 255, 20_000_000, "synthetic-stable-hardware-profile")
+
+    monkeypatch.setattr(operator, "LinuxObserver", Observer)
+    monkeypatch.setattr(capacity, "_volume", lambda *a: {"uuid": "destination-fs", "block_size": 4096})
+    monkeypatch.setattr(capacity, "_root_metadata", lambda tree: (4096, 0))
+    monkeypatch.setattr(capacity, "_free", availability)
+    monkeypatch.setattr(operator.UsbDestination, "_available", lambda self: availability(self.tree)[0])
+    monkeypatch.setattr(db, "connect", lambda *a, **k: pytest.fail("global catalog opened"))
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: pytest.fail("retrieval/real observer invoked"))
+
+    reviewed = operator.preview(catalog, destination, ["org/model"], "delivery")
+    tx = reviewed["transaction_id"]
+    assert reviewed["state"] == "ready" and not list(destination.iterdir())
+    assert operator.approve(tx, reviewed["seal"])["state"] == "approved"
+    result = operator.start(tx, destination, {"drive-a": archive})
+    assert result["state"] == "complete" and result["can_write"] is False
+    assert (destination / "delivery/org/model/model.safetensors").read_bytes() == DATA
+    receipt = json.loads((destination / "delivery/.modelark-slice-receipt.json").read_text())
+    assert receipt["status"] == "complete" and receipt["transaction"] == tx
+    assert receipt["seal"] == reviewed["seal"]
+    assert all(set(uuids) == {"fs-a", "other-fs"} for uuids in observations)
+    assert not tuple(destination.rglob(".slice-*"))
+    import sqlite3
+    with sqlite3.connect(catalog.as_uri() + "?mode=ro", uri=True) as con:
+        assert tuple(con.iterdump()) == before

--- a/tests/test_slice_operator.py
+++ b/tests/test_slice_operator.py
@@ -12,6 +12,7 @@ from modelark.slice import domain as d
 from modelark.slice import state as s
 from modelark.slice import transaction as t
 from modelark.slice.linux import BoundTree
+from modelark.slice.capacity import _root_metadata as PRODUCTION_ROOT_METADATA
 from test_slice_transaction import Destination, Sources, proposal
 
 
@@ -276,20 +277,35 @@ def test_ready_preview_persists_admission_without_output_writes(store, operator,
     assert not list(path.iterdir())
 
 
-def test_capacity_refusal_does_not_create_transaction(store, operator, monkeypatch, tmp_path):
+@pytest.mark.parametrize('failure', ['policy', 'io', 'absent', 'replaced', 'unknown'])
+def test_capacity_refusal_does_not_create_transaction(store, operator, monkeypatch, tmp_path, failure):
     _, _, snapshot = proposal()
     path = tmp_path / "destination"
     path.mkdir()
     monkeypatch.setattr(operator, "read_catalog", lambda *a: snapshot)
     monkeypatch.setattr(operator, "_archives", lambda path: ())
     evidence = SimpleNamespace(device_id="test-device", fs_uuid="test-filesystem", available_bytes=1_000_000)
-    monkeypatch.setattr(operator, "LinuxObserver", lambda: SimpleNamespace(observe=lambda *a, **k: evidence))
+    def recheck(tree, observed):
+        tree.check()
+        if failure in {'absent', 'replaced'}:
+            raise t.TransferRefusal('WAITING_DESTINATION' if failure == 'absent' else 'DESTINATION_CHANGED')
+        if failure == 'unknown':
+            raise OSError('reprobe unavailable')
+    monkeypatch.setattr(operator, "LinuxObserver", lambda: SimpleNamespace(
+        observe=lambda *a, **k: evidence, recheck_attachment=recheck))
 
     def refuse(*args):
+        if failure != 'policy':
+            import errno
+            from modelark.slice.io_errors import ProbeFailure
+            raise ProbeFailure(OSError(errno.EIO, 'capture ioctl failed'),
+                               'DESTINATION_CAPACITY_UNPROVEN', 'capacity capture')
         raise t.TransferRefusal("DESTINATION_CAPACITY_UNPROVEN")
 
     monkeypatch.setattr(operator, "_capacity", lambda: SimpleNamespace(capture=refuse))
-    with pytest.raises(t.TransferRefusal, match="DESTINATION_CAPACITY_UNPROVEN"):
+    expected = {'absent': 'WAITING_DESTINATION', 'replaced': 'DESTINATION_CHANGED'}.get(
+        failure, 'DESTINATION_CAPACITY_UNPROVEN')
+    with pytest.raises(t.TransferRefusal, match=expected):
         operator.preview(tmp_path / "explicit-catalog", path, ["org/model"], "delivery")
     with store._connection(write=False) as con:
         assert con.execute("SELECT COUNT(*) FROM transactions").fetchone()[0] == 0
@@ -373,7 +389,7 @@ def test_already_typed_bootstrap_refusal_is_preserved(operator, monkeypatch):
     assert caught.value.code == "STATE_BUSY"
 
 
-@pytest.mark.parametrize('mode', ['small', 'parent', 'large', 'unplug', 'acl-unplug'])
+@pytest.mark.parametrize('mode', ['small', 'parent', 'large', 'unplug', 'acl-unplug', 'metadata-unplug'])
 def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, monkeypatch, tmp_path, mode):
     """Only hardware/free-space observations are fake; all assembly and IO are real."""
     import os
@@ -410,6 +426,7 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     device = "operator-integration-" + uuid.uuid4().hex
     observations = []
     connected = [True]
+    payload_written = [False]
 
     def availability(tree):
         identities = set()
@@ -422,6 +439,9 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
                 initial_inodes - len(identities))
 
     class Observer:
+        def recheck_attachment(self, tree, evidence):
+            self.check_attachment(tree, evidence)
+
         def check_attachment(self, tree, evidence, **kwargs):
             if tree.path == destination and not connected[0]:
                 # Model physical backing disappearance while the mount ID remains present.
@@ -461,6 +481,13 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
         return result
     if mode == 'unplug':
         monkeypatch.setattr(operator.UsbDestination, 'append', unplug_after_payload)
+    if mode == 'metadata-unplug':
+        def arm_metadata_fault(self, path, token, data):
+            result = original_write(self, path, token, data)
+            if data == DATA[:len(data)]:
+                payload_written[0] = True
+            return result
+        monkeypatch.setattr(operator.UsbDestination, 'append', arm_metadata_fault)
     original_getxattr = os.getxattr
     def unplug_during_owned_directory_acl(fd, name, *args, **kwargs):
         import errno
@@ -477,12 +504,24 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     tx = reviewed["transaction_id"]
     assert reviewed["state"] == "ready" and not list(destination.iterdir())
     assert operator.approve(tx, reviewed["seal"])["state"] == "approved"
+    if mode == 'metadata-unplug':
+        # Retain the production metadata helper; inject below it at the actual
+        # ioctl boundary after payload has already been written/certified.
+        def ioctl(fd, command, flags, mutate=True):
+            import errno
+            if payload_written[0]:
+                connected[0] = False
+                raise OSError(errno.EIO, 'unplug during root metadata ioctl')
+            flags[0] = 0
+        monkeypatch.setattr(capacity.fcntl, 'ioctl', ioctl)
+        monkeypatch.setattr(capacity, '_root_metadata', PRODUCTION_ROOT_METADATA)
     result = operator.start(tx, supplied_destination, {"drive-a": archive})
-    if mode in {'unplug', 'acl-unplug'}:
+    if mode in {'unplug', 'acl-unplug', 'metadata-unplug'}:
         assert result['state'] == 'waiting_destination'
         assert store.status(tx).state == 'waiting_destination'
         assert not (destination / 'delivery/.modelark-slice-receipt.json').exists()
         connected[0] = True
+        payload_written[0] = False
         monkeypatch.setattr(operator.UsbDestination, 'append', original_write)
         monkeypatch.setattr(os, 'getxattr', original_getxattr)
         result = operator.start(tx, destination, {'drive-a': archive})
@@ -492,7 +531,7 @@ def test_actual_operator_catalog_reader_capacity_and_delivery_roundtrip(store, m
     assert receipt["status"] == "complete" and receipt["transaction"] == tx
     assert receipt["seal"] == reviewed["seal"]
     assert all(set(uuids) == {"fs-a", "other-fs"} for uuids in observations)
-    assert len(observations) <= (30 if mode in {'unplug', 'acl-unplug'} else 16)
+    assert len(observations) <= (30 if mode in {'unplug', 'acl-unplug', 'metadata-unplug'} else 16)
     assert not tuple(destination.rglob(".slice-*"))
     import sqlite3
     with sqlite3.connect(catalog.as_uri() + "?mode=ro", uri=True) as con:

--- a/tests/test_slice_paths.py
+++ b/tests/test_slice_paths.py
@@ -1,0 +1,40 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from modelark.slice.paths import canonical_attachment, utf8_size
+from modelark.slice.transaction import TransferRefusal
+
+
+def test_attachment_normalization_is_lexical_and_idempotent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / 'target'
+    target.mkdir()
+    (tmp_path / 'link').symlink_to(target, target_is_directory=True)
+    result = canonical_attachment('missing/../link')
+    assert result == tmp_path / 'link'
+    assert result != result.resolve()
+    assert canonical_attachment(result) == result
+
+
+def test_attachment_expands_home_without_requiring_it_to_exist(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, 'expanduser', lambda self: tmp_path / str(self)[2:])
+    assert canonical_attachment('~/missing/../usb') == tmp_path / 'usb'
+
+
+def test_attachment_retains_host_filesystem_encoding(tmp_path):
+    path = tmp_path / os.fsdecode(b'usb-\xff')
+    assert canonical_attachment(path) == path
+
+
+@pytest.mark.parametrize('value', ['plain', '模型/é', '😀'])
+def test_output_size_counts_utf8_bytes(value):
+    assert utf8_size(value) == len(value.encode('utf-8'))
+
+
+@pytest.mark.parametrize('value', ['bad-\udcff', '\ud800'])
+def test_output_size_refuses_surrogates(value):
+    with pytest.raises(TransferRefusal) as caught:
+        utf8_size(value)
+    assert caught.value.code == 'DESTINATION_LAYOUT_UNSUPPORTED'

--- a/tests/test_slice_probe_contract.py
+++ b/tests/test_slice_probe_contract.py
@@ -1,0 +1,276 @@
+"""Cross-adapter IO evidence contracts; faults are injected below actual probe helpers.
+
+Every path/device is disposable. A volume probe receives a synthetic opened block
+descriptor backed by a temporary file; no real block device is opened or read.
+"""
+import errno
+import os
+import stat
+from types import MethodType, SimpleNamespace
+
+import pytest
+
+from modelark.slice import capacity, hardware, linux, operator, transaction as t
+from modelark.slice.destination import OWNER_XATTR, _port_io
+from test_slice_transaction import api as api, setup as setup
+
+
+MEDIA_ERRORS = (errno.EIO, errno.ENODEV, errno.ENXIO)
+POLICY_CODES = {
+    "metadata": "DESTINATION_CAPACITY_UNPROVEN",
+    "marker": "DESTINATION_ALLOCATION_UNPROVEN",
+    "volume": "DESTINATION_CAPACITY_UNPROVEN",
+    "acl": "DESTINATION_CAPACITY_UNPROVEN",
+    "writable": "DESTINATION_NOT_WRITABLE",
+}
+
+
+@pytest.fixture
+def tree(tmp_path):
+    root = tmp_path / "probe-root"
+    root.mkdir()
+    with linux.BoundTree(root) as bound:
+        yield bound
+
+
+def inject_probe(monkeypatch, tree, name, number):
+    """Patch a syscall beneath the helper, not the classification/helper itself."""
+    original = OSError(number, "injected " + name + " failure")
+
+    def fail(*args, **kwargs):
+        raise original
+
+    if name == "metadata":
+        monkeypatch.setattr(capacity.fcntl, "ioctl", fail)
+        call = lambda: capacity._root_metadata(tree)
+    elif name in {"marker", "acl", "writable"}:
+        attribute = {"marker": OWNER_XATTR, "acl": "system.posix_acl_default",
+                     "writable": "user.modelark.slice-capability-probe"}[name]
+        getxattr = os.getxattr
+
+        def read_attribute(fd, key, *args, **kwargs):
+            if fd == tree.fd and key == attribute:
+                raise original
+            return getxattr(fd, key, *args, **kwargs)
+
+        monkeypatch.setattr(os, "getxattr", read_attribute)
+        call = {"marker": lambda: capacity._require_unique_marker(tree.fd, "a" * 32),
+                "acl": lambda: linux.require_no_default_acl(tree.fd),
+                "writable": lambda: hardware._writable_root(tree, SimpleNamespace(options={"rw"}))}[name]
+    else:
+        assert name == "volume"
+        # Duplicate the retained temporary-directory fd, then present only that
+        # duplicate as the expected block-device descriptor. pread fails before
+        # any content is consumed; regular-file/device mismatch cannot mask it.
+        actual_open, actual_fstat, actual_pread = os.open, os.fstat, os.pread
+        opened = set()
+        device = actual_fstat(tree.fd).st_dev
+        block_path = f"/dev/block/{os.major(device)}:{os.minor(device)}"
+
+        def open_block(path, *args, **kwargs):
+            if path == block_path:
+                fd = os.dup(tree.fd)
+                opened.add(fd)
+                return fd
+            return actual_open(path, *args, **kwargs)
+
+        def block_info(fd):
+            if fd in opened:
+                return SimpleNamespace(st_mode=stat.S_IFBLK | 0o600, st_rdev=device)
+            return actual_fstat(fd)
+
+        def read_block(fd, *args):
+            if fd in opened:
+                raise original
+            return actual_pread(fd, *args)
+
+        monkeypatch.setattr(os, "open", open_block)
+        monkeypatch.setattr(os, "fstat", block_info)
+        monkeypatch.setattr(os, "pread", read_block)
+        call = lambda: capacity._volume(tree, SimpleNamespace(fs_uuid="synthetic-volume"))
+    return call, original
+
+
+@pytest.mark.parametrize("name", POLICY_CODES)
+@pytest.mark.parametrize("number", (*MEDIA_ERRORS, errno.EACCES, errno.EOPNOTSUPP))
+def test_low_level_probe_retains_original_errno(tree, monkeypatch, name, number):
+    call, original = inject_probe(monkeypatch, tree, name, number)
+    with pytest.raises(OSError) as caught:
+        call()
+    assert caught.value.errno == original.errno
+    if caught.value is not original:
+        assert caught.value.original is original
+
+
+def test_missing_acl_is_positive_absence_not_probe_failure(tree, monkeypatch):
+    call, _ = inject_probe(monkeypatch, tree, "acl", errno.ENODATA)
+    assert call() is None
+
+
+def test_missing_marker_is_policy_refusal_not_unplug(tree, monkeypatch):
+    call, _ = inject_probe(monkeypatch, tree, "marker", errno.ENODATA)
+    with pytest.raises(t.TransferRefusal) as caught:
+        call()
+    assert caught.value.code == "DESTINATION_ALLOCATION_UNPROVEN"
+
+
+@pytest.mark.parametrize("probe_result,expected", [
+    (None, "FALLBACK"),
+    ("WAITING_DESTINATION", "WAITING_DESTINATION"),
+    ("DESTINATION_CHANGED", "DESTINATION_CHANGED"),
+    ("DESTINATION_UNPROVEN", "FALLBACK"),
+    ("DESTINATION_CAPACITY_UNPROVEN", "FALLBACK"),
+    ("raw-error", "FALLBACK"),
+])
+def test_classifier_only_conclusive_attachment_proof_overrides(probe_result, expected):
+    from modelark.slice.io_errors import classify_io
+    original = OSError(errno.EIO, "original disk IO")
+    fallback = t.TransferRefusal("DESTINATION_CAPACITY_UNPROVEN", "original capacity probe")
+    response = (OSError(errno.ENODEV, "reprobe failed") if probe_result == "raw-error"
+                else t.TransferRefusal(probe_result, "reprobe result") if probe_result else None)
+
+    def check():
+        if response:
+            raise response
+
+    result = classify_io(original, check, fallback)
+    assert result is (fallback if expected == "FALLBACK" else response)
+
+
+def test_probe_failure_decorator_retains_original_and_policy():
+    from modelark.slice.io_errors import ProbeFailure, probe_io
+    original = OSError(errno.ENXIO, "original IO")
+
+    @probe_io("DESTINATION_CAPACITY_UNPROVEN", "root metadata probe")
+    def failed():
+        raise original
+
+    with pytest.raises(ProbeFailure) as caught:
+        failed()
+    assert caught.value.original is original
+    assert caught.value.errno == original.errno
+    assert caught.value.code == "DESTINATION_CAPACITY_UNPROVEN"
+    assert "root metadata probe" in caught.value.detail
+
+
+def test_outer_probe_does_not_erase_narrower_policy_or_original_exception():
+    from modelark.slice.io_errors import ProbeFailure, probe_io
+    original = OSError(errno.EIO, "marker read")
+    narrow = ProbeFailure(original, "DESTINATION_ALLOCATION_UNPROVEN", "marker")
+
+    @probe_io("DESTINATION_CAPACITY_UNPROVEN", "outer capacity")
+    def outer():
+        raise narrow
+
+    with pytest.raises(ProbeFailure) as caught:
+        outer()
+    assert caught.value is narrow
+    assert caught.value.original is original
+
+
+def test_policy_refusal_is_not_reinterpreted_as_an_io_probe_failure():
+    from modelark.slice.io_errors import probe_io
+    original = t.TransferRefusal("DESTINATION_CAPACITY_UNPROVEN", "unsupported present ACL")
+
+    @probe_io("DESTINATION_NOT_WRITABLE", "outer writable proof")
+    def unsupported():
+        raise original
+
+    with pytest.raises(t.TransferRefusal) as caught:
+        unsupported()
+    assert caught.value is original
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+@pytest.mark.parametrize("attachment", ("attached", "absent", "replaced", "unknown", "policy"))
+def test_source_read_classification_preserves_source_side_and_original_failure(wrapped, attachment):
+    from modelark.slice.io_errors import ProbeFailure
+    from modelark.slice.local_source import _SourceErrors
+    original = OSError(errno.EIO, "original source failure")
+    error = (ProbeFailure(original, "DESTINATION_CAPACITY_UNPROVEN", "source metadata probe")
+             if wrapped else original)
+
+    def read(size):
+        raise error
+
+    def check():
+        if attachment == "absent":
+            raise t.TransferRefusal("WAITING_DESTINATION", "source backing absent")
+        if attachment == "replaced":
+            raise t.TransferRefusal("DESTINATION_CHANGED", "source backing replaced")
+        if attachment == "unknown":
+            raise OSError(errno.EACCES, "reprobe denied")
+        if attachment == "policy":
+            raise t.TransferRefusal("DESTINATION_UNPROVEN", "reprobe unknown")
+
+    source = _SourceErrors(SimpleNamespace(read=read), "source-label", check)
+    with pytest.raises(t.TransferRefusal) as caught:
+        source.read(1024)
+    expected = {"absent": "SOURCE_MISSING", "replaced": "SOURCE_CHANGED"}.get(
+        attachment, "SOURCE_IDENTITY_UNPROVEN" if wrapped else "SOURCE_READ_FAILED")
+    assert caught.value.code == expected
+    assert caught.value.__cause__ is error
+    if attachment not in {"absent", "replaced"}:
+        assert "original source failure" in caught.value.detail
+        assert "reprobe" not in caught.value.detail
+
+
+def checked_adapter(tree, attachment):
+    """Actual _CheckedDestination IO classifier with synthetic backing evidence only."""
+    adapter = object.__new__(operator._CheckedDestination)
+    adapter.tree = tree
+    adapter._evidence = SimpleNamespace()
+
+    def check_attachment(*args, **kwargs):
+        if attachment == "absent":
+            raise t.TransferRefusal("WAITING_DESTINATION", "bound backing absent")
+        if attachment == "replaced":
+            raise t.TransferRefusal("DESTINATION_CHANGED", "bound backing replaced")
+        if attachment == "unknown":
+            raise OSError(errno.EACCES, "backing reprobe unavailable")
+        if attachment == "policy":
+            raise t.TransferRefusal("DESTINATION_UNPROVEN", "backing evidence unavailable")
+
+    adapter._observer = SimpleNamespace(recheck_attachment=check_attachment)
+    return adapter
+
+
+@pytest.mark.parametrize("name", ("metadata", "marker", "volume", "acl"))
+@pytest.mark.parametrize("attachment", ("attached", "absent", "replaced", "unknown", "policy"))
+def test_real_helper_through_port_io_uses_proof_based_classification(tree, monkeypatch, name, attachment):
+    probe, original = inject_probe(monkeypatch, tree, name, errno.EIO)
+    adapter = checked_adapter(tree, attachment)
+
+    @_port_io
+    def operation(self):
+        probe()
+
+    with pytest.raises(t.TransferRefusal) as caught:
+        operation(adapter)
+    expected = {"absent": "WAITING_DESTINATION", "replaced": "DESTINATION_CHANGED"}.get(
+        attachment, POLICY_CODES[name])
+    assert caught.value.code == expected
+    if attachment in {"attached", "unknown", "policy"}:
+        assert "injected " + name in caught.value.detail
+        assert isinstance(caught.value.__cause__, OSError)
+        assert caught.value.__cause__.errno == original.errno
+
+
+@pytest.mark.parametrize("name", ("metadata", "marker", "volume", "acl"))
+@pytest.mark.parametrize("attachment,state", [("absent", "waiting_destination"),
+                                              ("attached", "invalidated"), ("replaced", "invalidated"),
+                                              ("unknown", "invalidated")])
+def test_probe_classification_reaches_durable_transaction_state(setup, tree, monkeypatch, name, attachment, state):
+    transaction, store, plan, tx, _, sources = setup
+    store.approve(tx, expected_seal=plan.seal)
+    probe, _ = inject_probe(monkeypatch, tree, name, errno.ENODEV)
+    adapter = checked_adapter(tree, attachment)
+
+    @_port_io
+    def check(self, *args):
+        probe()
+
+    adapter.check = MethodType(check, adapter)
+    with pytest.raises(t.TransferRefusal):
+        transaction.start(store, tx, adapter, sources)
+    assert store.status(tx).state == state

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -205,7 +205,7 @@ def test_private_v1_upgrade_preserves_transaction_authority(setup, api, missing_
         lease.close()
     assert upgraded.stop_requested(tx)  # A newer stop still wins after migration.
     with upgraded._connection(write=False) as con:
-        assert con.execute("PRAGMA user_version").fetchone()[0] == 5
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 6
     assert api[1].Store().events(tx) == before  # Reopening is idempotent.
     assert not list(dest.root.iterdir())
 

--- a/tests/test_slice_transaction.py
+++ b/tests/test_slice_transaction.py
@@ -205,7 +205,7 @@ def test_private_v1_upgrade_preserves_transaction_authority(setup, api, missing_
         lease.close()
     assert upgraded.stop_requested(tx)  # A newer stop still wins after migration.
     with upgraded._connection(write=False) as con:
-        assert con.execute("PRAGMA user_version").fetchone()[0] == 6
+        assert con.execute("PRAGMA user_version").fetchone()[0] == 8
     assert api[1].Store().events(tx) == before  # Reopening is idempotent.
     assert not list(dest.root.iterdir())
 


### PR DESCRIPTION
## Summary

Completes the coding portion of Slice 3's attended direct-USB vertical slice on merged Slices 1/2 (#68/#69):

- Guard every ModelArk application launch before startup, including direct portal and migration entrypoints. A second instance refuses immediately; existing internal attempt/archive fences remain.
- Join preview → exact-seal approval → synchronous Start/status/Stop through explicit, JSON-returning `modelark slice` commands. Ctrl+C acknowledges Stop within the running instance.
- Bind IO to Linux openat2/statx descriptors; admit a uniquely identified direct USB destination, excluding system/swap and all registered archive disks. Read local archive originals without retrieval via bounded raw/ZipNN/StreamZNN/optional-zstd decoding.
- Seal verified ext4 features, conservative workload/inode budgets, root evidence and explicit catalog in private schema v6. Reconcile owned allocation without drift tolerance, using unique external ownership markers.
- Recover certified files/directories; refuse ambiguous pre-certificate directory residue (DEC-123). Certificate schema v2 persists filesystem-scoped inode/birth identity, allowing device-number renumbering on reattachment while preserving live attachment checks.

DEC-124 records the operator's launch-level singleton clarification and trusted-account scope. DEC-125 documents admission/capacity policy. See `docs/usable-slice-direct.md` for workflow, limits and the reserve derivation.

## Round 1 corrections

Addressed all seven findings from Greptile and Codex: unrelated loop mounts, the remaining deployment launch probe, still-mounted physical unplug, per-MiB full hardware scans, relative/tilde source paths, effective root permission/user-xattr admission, and recursive deep-layout traversal. DEC-126 records the admission/streaming boundary separation. Protected/ambiguous ancestry remains fail-closed; launch exclusion and the trusted-account scope are unchanged.

## Round 2 corrections

Addressed the four round-2 findings: explicit runtime kernel-capability requirements and unsupported-syscall refusals; full generated temporary-path byte limits; lexical `..` normalization of source attachments without symlink resolution; and default-ACL exclusion from the bounded marker profile. Existing authenticated directories are checked too, covering inherited child ACLs after the root default is removed. No ACLs or permissions are automatically changed. DEC-127 records the complete-workload admission correction.

## Approved post-round-3 corrections

The agreed three-round loop completed at f55a8e2: Greptile returned 5/5 with no new findings, while Codex left two residual findings. The operator explicitly approved correcting both using a narrow shared Slice path contract; this is not a fourth review round and the watcher remains paused.

- P1 cached-loss lookup: operator preview/Start, LinuxObserver observation/recovery, BoundTree and LocalArchiveReader share lexical attachment normalization (expand home, collapse parent segments, no symlink resolution). Parent-segment destination spelling no longer loses the cached backing-loss proof during full-refresh IO/ACL failure.
- P2 UTF-8 refusal: final paths, generated temporary paths and components use strict validated byte counts. Surrogate-escaped Linux root input produces JSON DESTINATION_LAYOUT_UNSUPPORTED instead of a UnicodeEncodeError traceback. Host attachment encoding and sealed relative-path serialization are unchanged.
- DEC-128 records the approved scope; no schema change, weaker confinement, global authority, permission change, deployment or physical trial.
- Red regressions reproduced both issues (8 failures and 2 passing controls). Focused fixed tests: 176 passed. Full affected source suite: 588 passed, 5 optional-codec skips. Copied Slice/launch tests against the rebuilt installed wheel with isolated imports: 573 passed, including optional zstd. Package/source contents match exactly; Ruff and diff checks pass. Two upstream torch deprecation warnings only. New-head CI remains separate; no new-head reviewer-clearance claim.

## Approved adapter-boundary refactor

The operator approved a bounded architectural correction after the next comments exposed the same evidence/representation problem across several helpers. DEC-129 records the scope; no new review round was requested.

- Shared IO evidence contract: low-level metadata, superblock, ownership-marker, ACL and creation-capability probes preserve original errno/cause plus their fallback meaning. Only proven attachment loss/replacement overrides at the boundary. Unknown retry failures do not mask the original; semantic policy and private-state failures remain distinct.
- Existing consumers updated: destination/operator, preview while descriptors remain alive, and source setup/read/cleanup with source-side attribution. Consumer errors are not converted into source errors.
- Shared lossless procfs decoding/parsing across observer, mount-presence and capacity checks. Raw filename bytes, Unicode whitespace, escaped LF and known nsfs opaque roots are covered without making unsupported filesystems eligible destinations.
- Protected system directories and swapfiles use actual descriptor-backed device/mount identity. Resolved nested mounts are protected; target changes trigger fresh admission even with unchanged mountinfo. Destination/archive attachments retain no-symlink confinement.
- Validation injects syscall faults below actual helpers, asserts durable wait versus invalidation, and exercises certified partial-work recovery through a real operator Start. Final full affected source suite: **701 passed, 5 optional-zstd skips** (333.35s). Copied Slice/launch suite against the rebuilt installed wheel with isolated imports: **686 passed**, no skips (326.66s). Exact source/package comparison, Ruff and diff checks pass; two upstream torch warnings only. New-head CI remains separate from this completed local validation.

## Historical round-2 correction validation

- Full affected source suite: **570 passed, 5 optional-codec skips**.
- Copied Slice/launch suite against the rebuilt installed wheel: **555 passed**, including optional zstd.
- A subsequent narrow ACL media-error correction preserves backing-loss re-probing. Its real operator regression proves attended wait without a receipt, followed by successful fresh Start. Final affected subset after that correction: **225 passed from source and 225 passed from the rebuilt installed wheel**.
- Wheel/source contents match exactly; imports verified from site-packages with `python -I`. Ruff/diff checks pass. All physical observations remain synthetic, with real IO/ACLs confined to disposable directories. New-head CI and final round-3 reviews remain required.

## Round-1 correction validation (60995ca)

- Affected source suite: **549 passed, 5 optional-zstd skips**; a final narrow observation-error handler correction was followed by **58 passing hardware tests**.
- Final rebuilt installed wheel, copied Slice/launch suite with isolated imports and exact package/source comparison: **535 passed**, including optional zstd.
- Installed deployment metadata checks: **2 passed**; installed process smoke refused three competitors and allowed launch after release.
- Ruff and diff checks pass. Tests use disposable state and simulated hardware; no physical USB trial was performed. CI must rerun on the correction head.

## Initial-head validation (b751cee; not a claim about later heads)

- Final affected source suite: **521 passed, 5 optional-zstd skips**.
- Copied Slice/launch suite against the rebuilt installed wheel (`python -I`, package paths and content verified): **507 passed**, including zstd with no skips.
- Installed process smoke: three competing launches refused; launch after release succeeded.
- All remaining collected source regression: **1021 passed, 1 skipped**, with disposable catalog/state defaults (360.07s). Combined source coverage spans all 1529 collected tests, with 19 overlapping deploy/migration checks between the runs: **1523 unique passes, 6 skips**.
- Wheel build, repository Ruff and diff checks pass. Slice/wheel suites report only two upstream torch deprecation warnings; the remaining suite also exercises three expected legacy-capacity deprecations.

Disposable integration tests exercise real confined IO, private state, certificates and source fences with synthetic physical-device/free-space observations, including crash/recovery, Stop, unplug/replacement and typed IO refusal. They are not a physical USB trial.

## Scope / review protocol

No deployment, service restart, live catalog/archive mutation, formatting, mount changes, real-device trial or merge. The first attended physical trial and merge remain operator gates. Older unguarded live versions are not retroactively enrolled by the new launch guard.

Run the agreed bounded Greptile/Codex review loop: at most three review rounds total, including the initial round, then stop and summarize residual findings and any common architectural assumption. Do not expand the threat model into adversarial same-account filesystem manipulation.
