### PR TITLE
fix: reconcile dirty generations owned by ended Fill sessions

### DIFF
--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2850,3 +2850,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Native adapter, observer, plan/operator assembly, shared transaction/private-store dispatch and narrow Linux inventory/role helpers. Private schema upgrade only; no catalog migration, Fill/source fence changes, live deployment, USB writes or permission rewriting. FAT32 remains the separate pending session-only gate under DEC-130.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-folders.md, docs/usable-slice-direct.md, docs/usable-slice-transaction.md, docs/plans/folder-projection-scope.md, README.md
 - `related`: DEC-123, DEC-124, DEC-125, DEC-129, DEC-130
+
+### DEC-132: Reconcile ended Fill-owned dirty generations without rewriting execution history
+- `id`: DEC-132
+- `date`: 2026-09-09
+- `status`: accepted
+- `triggered_by`: Operator authorized a new recovery PR after physical-projection preflight found drive-07's dirty generation owned by a paused Fill; local Grok CLI accepted the corrected scope in pass 2.
+- `decision`: Extend the existing operator reconciliation path to recognized ended Fill owners with matching durable session/token evidence. Retain controller and physical-drive fences through full report-only inventory and final observation; compare the captured owner/token/exact state and drive facts inside the same immediate transaction that publishes the existing generation's anchor and planner revision. Refuse live sessions, held/unprovable child markers, changed ownership and owned-dirty capacity/identity transitions.
+- `rationale`: A recorded owner does not imply a live writer, and pause normally removes its child marker. Neither terminal state nor marker absence proves physical exclusion. Expired-live-session recovery cannot repair a paused generation's admission evidence; erasing ownership or opening a new epoch would lose the relevant history.
+- `impact`: Drive-bootstrap adapter, existing CLI refusal translation and focused regressions only. No schema change, auto-resume/completion, destructive cleanup, full-byte verification claim, deployment or live catalog/device mutation. A subsequent clean reconciliation keeps ordinary refresh semantics.
+- `docs_updated`: docs/decision_log.md, docs/operations.md, docs/plans/terminal-session-reconciliation.md
+- `related`: modelark/execution_authority.py, modelark/execution_recovery.py, modelark/drive_bootstrap.py

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -159,6 +159,24 @@ Its `present / missing / debris / extra` counts are evidence, not a cleanup requ
 remain on disk, are not adopted into catalogued residency, and are never deleted automatically. Do
 not use `--dedicated` to promote shared or otherwise unfenceable storage.
 
+A dirty generation may still name a Fill session that has paused, blocked, stopped, failed or
+finished. Reconciliation now supports that case without clearing its owner or changing the session:
+it inventories under controller/physical-drive locks, rechecks the exact owner/token/state in the
+publication transaction, and anchors the **existing** generation. A paused session needs no expired
+lease. This restores drive admission evidence; it does not resume the Fill or assert that it completed.
+
+Stop the portal/other ModelArk instance before launching the CLI against its catalog. Any live Fill
+session refuses with `FILL_SESSION_ACTIVE`. Missing/mismatched owner evidence refuses with
+`DRIVE_RECOVERY_OWNER_UNPROVEN`; a held or uninspectable owner child marker refuses with
+`DRIVE_RECOVERY_CHILD_UNPROVEN`. Missing markers are normal after pause, but physical-drive locks
+still exclude surviving transport children. The command may wait for those locks. Changes to the
+captured owner or drive facts during the scan refuse with `DRIVE_RECOVERY_OWNER_CHANGED`.
+An owned dirty generation with changed capacity/fingerprint/authority refuses with
+`DRIVE_RECOVERY_IDENTITY_CHANGED`; it cannot bypass recovery by opening a new epoch.
+
+No refusal publishes a clean anchor. Inventory establishes the existing catalog/location evidence,
+not a fresh full-byte hash verification; use physical verification for that separate evidence level.
+
 ## Verify archive copies
 
 Remote-header verification and physical archive verification are different operations. Tier A

--- a/docs/plans/terminal-session-reconciliation.md
+++ b/docs/plans/terminal-session-reconciliation.md
@@ -1,0 +1,99 @@
+# Terminal-session drive reconciliation — accepted scope
+
+## Goal and observed gap
+
+Enable the existing launch-guarded `modelark drive reconcile LABEL --dedicated` command to
+reconcile a dirty generation whose recorded Fill owner has ended. The live acceptance blocker
+is drive-07 epoch 1/generation 2, owned by a paused session with terminal code
+DRIVE_RECONCILIATION_REQUIRED. Ordinary reconciliation currently rejects any recorded owner;
+expired-session recovery only handles expired live sessions and never publishes an anchor.
+
+This PR is code, tests and documentation only. Do not recover the live catalog, stop/restart the
+portal, remount/write USB, alter archive payloads, deploy or merge as part of implementation.
+
+## Proposed contract
+
+- Reuse `drive_bootstrap.reconcile_drive` and its CLI, full report-only inventory, fresh final
+  physical evidence, controller then sorted drive fences, and short atomic publication.
+  No new schema, separate repair tool, automatic Fill resume or new destructive flag.
+- A dirty session-owned generation is eligible only with a complete owner-session/token pair,
+  an existing matching session token, and a recognized ended state (paused, blocked, stopped,
+  failed or done). No globally live Fill session may exist. Missing/unknown/mismatched owner
+  evidence refuses; never erase ownership to make this look sessionless.
+- Probe only the exact owner session's existing child marker on the owned-dirty path, before
+  waiting on controller locks when possible, and again while fenced. Missing or present-unlocked
+  marker means not held: pause normally removes the marker. Do not create a missing marker.
+  A held marker or probe error (including EACCES) refuses. Marker absence is not proof that a
+  writer exited: transport children inherit physical drive-fence FDs, not session-marker FDs.
+  Retain the
+  existing controller/physical-drive fences through inventory and commit; a stale timestamp or
+  terminal state alone is not evidence that a surviving writer has exited.
+- Validate owner evidence before every path that might publish or advance this owned dirty
+  generation. In particular, do not let the existing capacity-epoch transition branch bypass
+  owner validation. Keep capacity/identity transition of an owned dirty generation out of this
+  small recovery path: refuse rather than invent a new generation or discard its association.
+- Reuse full inventory's existing semantics: every catalogued claim must be proven; debris and
+  extras are reported, never deleted/adopted. This does not add full hash verification or claim
+  that an inventory is a physical byte-integrity scan. Retain actual free-space observation.
+- Before publishing, re-read under BEGIN IMMEDIATE: absence of a live session, exact captured
+  owner pair/session token/state, and unchanged drive epoch/generation/identity/capacity/authority.
+  Use the shared execution-authority helper for owner/token/state checks where appropriate.
+  Publish the existing generation's clean anchor and planner revision atomically. On a mismatch
+  or any inventory/final-evidence/publication failure, publish nothing.
+  Capture after both fences and before inventory; at commit normalize schema INTEGER tokens
+  and allow only the captured exact state. Do not use today's `publish_clean_anchor` unchanged
+  (its live-session check is outside BEGIN), `session_write`, or `recover_expired_session`.
+- Preserve session state, terminal reason, fencing token, dirty-generation owner pair, approval
+  and task history. Do not infer that the prior Fill completed; recovery only restores drive
+  admission evidence. Subsequent Fill/Slice operations revalidate through their normal paths.
+- Preserve existing sessionless recovery, clean refresh/drift, bootstrap and legacy refusal
+  behavior except for precise new owner/child-evidence refusals. Repeated ordinary reconciliation
+  after a successful recovery follows the existing clean-refresh contract.
+
+## Expected implementation surface
+
+`modelark/drive_bootstrap.py`: small private captured-owner validation and atomic recovered-anchor
+publication helpers integrated into existing reconciliation. Reuse, do not rewrite,
+`execution_authority`/`execution_recovery` child-fence and `drive_mutation` primitives.
+CLI help/operator docs explain ended-owner support and the distinction from expired-session
+recovery. Focused tests in drive-bootstrap/recovery test modules and public CLI coverage.
+`cmd_drive_reconcile` must also translate `proposal.Refusal`, including FILL_SESSION_ACTIVE,
+to its existing clean SystemExit format; no traceback for expected session/fence refusals.
+Use explicit drive recovery refusal codes for missing/mismatched owner evidence, child exclusion,
+and owned-dirty identity/capacity transitions. Preserve the legacy missing-session test as a
+missing-owner-evidence case, not as purported coverage of an actual live session row.
+
+## Regression matrix
+
+- Success for each recognized ended state; current real-style paused/no-expiry case.
+- Preserve session/task/dirty-owner records; only expected clean anchor/revision changes.
+- Refuse live owner or any other live session, missing session, unknown state, missing/half owner
+  pair, token mismatch, held/unprovable child fence; refuse before inventory where possible.
+- Owner/token/state/dirty pair/global-live/drive generation or identity changes during inventory
+  or at the commit boundary publish no anchor. Exercise real SQLite rollback and held fences.
+- Incomplete inventory, disappearing/replaced physical identity and failed publication leave dirty.
+- Capacity transition cannot bypass owned-dirty recovery guards.
+- Existing sessionless recovery/refresh/CLI progress and full relevant legacy suites remain green.
+- Installed-package tests and public invocation; no live catalog/device fixtures.
+
+## Local scope review
+
+Grok CLI session `01a08749-385a-72a2-a39d-cec7861a859a`, pass 1 REQUEST_CHANGES.
+The clarified contract above incorporates all four requested items: normal absent-marker semantics,
+guard-before-epoch-transition, captured fenced owner/CAS inside BEGIN, and public CLI Refusal handling.
+Add explicit real-style paused/no-expiry, real held-child flock, unchanged history, no publication
+on commit race, and ordinary second clean-refresh tests. No live recovery was attempted.
+
+Pass 2 in the same local Grok CLI session: ACCEPT. All four scope corrections and the
+regression matrix were accepted before implementation.
+
+Pass 3 reviewed the implementation and new regressions: ACCEPT, with no remaining correctness
+defect in the accepted scope. Focused legacy/new suites passed 177 tests; an isolated installed
+wheel passed 83 recovery/bootstrap/authority tests. All-source Ruff passed.
+
+## Review sequence
+
+Local Grok CLI checks this scope before implementation. Then implementation, regression tests,
+new PR and canonical Greptile/Codex requests. At most three newly requested web rounds; fix
+confirmed findings between rounds 1/2, stop on acceptance with green CI or after completed round 3.
+Summarize residual findings and common architectural assumptions at the cap. Never auto-merge.

--- a/modelark/cli.py
+++ b/modelark/cli.py
@@ -559,6 +559,7 @@ def cmd_drive_reconcile(args):
     from datetime import datetime, timezone
 
     from modelark import drive_bootstrap
+    from modelark.proposal import Refusal
 
     def progress(event):
         if event.phase == "inventory_started":
@@ -599,7 +600,7 @@ def cmd_drive_reconcile(args):
         r = drive_bootstrap.reconcile_drive(
             con, args.label, now=datetime.now(timezone.utc).isoformat(sep=" "),
             dedicated=args.dedicated, accept_drift=args.accept_drift, progress=progress)
-    except drive_bootstrap.DriveMutationRefused as exc:
+    except (drive_bootstrap.DriveMutationRefused, Refusal) as exc:
         # an offline/failed/unproven drive is an EXPECTED reconciliation outcome, not a crash: surface the
         # typed refusal as a clean operator message (the restore/hash-repair convention), not a traceback.
         raise SystemExit(f"drive reconcile failed: {exc.code}") from exc
@@ -823,7 +824,10 @@ def _main(argv, permit):
     dl = drsub.add_parser("list", help="list registered drives")
     dl.set_defaults(func=cmd_drive_list)
     rec = drsub.add_parser("reconcile",
-                           help="bootstrap identity + first clean anchor, or recover a dirty generation")
+                           help="bootstrap identity + first clean anchor, or recover a dirty generation",
+                           description="Reconcile a drive, including dirty generations owned by ended "
+                                       "Fill sessions. Live sessions/children or unproven ownership refuse; "
+                                       "recovery does not resume or complete the prior Fill.")
     rec.add_argument("label", help="the registered drive label to reconcile")
     rec.add_argument("--dedicated", action="store_true",
                      help="assert dedicated local storage no unsupported writer may modify (grants "

--- a/modelark/drive_bootstrap.py
+++ b/modelark/drive_bootstrap.py
@@ -1,4 +1,4 @@
-"""Drive identity bootstrap + first clean anchor + sessionless dirty recovery (RFC-002 / DEC-049 #35-B,
+"""Drive identity bootstrap + first clean anchor + fenced dirty recovery (RFC-002 / DEC-049 #35-B,
 PR-03c1) — the smallest usable predecessor to the #35-C admission-authority cutover.
 
 A neutral module: it depends only on the low-level catalog-v3 primitives (``drive_fence``,
@@ -25,7 +25,9 @@ a resize changes the fingerprint):
 generation + clean anchor + authority in ONE short transaction (a crash before it leaves the drive
 unknown and anchorless). ``dedicated_local`` is an explicit operator assertion (``dedicated=True``),
 never a probe result; ``dedicated=False`` persists nothing and refuses to downgrade an authoritative
-drive. Session-attributed recovery and label reuse/retirement are out of scope (#39, DEF-029).
+drive. Ended-session recovery preserves its owner/history and republishes only the existing
+generation after fenced inventory and transactional owner validation. Label reuse/retirement
+remains out of scope (DEF-029).
 """
 from __future__ import annotations
 
@@ -38,6 +40,7 @@ from typing import Callable
 
 from modelark import capacity_evidence, drive_fence, register
 from modelark import drive_mutation as dm
+from modelark import execution_authority as authority
 from modelark.core import db
 
 # Re-export the typed refusal so operator entry points (the `drive reconcile` CLI) can translate it to a
@@ -278,6 +281,82 @@ def _stable_identity_matches(ev: _LiveEvidence, persisted_fs, persisted_annex) -
     return True
 
 
+_ENDED_STATES = frozenset({"paused", "blocked", "stopped", "failed", "done"})
+
+
+@dataclass(frozen=True)
+class _RecoveryOwner:
+    attempt: authority.Attempt
+    state: str
+
+
+def _dirty_owner(con, label, facts):
+    epoch, gen, fp, cap, auth, _, _ = facts
+    if dm._generation_is_clean(con, label, epoch, gen, fp, cap, auth):
+        return None
+    row = con.execute(
+        "SELECT owner_session_id,owner_fencing_token FROM drive_dirty_generations "
+        "WHERE drive_label=? AND identity_epoch=? AND generation=?", [label, epoch, gen]
+    ).fetchone()
+    return None if row is None or row == (None, None) else row
+
+
+def _capture_recovery_owner(con, label, facts, *, expected=None):
+    """Validate durable identity; callers separately retain the physical exclusion fences."""
+    code = "DRIVE_RECOVERY_OWNER_CHANGED" if expected is not None else "DRIVE_RECOVERY_OWNER_UNPROVEN"
+    row = _dirty_owner(con, label, facts)
+    if row is None and expected is None:
+        return None
+    try:
+        if (row is None or not isinstance(row[0], str) or not row[0].strip()
+                or type(row[1]) is not int or row[1] < 1):
+            raise authority.AuthorityLost("incomplete dirty owner")
+        attempt = authority.Attempt(row[0], int(row[1]))
+        session = con.execute(
+            "SELECT fencing_token,state FROM execution_sessions WHERE session_id=?", [attempt.owner]
+        ).fetchone()
+        if session is None or type(session[0]) is not int:
+            raise authority.AuthorityLost("missing owner session/token")
+        captured = _RecoveryOwner(attempt, session[1])
+        if expected is not None and captured != expected:
+            raise authority.AuthorityLost("dirty owner or state changed")
+        authority.require_current(
+            attempt, authority.Attempt(attempt.owner, int(session[0])), session[1],
+            {expected.state} if expected is not None else _ENDED_STATES,
+        )
+    except authority.AuthorityLost as exc:
+        raise dm.DriveMutationRefused(code, drive=label) from exc
+    from modelark.execution_recovery import child_fence_still_held
+    try:
+        held = child_fence_still_held(session_id=attempt.owner)
+    except OSError as exc:
+        raise dm.DriveMutationRefused("DRIVE_RECOVERY_CHILD_UNPROVEN", drive=label) from exc
+    if held:
+        raise dm.DriveMutationRefused("DRIVE_RECOVERY_CHILD_UNPROVEN", drive=label)
+    return captured
+
+
+def _recover_owned_generation(con, label, dest, facts, owner, ev, now, progress):
+    """Inventory outside SQLite's write transaction, then CAS + anchor in one short commit."""
+    from modelark.execution_session import require_no_live_session
+    from modelark.proposal import bump_revision
+
+    inventory = _require_complete_inventory(con, label, dest, progress=progress)
+    final = _final_observation(con, label, ev)
+    epoch, gen = facts[:2]
+
+    def publish():
+        require_no_live_session(con)
+        if _persisted(con, label) != facts:
+            raise dm.DriveMutationRefused("DRIVE_RECOVERY_OWNER_CHANGED", drive=label)
+        _capture_recovery_owner(con, label, facts, expected=owner)
+        dm._publish_anchor_locked(con, label, epoch, gen, final.observation(), now)
+        bump_revision(con)
+
+    dm._immediate(con, publish)
+    return Reconciliation("recovered", epoch, gen, final.free, inventory=inventory)
+
+
 def reconcile_drive(con, label: str, *, now, dedicated: bool = False, accept_drift: bool = False,
                     blocking: bool = True,
                     progress: ProgressCallback | None = None) -> Reconciliation:
@@ -286,9 +365,14 @@ def reconcile_drive(con, label: str, *, now, dedicated: bool = False, accept_dri
     for the full contract; raises a typed ``dm.DriveMutationRefused`` for every fail-closed path."""
     from modelark.execution_session import require_no_live_session
     require_no_live_session(con)
+    # Early diagnostic only: capture again after both fences, before the inventory.
+    _capture_recovery_owner(con, label, _persisted(con, label))
     try:
         with drive_fence.hold_controller(db.DB_PATH, blocking=blocking):
-            p_epoch, p_gen, p_fp, p_cap, p_auth, p_fs, p_annex = _persisted(con, label)   # facts UNDER controller
+            require_no_live_session(con)
+            facts = _persisted(con, label)
+            p_epoch, p_gen, p_fp, p_cap, p_auth, p_fs, p_annex = facts
+            owner = _capture_recovery_owner(con, label, facts)
             ev = _live_evidence(con, label)
             if not ev.proven:
                 raise dm.DriveMutationRefused("DRIVE_IDENTITY_UNPROVEN", drive=label)
@@ -302,10 +386,22 @@ def reconcile_drive(con, label: str, *, now, dedicated: bool = False, accept_dri
             # A capacity change on the same stable identity transitions the epoch and changes the
             # fingerprint, so hold BOTH the old and the prospective new (fingerprint, epoch) drive fences.
             transition = p_fp is not None and ev.capacity != p_cap
+            if owner is not None and (p_gen <= 0 or p_fp != ev.fingerprint or p_cap != ev.capacity
+                                      or p_auth != "dedicated_local"):
+                raise dm.DriveMutationRefused("DRIVE_RECOVERY_IDENTITY_CHANGED", drive=label)
             keyed = ([(p_fp, p_epoch), (ev.fingerprint, p_epoch + 1)] if transition
                      else [(ev.fingerprint, p_epoch)])
             with drive_fence.hold_drives_sorted(keyed, blocking=blocking):
+                require_no_live_session(con)
+                if _persisted(con, label) != facts:
+                    raise dm.DriveMutationRefused("DRIVE_RECOVERY_OWNER_CHANGED", drive=label)
+                fenced_owner = _capture_recovery_owner(con, label, facts, expected=owner)
+                if fenced_owner != owner:
+                    raise dm.DriveMutationRefused("DRIVE_RECOVERY_OWNER_CHANGED", drive=label)
+                owner = fenced_owner
                 dest = register.archive_path(con, label)
+                if owner is not None:
+                    return _recover_owned_generation(con, label, dest, facts, owner, ev, now, progress)
                 return _decide_and_commit(con, label, dest, p_epoch, p_gen, p_fp, p_cap, ev, now,
                                           accept_drift, transition, progress)
     except drive_fence.FenceUnavailable as exc:
@@ -402,7 +498,7 @@ def _decide_and_commit(
         )
 
     if not dm._generation_is_clean(con, label, p_epoch, p_gen, p_fp, p_cap, "dedicated_local"):
-        # (B) sessionless dirty recovery — republish THIS generation's anchor (session-attributed = #39)
+        # (B) sessionless recovery; validated ended owners use the guarded path above.
         owner = con.execute("SELECT owner_session_id FROM drive_dirty_generations "
                             "WHERE drive_label=? AND identity_epoch=? AND generation=?",
                             [label, p_epoch, p_gen]).fetchone()

--- a/tests/test_drive_bootstrap.py
+++ b/tests/test_drive_bootstrap.py
@@ -575,9 +575,8 @@ def test_reconcile_recovers_sessionless_dirty_generation(tmp_path):
         assert report.outcome == "recovered", report
 
 
-def test_reconcile_refuses_a_live_session_dirty_generation(tmp_path):
-    """A dirty generation attributed to a live session (owner fields set) is NOT recovered here —
-    sessionless recovery refuses and defers session-attributed recovery to #39."""
+def test_reconcile_refuses_a_missing_session_dirty_owner(tmp_path):
+    """An owner pair without the corresponding session is not recovery authority."""
     with _catalog(tmp_path) as con:
         _proven_drive(con, "drive-00", fp=_FP, epoch=1, generation=1, fscap=1000)
         _dirty_gen(con, "drive-00", epoch=1, gen=1, owner="sess-1", token=1)
@@ -587,9 +586,9 @@ def test_reconcile_refuses_a_live_session_dirty_generation(tmp_path):
              mock.patch.object(register, "archive_path", return_value=tmp_path / "mount"):
             try:
                 bs.reconcile_drive(con, "drive-00", now="2026-07-23 12:00:00", dedicated=True)
-                raise AssertionError("a session-attributed dirty generation must not be recovered here (#39)")
+                raise AssertionError("an unproven owner must not be recovered")
             except dm.DriveMutationRefused as exc:
-                assert exc.code == "DRIVE_RECOVERY_SESSION_ACTIVE", exc.code
+                assert exc.code == "DRIVE_RECOVERY_OWNER_UNPROVEN", exc.code
         assert con.execute("SELECT count(*) FROM drive_clean_anchors").fetchone()[0] == 0
 
 

--- a/tests/test_terminal_session_reconciliation.py
+++ b/tests/test_terminal_session_reconciliation.py
@@ -1,0 +1,315 @@
+"""Ended Fill recovery: isolated catalogs, mocked media, real host locks/transactions."""
+import fcntl
+from types import SimpleNamespace
+
+import pytest
+
+import _pr09_gate1_fixtures as f
+from test_drive_bootstrap import _anchor, _catalog, _dirty_gen, _ev, _FP, _proven_drive
+from modelark import cli, drive_bootstrap as bs, drive_fence, execution_recovery as recovery
+from modelark import drive_mutation as dm, execution_authority as authority
+from modelark.proposal import Refusal
+
+
+@pytest.fixture
+def case(tmp_path, monkeypatch):
+    monkeypatch.setattr(drive_fence, '_LOCK_DIR', tmp_path / 'locks')
+    with _catalog(tmp_path) as con:
+        f.seed_plan_selection(con, repos=('org/a',))
+        _, proposal_id, _ = f.create_and_approve(con)
+        _proven_drive(con, generation=2)
+        _dirty_gen(con, gen=1)
+        _anchor(con, gen=1)
+        _dirty_gen(con, gen=2, owner='ended-fill', token=7)
+        con.execute(
+            "INSERT INTO execution_sessions(session_id,plan_id,approved_proposal_id,"
+            "controller_identity,worker_identity,state,bound_planner_revision,fencing_token,"
+            "terminal_at,terminal_code) VALUES('ended-fill','ark',?,'controller','worker',"
+            "'paused',0,7,'2026-09-07 14:15:53','DRIVE_RECONCILIATION_REQUIRED')", [proposal_id])
+        inventory = bs.Inventory(present=[('org/a', 'model.safetensors')], missing=[],
+                                 debris=['partial.tmp'], extra=['keep.txt'])
+        observed = _ev(fp=_FP, capacity=1000, free=870)
+        monkeypatch.setattr(bs, '_live_evidence', lambda *args: observed)
+        monkeypatch.setattr(bs.register, 'archive_path', lambda *args: tmp_path / 'archive')
+        calls = []
+        def inspect(*args, **kwargs):
+            calls.append(True)
+            return inventory
+        monkeypatch.setattr(bs, '_inventory', inspect)
+        yield SimpleNamespace(con=con, inventory=inventory, observed=observed,
+                              calls=calls, tmp=tmp_path, proposal_id=proposal_id)
+
+
+def run(case):
+    return bs.reconcile_drive(case.con, 'drive-00', dedicated=True,
+                              now='2026-09-09T18:00:00Z', blocking=False)
+
+
+def no_anchor(case):
+    assert case.con.execute("SELECT count(*) FROM drive_clean_anchors WHERE drive_label='drive-00' "
+                            "AND generation=2").fetchone()[0] == 0
+    assert not case.con.in_transaction
+
+
+@pytest.mark.parametrize('state', ['paused', 'blocked', 'stopped', 'failed', 'done'])
+def test_ended_session_recovers_without_rewriting_its_history(case, state):
+    con = case.con
+    con.execute('UPDATE execution_sessions SET state=?', [state])
+    session = con.execute('SELECT * FROM execution_sessions').fetchall()
+    dirty = con.execute('SELECT * FROM drive_dirty_generations').fetchall()
+    drives = con.execute('SELECT * FROM drives').fetchall()
+    revision = con.execute('SELECT planner_revision FROM planner_state').fetchone()[0]
+    result = run(case)
+    assert result.outcome == 'recovered'
+    assert (result.identity_epoch, result.generation, result.anchor_free_bytes) == (1, 2, 870)
+    assert result.inventory is case.inventory
+    assert con.execute('SELECT * FROM execution_sessions').fetchall() == session
+    assert con.execute('SELECT * FROM drive_dirty_generations').fetchall() == dirty
+    assert con.execute('SELECT * FROM drives').fetchall() == drives
+    assert con.execute('SELECT planner_revision FROM planner_state').fetchone()[0] == revision + 1
+    assert con.execute("SELECT generation,anchor_free_bytes FROM drive_clean_anchors "
+                       "WHERE drive_label='drive-00' ORDER BY generation").fetchall() == [(1, 900), (2, 870)]
+    assert not (drive_fence._LOCK_DIR / 'session-child-ended-fill.lock').exists()
+
+
+def test_second_reconcile_uses_existing_clean_refresh(case):
+    assert run(case).outcome == 'recovered'
+    assert run(case).outcome == 'refreshed'
+    assert case.con.execute("SELECT write_generation FROM drives WHERE drive_label='drive-00'").fetchone() == (3,)
+
+
+@pytest.mark.parametrize('change,code', [
+    ("DELETE FROM execution_sessions", 'DRIVE_RECOVERY_OWNER_UNPROVEN'),
+    ("UPDATE execution_sessions SET fencing_token=8", 'DRIVE_RECOVERY_OWNER_UNPROVEN'),
+    ("UPDATE execution_sessions SET state='running'", 'FILL_SESSION_ACTIVE'),
+])
+def test_invalid_or_live_owner_refuses_before_inventory(case, change, code):
+    case.con.execute(change)
+    with pytest.raises((dm.DriveMutationRefused, Refusal)) as raised:
+        run(case)
+    assert raised.value.code == code
+    assert not case.calls
+    no_anchor(case)
+
+
+def test_unknown_owner_state_fails_closed(case):
+    case.con.execute('PRAGMA ignore_check_constraints=ON')
+    case.con.execute("UPDATE execution_sessions SET state='unknown'")
+    with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECOVERY_OWNER_UNPROVEN'):
+        run(case)
+    assert not case.calls
+    no_anchor(case)
+
+
+def test_real_held_child_marker_refuses_before_inventory(case):
+    fds = recovery.inherit_drive_fence_fds(session_id='ended-fill', drive_labels=[])
+    try:
+        assert fds
+        with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECOVERY_CHILD_UNPROVEN'):
+            run(case)
+        assert not case.calls
+        no_anchor(case)
+    finally:
+        recovery.release_child_fences('ended-fill')
+
+
+def test_unlocked_existing_marker_does_not_prevent_recovery(case):
+    drive_fence._LOCK_DIR.mkdir(exist_ok=True)
+    (drive_fence._LOCK_DIR / 'session-child-ended-fill.lock').touch()
+    assert run(case).outcome == 'recovered'
+
+
+def test_child_probe_error_refuses(case, monkeypatch):
+    def denied(**kwargs):
+        assert kwargs == {'session_id': 'ended-fill'}
+        raise PermissionError('cannot inspect child marker')
+    monkeypatch.setattr(recovery, 'child_fence_still_held', denied)
+    with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECOVERY_CHILD_UNPROVEN'):
+        run(case)
+    assert not case.calls
+    no_anchor(case)
+
+
+def test_physical_drive_lock_blocks_even_without_child_marker(case):
+    with drive_fence.hold_drives_sorted([(_FP, 1)], blocking=False):
+        with pytest.raises(dm.DriveMutationRefused, match='DRIVE_FENCE_UNAVAILABLE'):
+            run(case)
+    assert not case.calls
+    no_anchor(case)
+
+
+def test_owned_dirty_capacity_transition_cannot_skip_recovery_guards(case):
+    case.observed.capacity = 2000
+    case.observed.fingerprint = 'b' * 64
+    before = case.con.execute('SELECT * FROM drives').fetchall()
+    with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECOVERY_IDENTITY_CHANGED'):
+        run(case)
+    assert not case.calls
+    assert case.con.execute('SELECT * FROM drives').fetchall() == before
+    no_anchor(case)
+
+
+@pytest.mark.parametrize('change', [
+    "UPDATE drives SET identity_fingerprint=NULL WHERE drive_label='drive-00'",
+    "UPDATE drives SET write_authority='unknown' WHERE drive_label='drive-00'",
+])
+def test_owned_dirty_bootstrap_or_authority_change_refuses(case, change):
+    case.con.execute(change)
+    with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECOVERY_IDENTITY_CHANGED'):
+        run(case)
+    assert not case.calls
+    no_anchor(case)
+
+
+@pytest.mark.parametrize('phase', ['before', 'inventory'])
+def test_other_live_session_also_blocks_recovery(case, monkeypatch, phase):
+    def add_live():
+        case.con.execute(
+            "INSERT INTO execution_sessions(session_id,plan_id,approved_proposal_id,"
+            "controller_identity,worker_identity,state,bound_planner_revision,fencing_token) "
+            "VALUES('other-fill','ark',?,'c','w','running',0,8)", [case.proposal_id])
+    if phase == 'before':
+        add_live()
+    else:
+        def inspect(*args, **kwargs):
+            add_live()
+            return case.inventory
+        monkeypatch.setattr(bs, '_inventory', inspect)
+    with pytest.raises(Refusal, match='FILL_SESSION_ACTIVE'):
+        run(case)
+    no_anchor(case)
+
+
+@pytest.mark.parametrize('pair', [(None, 7), ('ended-fill', None), ('', 7)])
+def test_corrupt_half_or_empty_owner_pair_is_not_sessionless(case, pair):
+    # Deliberately corrupt this isolated fixture; production schema forbids owner rewrites.
+    case.con.execute('DROP TRIGGER drive_dirty_generations_no_update')
+    case.con.execute('PRAGMA ignore_check_constraints=ON')
+    case.con.execute("UPDATE drive_dirty_generations SET owner_session_id=?,owner_fencing_token=? "
+                     "WHERE drive_label='drive-00' AND generation=2", pair)
+    with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECOVERY_OWNER_UNPROVEN'):
+        run(case)
+    assert not case.calls
+    no_anchor(case)
+
+
+def test_dirty_pair_changed_during_inventory_refuses(case, monkeypatch):
+    case.con.execute('DROP TRIGGER drive_dirty_generations_no_update')
+    def inspect(*args, **kwargs):
+        case.con.execute("UPDATE drive_dirty_generations SET owner_session_id=NULL,"
+                         "owner_fencing_token=NULL WHERE drive_label='drive-00' AND generation=2")
+        return case.inventory
+    monkeypatch.setattr(bs, '_inventory', inspect)
+    with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECOVERY_OWNER_CHANGED'):
+        run(case)
+    no_anchor(case)
+
+
+def test_child_marker_becomes_held_during_inventory_refuses(case, monkeypatch):
+    def inspect(*args, **kwargs):
+        recovery.inherit_drive_fence_fds(session_id='ended-fill', drive_labels=[])
+        return case.inventory
+    monkeypatch.setattr(bs, '_inventory', inspect)
+    try:
+        with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECOVERY_CHILD_UNPROVEN'):
+            run(case)
+        no_anchor(case)
+    finally:
+        recovery.release_child_fences('ended-fill')
+
+
+@pytest.mark.parametrize('phase', ['inventory', 'begin'])
+@pytest.mark.parametrize('change,code', [
+    ("UPDATE execution_sessions SET fencing_token=8", 'DRIVE_RECOVERY_OWNER_CHANGED'),
+    ("UPDATE execution_sessions SET state='stopped'", 'DRIVE_RECOVERY_OWNER_CHANGED'),
+    ("UPDATE execution_sessions SET state='running'", 'FILL_SESSION_ACTIVE'),
+    ("UPDATE drives SET write_generation=3 WHERE drive_label='drive-00'", 'DRIVE_RECOVERY_OWNER_CHANGED'),
+    ("UPDATE drives SET identity_epoch=2 WHERE drive_label='drive-00'", 'DRIVE_RECOVERY_OWNER_CHANGED'),
+    ("UPDATE drives SET filesystem_capacity_bytes=2000 WHERE drive_label='drive-00'",
+     'DRIVE_RECOVERY_OWNER_CHANGED'),
+    ("UPDATE drives SET write_authority='unknown' WHERE drive_label='drive-00'",
+     'DRIVE_RECOVERY_OWNER_CHANGED'),
+    ("UPDATE drives SET identity_fingerprint='" + 'b' * 64 + "' WHERE drive_label='drive-00'",
+     'DRIVE_RECOVERY_OWNER_CHANGED'),
+])
+def test_changes_during_inventory_or_before_commit_publish_nothing(case, monkeypatch, phase, change, code):
+    if phase == 'inventory':
+        def inspect(*args, **kwargs):
+            case.con.execute(change)
+            return case.inventory
+        monkeypatch.setattr(bs, '_inventory', inspect)
+    else:
+        original = dm._immediate
+        def begin(con, body):
+            con.execute(change)
+            return original(con, body)
+        monkeypatch.setattr(dm, '_immediate', begin)
+    with pytest.raises((dm.DriveMutationRefused, Refusal)) as raised:
+        run(case)
+    assert raised.value.code == code
+    no_anchor(case)
+
+
+def test_owner_check_and_anchor_publication_hold_both_fences_and_transaction(case, monkeypatch):
+    original = authority.require_current
+    seen = []
+    def require(expected, actual, state, allowed):
+        if case.con.in_transaction:
+            assert expected == actual == authority.Attempt('ended-fill', 7)
+            assert allowed == {'paused'}
+            for path in (drive_fence.controller_lock_path(bs.db.DB_PATH),
+                         drive_fence.drive_lock_path(_FP, 1)):
+                with open(path) as handle:
+                    with pytest.raises(BlockingIOError):
+                        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            seen.append(True)
+        original(expected, actual, state, allowed)
+    monkeypatch.setattr(authority, 'require_current', require)
+    run(case)
+    assert seen
+
+
+def test_incomplete_inventory_and_disappearing_media_leave_generation_dirty(case, monkeypatch):
+    case.inventory.missing.append(('org/a', 'missing'))
+    with pytest.raises(dm.DriveMutationRefused, match='DRIVE_RECONCILIATION_REQUIRED'):
+        run(case)
+    no_anchor(case)
+    case.inventory.missing.clear()
+    def lost(*args):
+        raise dm.DriveMutationRefused('DRIVE_IDENTITY_UNPROVEN')
+    monkeypatch.setattr(bs, '_final_observation', lost)
+    with pytest.raises(dm.DriveMutationRefused, match='DRIVE_IDENTITY_UNPROVEN'):
+        run(case)
+    no_anchor(case)
+
+
+def test_failed_publication_rolls_back_anchor_and_revision(case, monkeypatch):
+    before = case.con.execute('SELECT planner_revision FROM planner_state').fetchone()
+    original = dm._publish_anchor_locked
+    def fail(*args):
+        original(*args)
+        raise OSError('publication failure')
+    monkeypatch.setattr(dm, '_publish_anchor_locked', fail)
+    with pytest.raises(OSError, match='publication failure'):
+        run(case)
+    no_anchor(case)
+    assert case.con.execute('SELECT planner_revision FROM planner_state').fetchone() == before
+
+
+def test_cli_runs_ended_recovery_and_reports_existing_inventory_counts(case, monkeypatch, capsys):
+    monkeypatch.setattr(cli.db, 'connect', lambda: case.con)
+    cli.main(['drive', 'reconcile', 'drive-00', '--dedicated'])
+    output = capsys.readouterr().out
+    assert 'recovered' in output
+    assert 'present=1 missing=0 debris=1 extra=1' in output
+    assert 'never deleted automatically' in output
+
+
+@pytest.mark.parametrize('code', ['FILL_SESSION_ACTIVE', 'CHILD_FENCE_HELD', 'SESSION_TOKEN_MISMATCH'])
+def test_cli_translates_session_refusals(case, monkeypatch, code):
+    def refuse(*args, **kwargs):
+        raise Refusal(code, {}, ())
+    monkeypatch.setattr(cli.db, 'connect', lambda: case.con)
+    monkeypatch.setattr(bs, 'reconcile_drive', refuse)
+    with pytest.raises(SystemExit, match='drive reconcile failed: ' + code):
+        cli.main(['drive', 'reconcile', 'drive-00', '--dedicated'])


### PR DESCRIPTION
## Summary

Add the missing operator recovery path for a dirty drive generation whose Fill session has ended. A paused Fill can legitimately retain ownership and have no lease expiry; treating every owner as a live session makes ordinary reconciliation permanently refuse that generation.

- Reuse the existing `drive reconcile LABEL --dedicated` command, report-only inventory and physical fences.
- Require a matching ended owner/token; reject any live Fill or held/unprovable owner child marker. Missing markers are normal after pause and do not replace physical exclusion.
- Capture after both fences, inventory, take fresh physical evidence, then atomically revalidate owner/token/exact state and drive facts before publishing the **existing** generation's anchor and planner revision.
- Preserve session state/reason/token, dirty owner pair and execution history. Refuse owned-dirty identity/capacity transitions before bootstrap/epoch paths can bypass owner guards.
- Translate expected session refusals into clean CLI errors and document the evidence limits.

No schema change, automatic resume/completion, cleanup, full-byte verification claim, live recovery, deployment or USB/archive payload writes.

## Local review and verification

- Grok CLI scope review: pass 1 requested four contract corrections; pass 2 accepted the corrected scope. Session `01a08749-385a-72a2-a39d-cec7861a859a`.
- Focused recovery/session/fencing/revision suites: **177 passed**.
- All-source Ruff: passed.
- Installed-wheel recovery/bootstrap/authority tests, run outside the source checkout: **83 passed**.
- Final local Grok implementation review (pass 3): **ACCEPT**, no remaining correctness defect in scope.
- Full non-browser suite: still running locally without failures so far; final result will be posted. GitHub CI provides Python-version and browser coverage.

## Requested review process

Up to three explicitly requested Greptile/Codex rounds. Fix confirmed findings between rounds 1 and 2; stop on exact-head acceptance plus green CI, or after completed round 3 and summarize residual issues/common causes. No automatic merge.
