### PR TITLE
feat(codec): qualify shared compression and decode memory policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,19 @@ GitHub API identities such as `greptile-apps[bot]` identify reactions and review
 authors; they are not substitutes for the trigger mention, even if a push causes
 an automatic review at the same time.
 
+After every push to an open PR, request both `@greptileai review` and
+`@codex review` on the resulting head, covering every newly pushed commit.
+Documentation-only changes, merge commits and base-branch reconciliation are
+not exemptions. Verify both reviewers' results against the current head;
+earlier-head approval and CI success do not substitute for current-head review.
+Apply at most three review/fix rounds per scoped stage, not three fresh rounds
+per push. Batch known changes before requesting a round. After round three,
+stop and summarize unresolved findings, review state, and any common
+architectural cause before further changes or another review cycle. Do not
+push an unreviewed final fix or silently reset the counter. A user-authorized
+exception applies only to its explicitly named scope; PR #73's one-time
+no-review-wait merge authorization does not carry forward to other PRs.
+
 ## Operator approval continuity (2026-09-10)
 
 When the operator replies "ok", "begin", "go", "continue", or equivalent to an

--- a/docs/codec-resource-qualification.md
+++ b/docs/codec-resource-qualification.md
@@ -1,0 +1,75 @@
+# Stage A — shared codec resource contract
+
+DEC-138 requires one RAM-admission methodology for compression, canary, restore
+and Slice. Stage A implements an operation-neutral `CodecMemoryPolicy` and a
+disposable qualification runner. **No live caller adopts it yet.** This is not a
+claim that Slice's 64 MiB incompatibility is fixed.
+
+## What the policy means
+
+The same versioned record controls all three qualification operations. It has an
+explicit address-space ceiling and a headroom reserve; no separate compression
+multiplier, decoder cap, implicit environment variable or Slice default.
+It requires observed available memory of at least ceiling + reserve. The Linux
+runner uses `MemAvailable` and all visible ancestor cgroup hard-limit headrooms,
+including a constrained visible root, taking the minimum. Unknown accounting
+refuses. This is conservative sampled admission, **not a memory reservation**.
+Unrelated processes can still consume memory after the observation.
+
+Fresh workers install `RLIMIT_AS` before importing the native codec, disable core
+dumps and refuse a lower inherited limit instead of relaxing it. This is a hard
+virtual address-space ceiling, not an RSS cap or protection against arbitrary
+concurrent host pressure. Existing native file mappings make virtual and resident
+usage differ substantially. A successful run cannot certify all future workloads.
+
+Qualification uses an **8 GiB AS ceiling plus 2 GiB observed headroom reserve**.
+These are experimental parameters for this runtime, not newly deployed defaults.
+Whole and StreamZNN operations are performed in separate fresh processes with the
+same policy. Native diagnostics go to separate files; results use exclusive JSON
+files rather than stdout. Temporary synthetic bytes are removed on exit, while
+results and diagnostic files remain in the reported private qualification directory.
+
+## Running
+
+From the checkout, with its dev Python:
+
+```sh
+python -m pytest -q tests/test_codec_resources.py tests/test_codec_qualification.py
+python -m scripts.qualify_codec_resources --large --output-parent /tmp
+```
+
+Without `--large`, the runner uses 2 MiB inputs. Large mode uses exactly
+99,630,640 and 409,993,344 bytes of synthetic valid BF16 safetensors data. Each size
+is compressed through real whole-ZipNN and StreamZNN writers, independently
+canary-verified, and restored with complete original-size/hash checking. Misleading
+`.blob` filenames ensure the restore routes by actual magic rather than suffix.
+The runner asserts writer format headers too. It also tests a refused allocation
+larger than the AS ceiling without trying to touch that much resident memory.
+
+Reports include exact policy, source-code digests, Python/ZipNN/Torch versions,
+format magic, original/stored identities, and peak RSS/virtual memory by phase.
+Code changes during a run invalidate it. No source/encoded/runtime fixture is
+read from the live archive, and no application service is started or stopped.
+
+## Limits and next gates
+
+- A raw allocation refusal and an injected native abort test are not a complete
+  adversarial native-decoder qualification. Header validation, cancellation,
+  parent death, bounded pipes and per-read attachments belong to later stages.
+- The corpus is deterministic BF16-like synthetic data, not every dtype, data
+  distribution, archive format or historical whole-file size.
+- Visible cgroup limits and a fresh host sample cannot reserve RAM or prove the
+  absence of hidden outer constraints. Run only in a understood Linux host
+  environment; production discovery/admission must be reviewed before adoption.
+- Successful new-fixture round trips do not migrate old archives, prove physical
+  USB delivery, or change existing seals, source-read authority or Fill policy.
+- Shared resource admission must be adopted by production compression/canary and
+  readers before declaring DEC-138 parity complete. Module existence alone is
+  not integration. See the approved representation plan for staged adoption.
+
+## Stage results and reviews
+
+Initial local unit/regression run: 63 passed, 5 skipped (optional zstd cases in
+the local environment). Large exploratory runs completed all 13 child checks;
+the final reviewed-code run and review status will be recorded before handoff.
+These remain HYP-002 evidence, not a blanket production go decision.

--- a/docs/codec-resource-qualification.md
+++ b/docs/codec-resource-qualification.md
@@ -16,8 +16,8 @@ including a constrained visible root, taking the minimum. Unknown accounting
 refuses. This is conservative sampled admission, **not a memory reservation**.
 Unrelated processes can still consume memory after the observation.
 
-Fresh workers install `RLIMIT_AS` before importing the native codec, disable core
-dumps and refuse a lower inherited limit instead of relaxing it. This is a hard
+Fresh workers install `RLIMIT_AS` before importing the native codec, set their
+core-file limit to zero and refuse a lower inherited limit instead of relaxing it. This is a hard
 virtual address-space ceiling, not an RSS cap or protection against arbitrary
 concurrent host pressure. Existing native file mappings make virtual and resident
 usage differ substantially. A successful run cannot certify all future workloads.

--- a/docs/codec-resource-qualification.md
+++ b/docs/codec-resource-qualification.md
@@ -69,7 +69,7 @@ read from the live archive, and no application service is started or stopped.
 
 ## Stage results and reviews
 
-Local targeted regression run after review hardening: **71 passed, 5 skipped**
+Local targeted regression run after remote-review hardening: **74 passed, 5 skipped**
 (optional zstd cases in this environment); full-project Ruff passed.
 
 Unchanged-code large runs passed all **13** checks in both dependency stacks:
@@ -91,9 +91,20 @@ were addressed. Round 2 **ACCEPTED 4311547** with no blockers. Child-process-gro
 lifecycle, native binary identity and general-purpose worker API remain outside
 this unadopted qualification stage; they must not be inferred from its result.
 
-The full core suite is also being run in a disposable user/network namespace:
+Remote review round 1 found a cgroup named `host` could overwrite the host sample
+in a flat observation dictionary. A regression reproduced the overestimate. Host
+and cgroup evidence now occupy separate structural fields; tests cover `host`
+and names matching both new field labels. The post-fix installed-dependency run
+passed all 13 checks: `/tmp/modelark-codec-qualification-9bdahflv/result.json`.
+Its source fingerprints bind that result to the corrected implementation.
+
+The full core suite ran in a disposable user/network namespace:
 ordinary sandbox execution blocks localhost sockets, and ordinary host execution
 collides with the live portal's intentionally host-wide singleton. Namespace
 isolation preserves that guard and does not stop the live service. CI validates
-the PR revision independently. These remain HYP-002 evidence, not a blanket
+the PR revision independently. The namespace run had 3,297 passes, 6 skips and
+7 permission/ACL failures caused by user-namespace UID mapping; those seven
+passed when rerun as the ordinary host user. The initial PR head also passed
+both Python CI test jobs and E2E. New commits require their own CI/review results.
+These remain HYP-002 evidence, not a blanket
 production go decision or a completed physical Slice test.

--- a/docs/codec-resource-qualification.md
+++ b/docs/codec-resource-qualification.md
@@ -69,7 +69,31 @@ read from the live archive, and no application service is started or stopped.
 
 ## Stage results and reviews
 
-Initial local unit/regression run: 63 passed, 5 skipped (optional zstd cases in
-the local environment). Large exploratory runs completed all 13 child checks;
-the final reviewed-code run and review status will be recorded before handoff.
-These remain HYP-002 evidence, not a blanket production go decision.
+Local targeted regression run after review hardening: **71 passed, 5 skipped**
+(optional zstd cases in this environment); full-project Ruff passed.
+
+Unchanged-code large runs passed all **13** checks in both dependency stacks:
+
+| Runtime | Code revision | Python / ZipNN / Torch | Result |
+|---|---|---|---|
+| Development | f336101 | 3.10.12 / 0.5.4 / 2.13.0 | 13/13 |
+| Installed dependencies, checkout code | 4311547 | 3.10.12 / 0.5.4 / 2.14.0 | 13/13 |
+
+Final installed-dependency run: `/tmp/modelark-codec-qualification-b8fo65k8/result.json`.
+Its maximum measured RSS across phases was 1,765,400,576 bytes (about 1.64 GiB);
+maximum virtual-address peak was 6,774,444,032 bytes (about 6.31 GiB), under the
+same 8 GiB AS policy. Source-code fingerprints are in the report. Package
+versions and these source hashes are not native-binary attestation.
+
+Local Grok CLI review round 1 found no blockers, with hardening suggestions.
+Accounting-error typing, malformed membership rejection and precise test wording
+were addressed. Round 2 **ACCEPTED 4311547** with no blockers. Child-process-group
+lifecycle, native binary identity and general-purpose worker API remain outside
+this unadopted qualification stage; they must not be inferred from its result.
+
+The full core suite is also being run in a disposable user/network namespace:
+ordinary sandbox execution blocks localhost sockets, and ordinary host execution
+collides with the live portal's intentionally host-wide singleton. Namespace
+isolation preserves that guard and does not stop the live service. CI validates
+the PR revision independently. These remain HYP-002 evidence, not a blanket
+production go decision or a completed physical Slice test.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2992,3 +2992,6 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `method`: Stage A uses fresh sequential workers, an 8 GiB RLIMIT_AS ceiling, 2 GiB additional observed host/visible-cgroup headroom, full original hashes and a deliberate denied allocation. No resource reservation or production/physical acceptance is inferred. Wider hostile-input, installed-runtime and lifecycle qualification remains necessary before live admission.
 - `docs_updated`: docs/decision_log.md, docs/codec-resource-qualification.md
 - `related`: DEC-138, DEC-139, scripts/qualify_codec_resources.py
+
+#### HYP-002 results — 2026-09-10
+- Unchanged-code synthetic runs completed all 13 checks using Python 3.10.12 / ZipNN 0.5.4 with dev Torch 2.13.0 (f336101) and installed-dependency Torch 2.14.0 (4311547). Both whole and StreamZNN compression/canary/restore passed original hashes at both observed failure sizes under one 8 GiB AS policy plus 2 GiB sampled headroom. Final report: `/tmp/modelark-codec-qualification-b8fo65k8/result.json`, with implementation fingerprints; max RSS 1,765,400,576 bytes and virtual peak 6,774,444,032 bytes. This supports feasibility for these fixtures, not general host-OOM protection, native binary attestation or production caller adoption. HYP remains open for the broader qualification/integration gates.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -2939,3 +2939,56 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `revisit_when`: Scope the next Slice/USB onboarding UI increment, and before presenting FAT32 delivery as a self-service workflow without attended CLI assistance.
 - `docs_updated`: docs/decision_log.md, docs/usable-slice-folders.md
 - `related`: DEC-130, docs/usable-slice-direct.md, modelark/slice/fat32_observation.py
+
+### DEC-138: Share RAM-safety admission across compression and original-byte decoding
+- `id`: DEC-138
+- `date`: 2026-09-10
+- `status`: accepted
+- `triggered_by`: Operator condition on the representation plan: a file accepted for compression must be decompressible under equivalent conditions, using the same RAM-safety methodology rather than a separate Slice limit.
+- `decision`: Use one shared resource-admission mechanism and explicit budget/headroom methodology for compression, round-trip verification, restore and Slice decoding. Operation-specific resource estimates are permitted only when qualified; identical methodology does not mean pretending compression and decompression allocate identically. Under the same supported codec/runtime, resource profile and available headroom, accepted compression must produce output that the corresponding decoder admits and verifies byte-for-byte. Test both operations under that shared profile. Genuine runtime/resource differences may cause a typed resource refusal, never an unexplained consumer-specific format/size cap.
+- `rationale`: Sharing codec parsing alone leaves the writer/reader RAM-policy mismatch intact. Successful compression or a child process is not by itself proof of safe decoding; qualify the complete round trip, including native memory and buffers.
+- `impact`: Tightens docs/plans/slice-representation-architecture.md: common RAM admission on the compression side is required before claiming parity, while broader decoder-adapter migration remains staged. Preserve archive bytes, original hashes, canary-before-drop, old approval semantics and distinct source/transport authority. Existing archives may have been created under different resources and must be detected and evaluated rather than assumed compatible with today's budget.
+- `docs_updated`: docs/decision_log.md, docs/plans/slice-representation-architecture.md
+- `related`: DEC-021, DEC-022, INC-003
+- `scope_boundary`: Design requirement only; no implementation, deployment, archive rewrite, live test, PR push or host configuration change is performed or authorized by this confirmation.
+
+### DEC-139: Reuse standalone StreamZNN behind explicit Slice representation boundaries
+- `id`: DEC-139
+- `date`: 2026-09-10
+- `status`: accepted
+- `triggered_by`: Operator approved the jointly reviewed representation plan and staged implementation/review workflow after DEC-138 made shared RAM admission mandatory.
+- `decision`: Separate selection of original-file identity, delivery representation and transport. Preserve current original-file delivery; extend the MIT standalone StreamZNN with caller-owned bounded stream primitives rather than duplicate its decoder. Keep ModelArk resource orchestration and archive/destination authority outside that module. Stage common RAM qualification, reusable reading, guarded whole-frame admission, existing-consumer alignment and end-to-end qualification. Original-output source alternatives may have different encodings of identical original bytes; future stored output must bind exact stored bytes and its own verification claim.
+- `rationale`: A second consumer-specific codec/resource policy recreated a producer/reader incompatibility. Shared mechanisms must not collapse different delivery evidence or grant Slice archive retrieval/mutation authority.
+- `impact`: Implementation and review sequence in docs/plans/slice-representation-architecture.md; each stage gets up to three local Grok CLI rounds followed by up to three Greptile/Codex PR rounds. Remaining findings or common architectural causes are summarized instead of patched indefinitely. Operator retains merge control. Live deployment and physical acceptance remain separately scoped.
+- `docs_updated`: docs/decision_log.md, docs/plans/slice-representation-architecture.md, docs/codec-resource-qualification.md
+- `related`: DEC-021, DEC-022, DEC-081, DEC-098, DEC-138
+
+### DEF-045: Defer selectable stored-representation export
+- `id`: DEF-045
+- `date`: 2026-09-10
+- `status`: active
+- `triggered_by`: DEC-139 separates selection from requested representation; operator explicitly places compressed-output choice in later work.
+- `decision`: Specify but do not expose stored-export CLI/profile modes in the current original-delivery repair. Future stored output must bind stored digest/size, original linkage, exact paths, capacity and truthful receipt evidence without automatic decoding or recompression.
+- `revisit_when`: Operator scopes compressed local export or peer serving; complete those representation/evidence contracts before exposing a public switch.
+- `docs_updated`: docs/decision_log.md, docs/plans/slice-representation-architecture.md
+- `related`: DEC-139
+
+### DEF-046: Defer peer transport implementation behind representation contracts
+- `id`: DEF-046
+- `date`: 2026-09-10
+- `status`: active
+- `triggered_by`: DEC-139 and operator direction that later P2P builds on Slice functionality.
+- `decision`: No peer listener, discovery, authorization or network transport in the current arc. Preserve the distinction between network representation and requested final output; transport must not widen approval or verification claims.
+- `revisit_when`: Peer distribution is explicitly scoped after representation identity and verification contracts are stable.
+- `docs_updated`: docs/decision_log.md, docs/plans/slice-representation-architecture.md
+- `related`: DEC-139, DEF-045
+
+### HYP-002: Can one explicit address-space envelope admit both codec directions on the installed stack?
+- `id`: HYP-002
+- `date`: 2026-09-10
+- `status`: open
+- `triggered_by`: DEC-138; ZipNN imports substantial virtual mappings, so a byte-frame cap or compression multiplier is not a complete memory methodology.
+- `question`: Can whole and streamed compression, canary and restoration of synthetic fixtures matching the observed 99,630,640 and 409,993,344 byte failures succeed under one enforced worker AS ceiling, with measured RSS and controlled over-limit refusal?
+- `method`: Stage A uses fresh sequential workers, an 8 GiB RLIMIT_AS ceiling, 2 GiB additional observed host/visible-cgroup headroom, full original hashes and a deliberate denied allocation. No resource reservation or production/physical acceptance is inferred. Wider hostile-input, installed-runtime and lifecycle qualification remains necessary before live admission.
+- `docs_updated`: docs/decision_log.md, docs/codec-resource-qualification.md
+- `related`: DEC-138, DEC-139, scripts/qualify_codec_resources.py

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3008,3 +3008,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 
 #### HYP-002 results — 2026-09-10
 - Unchanged-code synthetic runs completed all 13 checks using Python 3.10.12 / ZipNN 0.5.4 with dev Torch 2.13.0 (f336101) and installed-dependency Torch 2.14.0 (4311547). Both whole and StreamZNN compression/canary/restore passed original hashes at both observed failure sizes under one 8 GiB AS policy plus 2 GiB sampled headroom. Final report: `/tmp/modelark-codec-qualification-b8fo65k8/result.json`, with implementation fingerprints; max RSS 1,765,400,576 bytes and virtual peak 6,774,444,032 bytes. This supports feasibility for these fixtures, not general host-OOM protection, native binary attestation or production caller adoption. HYP remains open for the broader qualification/integration gates.
+
+### DEC-140: Review every pushed PR head with both reviewers within the stage's three-round budget
+- `id`: DEC-140
+- `date`: 2026-09-10
+- `status`: accepted
+- `triggered_by`: Operator clarified that every new commit pushed to a PR must receive Codex and Greptile review after PR #74's documentation/main reconciliation.
+- `decision`: After each push, request both canonical reviewer mentions on the resulting head, covering all new commits including documentation and merge commits. Verify head-specific results before declaring review acceptance. Keep at most three review/fix rounds for the scoped stage; do not restart that allowance per push. After the third round, summarize unresolved findings and common architectural causes before further changes or reviews. Batch known changes rather than leaving an unreviewed final fix.
+- `rationale`: Unchanged runtime code does not establish review acceptance of new documentation, policy or merge results. Completed CI and previous-head approval are separate evidence.
+- `impact`: AGENTS.md carries the ongoing rule. PR #74's remaining third round must cover reconciliation and this policy record. The explicit no-review-wait merge exception for already-merged PR #73 does not apply to #74 or future PRs; merge authority remains separately scoped.
+- `docs_updated`: AGENTS.md, docs/decision_log.md
+- `related`: DEC-139, BOT-008

--- a/docs/plans/slice-decompression-compatibility.md
+++ b/docs/plans/slice-decompression-compatibility.md
@@ -1,0 +1,173 @@
+# Slice decompression compatibility — proposed scope
+
+Historical draft: superseded as the active proposal by
+[Slice representation architecture](slice-representation-architecture.md), jointly
+reviewed with Grok CLI on 2026-09-10. Retained for review history; do not implement
+this helper-only scope independently of the newer plan.
+
+Status: PROPOSED, not approved or implemented. 2026-09-10.
+Related: decision_log.md INC-003, DEC-021, DEC-022; PR #73 acceptance evidence.
+
+## Problem and objective
+
+Slice currently uses the same 64 MiB number for caller read size, stored frame
+size, decoded frame size, and zstd window size. The archive writer still selects
+whole-file ZipNN when a shard fits its configured compression RAM budget.
+Consequently valid existing archives can restore through the general restore
+path but refuse through Slice. A 99,630,640-byte Qwen shard and 409,993,344-byte
+Trinity shard refused in read-only preflight; their larger streamed siblings
+returned a first decoded byte. This is not complete model verification.
+
+Support existing archive encodings with explicit resource admission. Preserve
+original-byte hashes, attachment-bound source reads, read-only archive access,
+and destination publication/receipt guarantees. Do not rewrite existing archives.
+
+## Proposed design
+
+1. Keep this first change in Slice: separate validated byte-format header parsing,
+   stored and decoded frame limits, streaming chunk/window limits, and decode
+   resource requirements. Original artifact size is an integrity bound, not
+   permission to allocate that much RAM. Keep caller-facing IO chunks small and
+   independent. Use actual writer output as the compatibility test contract;
+   do not change writer/canary/restore production behavior in this PR.
+   Compressed expansion/header overhead must not accidentally make a legitimate
+   writer-produced 64 MiB original chunk unreadable.
+
+2. Separate compatibility from resource admission. Whole-file ZipNN is supported
+   but requires a budget appropriate to that frame; large StreamZNN frames from
+   previously configurable chunk sizes need the same consideration. Never derive
+   today's permission solely from current compression settings or file headers.
+   A machine may safely refuse a valid archive it cannot decode with its approved
+   resources, with an actionable explanation rather than "unsupported archive".
+
+3. Decode large frames in a fresh, one-at-a-time helper process with an enforced
+   memory/allocation ceiling. The main process alone reads the retained, confined
+   source descriptor in bounded chunks, checking the source attachment before and
+   after each stored-byte read. It feeds the helper through bounded pipes; the
+   helper receives no catalog, archive/destination path or inherited archive fence
+   descriptors. It returns bounded output messages; the parent never buffers the
+   entire decoded frame. No whole-file scratch, network, retrieval, or new GPU work.
+   Existing small-frame streaming remains available; do not claim that its 64 MiB
+   frame cap alone is a hard process-memory limit.
+
+4. First implementation gate: qualify the resource-control mechanism against the
+   installed ZipNN stack and Linux deployment. Investigate a fresh-worker address-
+   space limit versus an OS-enforced resident-memory budget; these are not the
+   same. An address-space cap needs interpreter/import/mapping headroom, while a
+   resident-memory controller may require unavailable host delegation. Do not
+   silently add sudo/service setup, treat a subprocess alone as OOM protection,
+   or claim the compression-side 4x estimate bounds decoding. Measure real peak
+   usage, imports and copies; set explicit conservative defaults and hard ceilings
+   only after qualification. If a suitable guard cannot be installed, large-frame
+   decoding refuses; no unbounded fallback. Bring back any host-setup requirement.
+
+5. Keep lifecycle and integrity in the parent: source fence remains held until
+   helper termination/reaping; stop, attachment loss, decode failure and consumer
+   failure cancel the worker and close pipes. Bounded communication must support
+   cancellation/backpressure without deadlock. Use a one-frame request protocol:
+   child consumes the declared input and its EOF before decoding/output, while
+   the parent closes input after sending the frame. Parent supervision must stay
+   interruptible during pipe writes, native decode and output reads; do not use a
+   blocking full-buffer communicate() or accumulate a whole response. Close
+   unrelated inherited descriptors; establish parent-death termination with a
+   race-safe handshake as well as ordinary cleanup. Enforce both input and output
+   lengths, header allowlists, framing/EOF, and final original SHA-256. Worker
+   success alone is never delivery success. Partial output follows the existing
+   destination rules; no success receipt on resource failure or native crash.
+
+6. Establish consistency through cross-path tests in this PR: generate fixtures
+   with the real writer, require its canary and general restore to pass, then
+   require Slice to emit the same original bytes under a qualified budget. Preserve
+   DEC-022 codec selection, capacity math, canary-before-drop, restore publication,
+   and standalone StreamZNN. No new writer decode-eligibility gate or codec-column
+   schema migration. A shared production codec module can be separately proposed
+   after the safe Slice read path works; that broader refactor is not required
+   to read existing archives. Do not promise every archive fits every machine.
+
+7. Add an execution-readiness check before creating/writing a destination, when
+   sources are attached: inspect currently attached, sealed source candidates under
+   the same source confinement/fences and identify resource refusals early. Respect
+   per-artifact alternate candidates; do not require every sealed drive to be
+   attached simultaneously or mark absent candidates as checked. Preserve existing
+   attended-swap/wait semantics. For StreamZNN, readiness must walk frame headers
+   with checked bounded reads or confined seeks, not certify the whole container
+   from just its first frame; zstd uses its actual header length. Offline catalog
+   preview remains offline and cannot certify unseen compressed headers. Recheck
+   on actual open/use; preflight is not durable authorization or a full decode.
+   Integrate resource settings into the existing Slice configuration/admission
+   model explicitly across legacy direct, native-folder and FAT32 envelopes. Seal
+   both frame ceilings and the resource policy/version into approval; do not read
+   mutable wishlist compression settings at Start. Old approvals without those
+   fields retain old limits, and using new limits needs fresh preview/approval.
+   Run readiness before the FAT attempt is consumed or any control/root/temp write.
+   A header/resource pass is not proof against later corruption or runtime OOM.
+   Source-candidate
+   selection must not silently widen the sealed proposal.
+
+## Scope and delivery slices (one separate code PR after approval)
+
+1. Resource-control qualification and cross-path tests using real writer-generated
+   whole/streamed/raw/zstd fixtures. Document measured limits. This is a go/no-go
+   gate: roughly 100 MiB and 410 MiB whole frames must successfully decode with
+   the chosen guard on the target stack before calling the proposal viable.
+2. Confined large-frame worker and Slice integration, cancellation/error tests,
+   early readiness and explicit resource settings.
+3. Complete writer/canary/restore compatibility regression coverage with no changes
+   to their production behavior; retain codec selection, disk capacity accounting
+   and canary-before-drop unchanged.
+4. End-to-end synthetic public CLI qualification, then separately scoped physical
+   compressed-source acceptance. Append approved decisions to the authoritative
+   ledger and synchronize user docs. Review Grok locally and Greptile/Codex in PR
+   according to the user's review workflow when implementation is authorized.
+
+## Required tests and review hazards
+
+- Real writer round trips above 64 MiB, including roughly 100 MiB and 410 MiB
+  whole frames, short tail frames, configurable stream chunks, incompressible
+  expansion, all supported byte dtypes, optional zstd absence and raw fallback.
+- Do not monkeypatch away the native decoder for resource qualification. Test the
+  actual enforced ceiling, native allocation failure/crash, controlled low budget,
+  malformed oversized headers, truncated/trailing frames and wrong hashes.
+- Worker cleanup on stop, source unplug/remount, destination ENOSPC/EIO, blocked
+  pipe and parent failure; no inherited fence lifetime, orphan worker or success
+  certificate. Preserve source-vs-destination error attribution.
+- A failed readiness check must create no destination. Runtime rechecks still
+  catch changes after preflight. Existing FAT one-attempt/no-resume stays intact.
+- Prove archive bytes and catalog identity/generation are untouched by Slice;
+  no serial repair, schema migration, annex-key change, re-compression or retrieval.
+- Writer and canary must not produce/drop the original of an output they cannot
+  round-trip; restore must preserve current supported formats and publication
+  behavior. Capacity upper-bound/fallback tests must continue to hold.
+
+## Alternatives rejected for the proposal
+
+- Just raise/remove 64 MiB: combines unrelated limits and offers no native-memory
+  protection or common producer/consumer contract.
+- Stream all future archives only: leaves existing valid whole-file archives
+  unreadable by Slice and changes DEC-022 without solving backward compatibility.
+- Rewrite the archive or change its catalog: unnecessary mutation and migration
+  risk for what should be a read-path compatibility fix.
+
+## Review
+
+Local Grok CLI review completed 2026-09-10, session
+`01a08c73-d885-7930-bcc6-bb6dd26a9e56`; verdict on the initial draft:
+ACCEPT WITH CHANGES. Its initial inspection reached the turn cap; the same session
+was resumed to deliver its conclusion, not a separate review pass.
+
+Incorporated: narrow first PR to Slice and cross-path tests; preserve DEC-022 and
+restore/canary behavior; preflight attached sealed candidates without breaking
+drive swaps; bind budgets to approval; specify pipe lifecycle and descriptor
+ownership. Keep StreamZNN standalone and zstd out of the ZipNN helper.
+
+Not accepted: Grok suggested that a child that can OOM is sufficient initial
+protection and that hard memory enforcement should be optional. Process isolation
+contains many native crashes but does not itself guarantee protection of the
+parent or host under memory pressure. Resource enforcement and successful real
+fixture qualification remain required. This revised plan has not received a
+second Grok verdict; do not describe it as unconditionally approved.
+
+No implementation or live test authorized by this proposal itself. The unrelated
+docs-only PR #73 must remain unchanged remotely. No accepted DEC has been appended:
+this remains a proposal pending operator approval, with its resource mechanism
+explicitly subject to qualification rather than assumed proven.

--- a/docs/plans/slice-representation-architecture.md
+++ b/docs/plans/slice-representation-architecture.md
@@ -1,0 +1,355 @@
+# Slice representation architecture and compatibility plan
+
+Date: 2026-09-10. Status: APPROVED FOR STAGED IMPLEMENTATION (DEC-139).
+Engineering qualification and staged local/remote reviews remain required.
+Post-review operator requirement: shared RAM-safety admission, DEC-138. This
+addition is binding on the proposal and has not had a further Grok review.
+Code basis: worktree HEAD `eb95945060e5b178509432c8016355f225ef56f1` (PR #73
+docs-only closeout on merged application commit `16e8b3f`).
+Related: DEC-021, DEC-022, DEC-081, DEC-098, DEC-101 in ../decision_log.md.
+This replaces the proposed direction in slice-decompression-compatibility.md;
+that document remains a historical draft, not a second active implementation plan.
+
+## Plain-language outcome
+
+A slice says which files you want. A delivery profile says whether you want the
+original files or their existing stored representation. Transport says where and
+how they move. Decoding is requested by the profile, not inherent in selecting a
+slice. Today we implement original-file delivery correctly and establish the
+reusable boundary. Stored-format export and P2P remain later work, with their
+requirements written here so the current fix does not obstruct them.
+
+## Evidence and problem
+
+The writer's `compress.plan_codec` intentionally permits whole-file ZipNN when
+the shard fits DEC-022's compression budget. Slice's `decoding.py` independently
+applies 64 MiB to caller reads, encoded frames, decoded frames and zstd windows.
+Real preflight refused 99,630,640-byte Qwen and 409,993,344-byte Trinity original
+files stored as whole ZipNN. Larger streamed siblings returned a first byte.
+Neither preflight nor this plan proves a complete compressed-source delivery.
+This is our producer/consumer mismatch, not a foreign ZIP format or USB issue.
+
+Current `hf-tree-v1` means original paths/bytes/hashes, not functional model
+loadability. `CopyFact` has original and stored sizes, an original digest and
+annex key, but no explicit codec or standalone stored SHA-256 field. Some valid
+original-byte sources lack a usable SHA256 annex key. Do not invent missing
+stored identity or make current original-byte sources ineligible merely to
+prepare for a future compressed-export feature.
+
+## 1. Three independent choices
+
+1. Selection: frozen repository/file closure and original-file identity/evidence.
+2. Delivery representation/profile: original-file tree now; exact stored-object
+   bundle later. A stored bundle may include compressed weights and raw auxiliary
+   files. It is not a promise to newly compress everything or to produce ZIP files.
+3. Transport/destination: current attended local filesystem adapters; future peer
+   or scratch transport. No networking, listener, peer authorization, discovery,
+   resume protocol, object-store integration, or archive registration in this arc.
+
+Use original digest + length as byte-content identity, retaining repository/path
+and revision evidence separately. The exact stored representation has its own
+digest + length, encoding description and evidence linking it to the original.
+Two encodings of the same original are different transferable objects. Matching a
+stored hash proves a stored-byte copy, not a fresh original-byte decode check.
+That exact-object distinction constrains future stored delivery, not current
+original delivery: `hf-tree-v1` keeps all otherwise eligible sealed raw/ZipNN/
+StreamZNN/zstd alternatives for the same original hash and length. Resource
+admission may make a candidate unusable today; it does not change its original
+identity or authorize pruning/widening an approved closure.
+
+Output representation and bytes-on-the-wire need not be identical in a future
+peer protocol. Where decoding happens must be explicit; changing transport must
+not silently alter the requested output, approval, resource budget or receipt.
+
+## 2. Reusable byte-reading boundary (implement now)
+
+Prefer extending the existing MIT standalone `modelark/streamznn.py` with a small
+stream-oriented API over duplicating its decoder in a new ModelArk component.
+Its existing `decompress_to(path, sink)` already shares decoding between canary
+and restore, but opens a path internally. Extract an iterator/reader primitive
+over a caller-owned binary stream, with explicit encoded/decoded/total limits,
+bounded IO and optional neutral frame-decoder injection. Keep path-based APIs
+as wrappers with compatible behavior; callers own and close supplied streams.
+Use that primitive from Slice through its confined attachment-checked stream.
+Retain the MIT header, standalone stdlib + ZipNN dependencies and container bytes.
+No Slice exceptions, catalog/drive knowledge or process manager inside StreamZNN.
+
+Where feasible, expose the standalone validated ZipNN frame primitive too, so
+whole-ZipNN and StreamZNN adapters share interpretation instead of reproducing
+their headers. The neutral frame-decoder hook can call a supervised worker from
+ModelArk; standalone callers remain non-spawning. An API/validation extension is
+allowed; rewriting ZipNN's native codec, changing the on-disk format or claiming
+that arbitrary whole blobs can be streamed would require separate scope.
+
+Introduce a small neutral module/package, provisionally `modelark/artifact_io`,
+only as needed for raw/ZipNN/StreamZNN/zstd dispatch and resource orchestration;
+it must reuse the standalone primitives, not become a second StreamZNN engine
+or a general transport framework. It must not import `modelark.slice`, SQL,
+drive registration, archive mutation, git-annex retrieval, or destination code.
+
+It operates on caller-supplied bounded byte streams and explicit expectations:
+
+- Container recognition and supported lossless byte-format parsing.
+- Separate stored frame, original frame, consumer read and zstd-window bounds.
+- Original-byte stream production, codec requirements, typed neutral errors,
+  cancellation and explicit resource policy.
+- A stored-byte passthrough primitive with length/digest verification may be
+  internal plumbing; it is not an executable stored-export CLI/profile yet.
+
+Keep source acquisition and physical attachment checks outside this module.
+`LocalArchiveReader` retains descriptor confinement, identity checks and IO error
+attribution, supplies attachment-checked bounded reads to the codec layer, and
+maps neutral errors into Slice refusal codes. `FencedSources` retains current
+catalog evidence, candidate gates and drive-lock lifetime.
+
+Slice's delivery adapter requests originals for `hf-tree-v1`. Its transaction
+core owns approval, owned temporaries, publication and receipts, not codec rules.
+Old direct/native/FAT output semantics and hashes stay original-byte semantics.
+No branch that silently sends compressed bytes after a decode refusal.
+
+## 3. Bring existing consumers into consistency, without importing their authority
+
+Use actual writer fixtures as the compatibility contract from the start. Preserve
+writer codec preferences, chunk format, disk capacity math, raw fallback and
+canary-before-drop. DEC-138 additionally requires writer and reader admission to
+use the same RAM-safety mechanism: this scoped integration is required, not an
+unrelated compression-policy retune. Leave StreamZNN standalone.
+
+Stage caller adoption: first Slice; then a separately gated follow-on for
+`compress.canary_ok` and `compress.decompress_file` (and therefore restore) to use
+the same neutral byte decoder. This is shared decoding, not shared source access:
+restore retains its current retrieval policy and atomic publication wrapper;
+Slice never gains retrieval. Canary retains its known original hash and drop gate.
+Standalone StreamZNN APIs remain independently usable and cross-tested.
+Its own `decompress_file` / `verify_sha256` wrappers adopt the extracted primitive
+together; this is immediate reuse of the existing canary/restore path, not a
+second independent implementation. The separately gated adoption below covers
+ModelArk's whole-ZipNN/zstd dispatch and differing caller execution policies.
+This follow-on is part of the centralization roadmap, not a prerequisite for
+unblocking Slice or permission to force incompatible behavior into existing
+callers. Shared format interpretation, byte decoding and RAM-safety methodology
+are the target; source authority and execution topology remain caller-specific.
+If only parser sharing is safely possible
+in that follow-on, document the remaining duplicate execution paths explicitly
+and do not describe the broader decoder consolidation as complete.
+
+Before migrating a caller, inventory its currently accepted header/mode variants,
+expected-size availability, exceptions and return conventions. Do not silently
+impose Slice's old allowlist or 64 MiB cap on restore/canary. Shared format support
+must cover known writer-produced and supported existing representations; unsafe
+or conflicting modes require an explicit compatibility decision, not accidental
+acceptance or refusal. Resource profiles can differ only explicitly (for example,
+a different host budget or an old sealed approval), never through independent
+per-consumer RAM logic. Format interpretation and original-byte results may not
+drift. Stop and rescope
+if preservation requires archive migration or unrelated restore/Fill redesign.
+
+## 4. Large-frame compatibility and resource gate
+
+Required parity invariant (DEC-138): compression, canary, restore and Slice call
+one resource-admission mechanism with common budget interpretation, headroom and
+guard methodology, using qualified estimates for each operation. Do not reuse the
+compression 4x factor blindly for decoding, nor retain an unrelated Slice limit
+as the new policy. Under equivalent supported codec/runtime, budget and available
+headroom, an accepted compression must produce a representation that the decoder
+admits and fully hash-verifies under that same profile. The writer's canary uses
+this mechanism, not a more permissive path that bypasses reader requirements.
+
+Test both phases under equivalent conditions and also genuine differences in
+host/concurrency/budget that must yield an explicit resource refusal. Shared RAM
+admission on the compression side is required within this arc before declaring
+parity complete; it is not deferred with optional broader decoder consolidation.
+No migration or assumption about historic compression resources is implied.
+
+The three-way product separation does not cause a RAM problem. Two independent
+facts must be explained separately: the delivery profile decides whether decoding
+is needed; codec framing determines how much work must be decoded at once.
+The compression side already combines (a) DEC-022's estimated RAM gate for whole
+files, (b) StreamZNN's independent small blocks for larger files, and (c) a child
+process for native crash containment. Only (a)/(b) bound the intended workload;
+process isolation alone neither adds RAM nor enforces a host memory ceiling.
+
+Lean on StreamZNN for already-streamed content. The existing troublesome files
+are bare whole-ZipNN blobs, not StreamZNN containers. A small stream-reader API
+does not retroactively split them into independent compressed blocks: the
+installed ZipNN API still returns the entire decoded blob. The proposed extension
+therefore removes duplication and enables safe confined streaming, while large
+whole-frame resource admission remains a distinct compatibility requirement.
+Do not relabel an archive rewrite as a small StreamZNN API change.
+
+Keep bounded streaming for raw/StreamZNN/zstd. Permit supported whole ZipNN and
+large historical stream frames through a supervised helper, once qualified.
+Allow legitimate encoded framing overhead separately from the original-frame
+ceiling. Never use the original file length or current compression config as
+unlimited allocation permission; the compression 4x estimate is not a proven
+decoder memory bound.
+
+The first engineering slice qualifies a guard against the installed decoder:
+measure import/mapping baseline, native working memory, buffers and copies, using
+real writer-made roughly 100 MiB and 410 MiB whole frames and 64 MiB stream frames.
+Test the actual enforced limit with adversarial headers, allocation failure and
+native crashes. A helper alone isolates many crashes but does not guarantee host
+or parent OOM protection. `RLIMIT_AS` limits virtual address space, not RSS; a
+resident-memory controller has different deployment requirements. No claim that
+`RLIMIT_RSS` provides a Linux hard bound. No automatic cgroup/sudo/service changes.
+
+Agreement is on a qualification-gated design, not on an unmeasured numeric limit
+or already-proven mechanism. Larger decoding ships only after both useful real
+fixtures succeed under the chosen guard AND failure stays contained. If no guard
+works without new host authority, stop and report the remaining choice; do not
+relax the guard or call the compatibility defect fixed. Existing approvals and
+current small-frame behavior remain valid; this gate need not block the neutral
+refactor and compatibility tests.
+
+Helper protocol: one frame at a time, parent reads retained source descriptors in
+small checked pieces; helper receives only data/control pipes, not paths, archive
+or destination handles, catalog or fence FDs. Use dedicated protocol FDs, not
+stdout: `compress_worker.py` already documents native-library stdout pollution.
+Input completion precedes decode/output; parent supervision remains responsive
+through input, compute and output, with backpressure and bounded message lengths.
+No whole-file parent buffer, `communicate()` accumulation or scratch file.
+Drain/discard diagnostics with a bounded retained tail; never let logging fill a
+pipe and stall the child. No GPU tensors or new GPU workflow.
+
+Parent validates size/framing/EOF and final hashes, cancels on stop/unplug/consumer
+failure, terminates/reaps before releasing source fences, and has tested parent-
+death handling. Worker success is never destination success. ENOSPC/EIO remains a
+destination error; no success receipt after failure. Canary already runs inside
+its existing compression worker: it uses a non-spawning decode adapter within
+that worker, never a new nested helper. Existing write-fence inheritance for
+compression remains unchanged; do not copy that inheritance into the read-only
+Slice helper. Preserve the compression worker's result-file protocol. If safe
+full decoder adoption cannot preserve these boundaries, share parsing first and
+record the remaining consolidation instead of inventing unsafe child ownership.
+
+## 5. Admission, compatibility and early checks
+
+For new original-delivery approvals, seal a versioned decode/resource policy into
+the appropriate direct/native/FAT admission envelope. No mutable wishlist lookup
+may widen approved behavior at Start. Old plans without new fields retain legacy
+limits; fresh preview/approval is needed to use larger ones. Version readers so
+older binaries cannot reinterpret new approved semantics. Do not migrate the live
+catalog or reinterpret old receipts. Define private-state compatibility explicitly.
+Put the policy in each binding's canonical hash payload, not an unbound side
+record. Retain closed-world key/version validation so an older binary refuses
+new semantics; test the actual direct, native and FAT readers rather than
+assuming one envelope's change covers the others.
+
+Before first destination mutation or consuming FAT's one attempt, inspect attached
+sealed source candidates under the existing source fences/confinement. Respect
+alternatives and absent-drive/wait semantics; do not require all drives online or
+label absent candidates checked. Check all relevant StreamZNN frame headers with
+bounded reads/checked seeks, not only the first. Offline preview remains offline.
+Recheck on actual use. Preflight detects known header/resource refusals, not later
+corruption, resource contention or full-file correctness. Preserve native resume
+and FAT one-attempt/no-resume behavior. No new source labels or widening a seal.
+
+## 6. Stored representation delivery (design now; implement later)
+
+Add a distinct versioned profile only when explicitly scoped for implementation.
+It must seal exact output paths, encoded digest/size, codec/version or honest
+unknown-encoding status, original identity and linkage evidence, approved source
+alternatives, capacity calculation, and verification claims.
+
+- Copy stored bytes exactly; no decoder allocation and no implicit recompression.
+- Require trustworthy expected stored digest/size before claiming verified stored
+  delivery. SHA256 annex keys can supply that evidence when valid. Missing evidence
+  is a gap requiring separately authorized observation/enrichment, not a fabricated
+  value or a reason to break existing original-file delivery.
+  A compressed object's annex hash identifies its stored bytes, not its decoded
+  original. For a raw object the same hash identifies both, because those bytes
+  are identical. Always retain the original-to-stored linkage evidence separately.
+- Different encodings sharing an original digest are not interchangeable after
+  approval of exact stored bytes. Equivalent sources must supply identical sealed
+  output bytes, or a newly approved proposal is needed.
+- Use a dedicated bundle layout/manifest mapping logical paths to stored objects;
+  do not copy annex object-store structure or append `.znn` blindly. Resolve raw/
+  compressed filename collisions and FAT case/short-name collisions at planning.
+- Count stored bytes plus manifest/receipt/filesystem overhead, and apply FAT's
+  per-file ceiling to actual output sizes. Do not reuse original-size totals.
+- Receipt says stored representation verified and separately identifies historical
+  original-byte evidence. It cannot claim fresh decode verification, model
+  loadability, archive registration or desired-copy satisfaction.
+- Wire-to-output transcoding, peer trust and negotiation are future protocol work.
+  No placeholder public switch that accepts unsupported stored/P2P modes now.
+
+Revisit stored-profile implementation when the operator scopes compressed/local
+export or peer serving; require the evidence/layout/admission specification above
+before exposing a switch. Revisit P2P transport when peer distribution is scoped,
+after representation identity and verification claims are stable. These are
+proposed deferrals to be recorded in the ledger on approval, not shipped features.
+
+## Implementation sequence after operator approval
+
+| Slice | Work | Exit evidence |
+|---|---|---|
+| A | Characterize shared codec and RAM-admission contract; qualify compression and decode guards | Real writer/canary/restore/decoder fixtures under the same profile; measured successful and failure limits; explicit go/no-go |
+| B | Small standalone StreamZNN stream API, existing wrappers, thin neutral dispatcher and Slice original-output adapter | Shared existing decode loop; MIT/standalone APIs/container preserved; identity, confinement, format, hash and transaction tests pass; no behavior widening |
+| C | Qualified large-frame helper, sealed policy and early admission | Real failing-size fixtures now decode; old seals safe; stop/crash/unplug/pipe/FAT tests pass |
+| D | Separately gated canary/restore decoder adoption, without policy changes | Existing format/publication/retrieval/capacity/fallback contracts preserved; no nested helper; any parser-only adoption explicitly reported as partial |
+| E | Full public-CLI synthetic delivery and documentation | Complete decoded hashes/receipts, failure matrix, truthful acceptance summary; physical test separately scoped |
+
+Use a new implementation PR, not unrelated docs-only PR #73. Land/review slices
+incrementally in that PR; do not merge an unsafe intermediate behavior widening.
+Follow the operator's Grok CLI and Greptile/Codex review workflow, with at most
+three review/fix cycles before summarizing unresolved findings. Operator merges.
+No changes to the live service, USB, archive or catalog in this implementation
+stage. The approved workflow permits scoped commits, PRs and review requests,
+not automatic merging or deployment. No performance guarantee or full physical
+acceptance is claimed by unit tests.
+
+## Must-test regressions and scope boundaries
+
+- Whole/stream/raw/optional-zstd real fixtures, all supported byte dtypes, exact
+  cap boundaries, incompressible overhead, large final/tail frames and historical
+  configurable chunks; round trips match original hashes across consumers.
+- Oversized/malformed/truncated/trailing content; worker crash/allocation failure;
+  noisy stdout/stderr; blocked pipes; stop during native compute; parent death;
+  no orphan or leaked fence; attachment changes on every stored/read-output leg.
+- Exact file and aggregate lengths, original verification after EOF, source versus
+  destination errors, no false success receipt, old seal decoding and reader fences.
+- Known attached-source refusals before FAT attempt consumption; safe source
+  alternatives; drive swaps; native partial recovery unchanged.
+- Slice changes no archive bytes, catalog identity, generation or schema. No
+  archive recompression, new replica, automatic host configuration or broad Fill
+  refactor. Shared code must not introduce retrieval into Slice.
+- Future stored-export contract tests/specification must not masquerade as a
+  shipped selectable mode or as a completed P2P capability.
+- StreamZNN stream API handles short reads, non-seekable input, bounded requests,
+  callback failures, early cancellation and caller-owned descriptor lifetime;
+  existing path APIs produce identical output and retain exception/publication
+  behavior. No accidental new dependency or on-disk format change.
+
+## Review and decision record
+
+Local Grok CLI session: `01a08c73-d885-7930-bcc6-bb6dd26a9e56`.
+No web Grok or delegated reviewer was used. The previous helper-only review does
+not count as architecture approval; this direction received its own review:
+
+1. Revised architecture: ACCEPT WITH REQUIRED CHANGES. Incorporated preservation
+   of original-identity alternatives, stored/original hash distinction, all
+   admission hashes, no nested canary helper, candidate-aware preflight and
+   explicit stored/P2P deferrals. Grok agreed that the memory guard is mandatory
+   before large-frame rollout, not optional crash isolation.
+2. Amended written architecture: ACCEPT. Codex agrees with the staged scope,
+   boundaries and qualification gates. Broader caller adoption remains separately
+   gated, with partial centralization reported honestly.
+3. Operator-requested StreamZNN reuse amendment: ACCEPT. Both reviewers prefer
+   the small caller-owned stream API in the existing standalone MIT module, its
+   path wrappers sharing that loop, and a thin ModelArk dispatcher rather than a
+   duplicate StreamZNN decoder. Both distinguish this reuse from the unresolved
+   engineering requirement to safely decode existing whole-ZipNN frames.
+
+No unresolved architecture disagreement remains. The concrete memory-guard
+mechanism and numerical limits are deliberately qualification results, not facts
+asserted by the plan. Agreement means agreement on staged scope and gates, not
+proof that the compatibility defect is fixed or implementation is complete.
+Operator approval is now recorded in DEC-139, with DEF-045/DEF-046 for stored
+export and P2P and HYP-002 for the resource qualification. DEC-138 remains the
+mandatory shared-RAM invariant. IDs were allocated in the authoritative ledger.
+
+## Implementation progress
+
+Stage A is in progress on `codex/codec-resource-contract`: shared policy,
+disposable real-codec qualification and tests. Production adoption is false.
+See ../codec-resource-qualification.md for evidence limits and review state.

--- a/modelark/codec_resources.py
+++ b/modelark/codec_resources.py
@@ -68,7 +68,8 @@ class CodecMemoryPolicy:
 
         Install before importing native codecs. Never call in the service or
         use preexec_fn in a multithreaded parent. Failure means abort that child;
-        do not fall back to an unguarded decode. Core dumps are disabled too.
+        do not fall back to an unguarded decode. Set the core-file limit to zero;
+        this does not change the host's separate crash-reporting policy.
         """
         if sys.platform != "linux":
             raise CodecResourceRefusal("codec AS guard is only qualified on Linux")

--- a/modelark/codec_resources.py
+++ b/modelark/codec_resources.py
@@ -1,0 +1,89 @@
+"""Shared, operation-neutral memory admission for isolated codec workers.
+
+Stage A: qualification consumers only. No live writer/reader policy changes.
+RLIMIT_AS is a hard virtual-address-space ceiling, NOT an RSS reservation.
+Available memory is a fresh caller observation of the smallest host/cgroup
+headroom, not MemFree and not a promise against unrelated concurrent allocation.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import sys
+
+
+class CodecResourceRefusal(RuntimeError):
+    """The requested resource envelope cannot be admitted or enforced."""
+
+
+def _bytes(value, name, *, zero=False):
+    if type(value) is not int or value < (0 if zero else 1):
+        raise ValueError(f"{name} must be {'nonnegative' if zero else 'positive'} integer bytes")
+    return value
+
+
+@dataclass(frozen=True)
+class CodecMemoryPolicy:
+    """One explicit envelope used by both compression and decompression.
+
+    No compression-size multiplier or consumer-specific default lives here.
+    The complete round trip must be qualified against the same envelope.
+    Conservatively require physical headroom for the entire AS ceiling plus
+    reserve; subtracting lazy native mappings would need a different proof.
+    """
+
+    address_space_bytes: int
+    reserve_bytes: int
+    version: str = "modelark.codec-memory.v1"
+
+    def __post_init__(self):
+        _bytes(self.address_space_bytes, "address_space_bytes")
+        _bytes(self.reserve_bytes, "reserve_bytes", zero=True)
+        if self.version != "modelark.codec-memory.v1":
+            raise ValueError("unknown codec memory policy")
+
+    def to_record(self):
+        return asdict(self)
+
+    @classmethod
+    def from_record(cls, record):
+        if type(record) is not dict or set(record) != {
+                "version", "address_space_bytes", "reserve_bytes"}:
+            raise ValueError("invalid codec memory policy fields")
+        return cls(**record)
+
+    def admit(self, available_bytes: int) -> None:
+        """Use identical admission math for every codec operation.
+
+        Caller must account for applicable cgroup ancestors and concurrent jobs.
+        This sample admits a launch; it is not a durable resource reservation.
+        """
+        _bytes(available_bytes, "available_bytes", zero=True)
+        required = self.address_space_bytes + self.reserve_bytes
+        if available_bytes < required:
+            raise CodecResourceRefusal(
+                f"headroom {available_bytes} is below policy requirement {required}")
+
+    def install_in_worker(self) -> None:
+        """Irreversibly constrain THIS process; call only in a fresh child.
+
+        Install before importing native codecs. Never call in the service or
+        use preexec_fn in a multithreaded parent. Failure means abort that child;
+        do not fall back to an unguarded decode. Core dumps are disabled too.
+        """
+        if sys.platform != "linux":
+            raise CodecResourceRefusal("codec AS guard is only qualified on Linux")
+        import resource
+
+        try:
+            inherited = resource.getrlimit(resource.RLIMIT_AS)
+            if any(limit != resource.RLIM_INFINITY and limit < self.address_space_bytes
+                   for limit in inherited):
+                raise CodecResourceRefusal("inherited AS ceiling is below requested policy")
+            resource.setrlimit(resource.RLIMIT_AS,
+                               (self.address_space_bytes, self.address_space_bytes))
+            resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+            if resource.getrlimit(resource.RLIMIT_AS) != (
+                    self.address_space_bytes, self.address_space_bytes):
+                raise CodecResourceRefusal("AS ceiling was not installed")
+        except (OSError, ValueError, OverflowError) as exc:
+            raise CodecResourceRefusal("could not install codec memory guard") from exc

--- a/scripts/qualify_codec_resources.py
+++ b/scripts/qualify_codec_resources.py
@@ -25,6 +25,13 @@ from modelark.codec_resources import CodecMemoryPolicy, CodecResourceRefusal
 
 def available_memory() -> dict:
     """Conservative visible Linux memory headroom; unknown accounting refuses."""
+    try:
+        return _available_memory()
+    except (OSError, ValueError, OverflowError) as exc:
+        raise CodecResourceRefusal("could not establish memory headroom") from exc
+
+
+def _available_memory():
     values = {}
     for line in Path("/proc/meminfo").read_text().splitlines():
         fields = line.split()
@@ -32,6 +39,8 @@ def available_memory() -> dict:
             if len(fields) != 3 or fields[2] != "kB":
                 raise CodecResourceRefusal("unrecognized MemAvailable accounting")
             values["host"] = int(fields[1]) * 1024
+            if values["host"] < 0:
+                raise CodecResourceRefusal("negative host memory accounting")
     if "host" not in values:
         raise CodecResourceRefusal("host available memory is unknown")
     mounts = [line.split() for line in Path("/proc/self/mountinfo").read_text().splitlines()
@@ -42,7 +51,7 @@ def available_memory() -> dict:
     if len(groups) != 1 or not groups[0].startswith("0::/"):
         raise CodecResourceRefusal("unrecognized unified cgroup membership")
     relative = groups[0][4:]
-    if any(part in {".", ".."} for part in relative.split("/")):
+    if relative and any(part in {"", ".", ".."} for part in relative.split("/")):
         raise CodecResourceRefusal("invalid cgroup membership")
     root = Path("/sys/fs/cgroup")
     current = root / relative
@@ -52,6 +61,8 @@ def available_memory() -> dict:
         if current != root or (current / "memory.max").exists():
             maximum = (current / "memory.max").read_text().strip()
             used = int((current / "memory.current").read_text().strip())
+            if used < 0 or maximum != "max" and int(maximum) < 0:
+                raise CodecResourceRefusal("negative cgroup memory accounting")
             if maximum != "max":
                 values[str(current.relative_to(root))] = max(0, int(maximum) - used)
         if current == root:

--- a/scripts/qualify_codec_resources.py
+++ b/scripts/qualify_codec_resources.py
@@ -32,16 +32,16 @@ def available_memory() -> dict:
 
 
 def _available_memory():
-    values = {}
+    host_available = None
     for line in Path("/proc/meminfo").read_text().splitlines():
         fields = line.split()
         if fields and fields[0] == "MemAvailable:":
             if len(fields) != 3 or fields[2] != "kB":
                 raise CodecResourceRefusal("unrecognized MemAvailable accounting")
-            values["host"] = int(fields[1]) * 1024
-            if values["host"] < 0:
+            host_available = int(fields[1]) * 1024
+            if host_available < 0:
                 raise CodecResourceRefusal("negative host memory accounting")
-    if "host" not in values:
+    if host_available is None:
         raise CodecResourceRefusal("host available memory is unknown")
     mounts = [line.split() for line in Path("/proc/self/mountinfo").read_text().splitlines()
               if " - cgroup2 " in line]
@@ -55,6 +55,7 @@ def _available_memory():
         raise CodecResourceRefusal("invalid cgroup membership")
     root = Path("/sys/fs/cgroup")
     current = root / relative
+    cgroup_headroom = {}
     while True:
         # Initial hierarchy roots have no memory.max; a visible namespace root
         # may have one and its limit must not be discarded.
@@ -64,11 +65,13 @@ def _available_memory():
             if used < 0 or maximum != "max" and int(maximum) < 0:
                 raise CodecResourceRefusal("negative cgroup memory accounting")
             if maximum != "max":
-                values[str(current.relative_to(root))] = max(0, int(maximum) - used)
+                cgroup_headroom[str(current.relative_to(root))] = max(0, int(maximum) - used)
         if current == root:
             break
         current = current.parent
-    return {"available_bytes": min(values.values()), "observations": values}
+    return {"available_bytes": min([host_available, *cgroup_headroom.values()]),
+            "observations": {"host_available_bytes": host_available,
+                             "cgroup_headroom_bytes": cgroup_headroom}}
 
 
 def _dump(path, record):

--- a/scripts/qualify_codec_resources.py
+++ b/scripts/qualify_codec_resources.py
@@ -1,0 +1,249 @@
+"""Disposable Stage-A codec round trips under one shared AS policy.
+
+Run with the project's dev Python: -m scripts.qualify_codec_resources [--large].
+No live catalog, archive, service, USB, network or host configuration is accessed.
+The parent observes Linux host/visible ancestor cgroup headroom before each
+sequential child. This is a sampled admission, not a system memory reservation.
+The qualification report is evidence for this runtime and fixtures, not blanket
+qualification of every codec input or a completed Slice delivery.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+import random
+import resource
+import subprocess
+import sys
+import tempfile
+
+from modelark.codec_resources import CodecMemoryPolicy, CodecResourceRefusal
+
+
+def available_memory() -> dict:
+    """Conservative visible Linux memory headroom; unknown accounting refuses."""
+    values = {}
+    for line in Path("/proc/meminfo").read_text().splitlines():
+        fields = line.split()
+        if fields and fields[0] == "MemAvailable:":
+            if len(fields) != 3 or fields[2] != "kB":
+                raise CodecResourceRefusal("unrecognized MemAvailable accounting")
+            values["host"] = int(fields[1]) * 1024
+    if "host" not in values:
+        raise CodecResourceRefusal("host available memory is unknown")
+    mounts = [line.split() for line in Path("/proc/self/mountinfo").read_text().splitlines()
+              if " - cgroup2 " in line]
+    if len(mounts) != 1 or mounts[0][3:5] != ["/", "/sys/fs/cgroup"]:
+        raise CodecResourceRefusal("full cgroup2 hierarchy is not visible")
+    groups = Path("/proc/self/cgroup").read_text().splitlines()
+    if len(groups) != 1 or not groups[0].startswith("0::/"):
+        raise CodecResourceRefusal("unrecognized unified cgroup membership")
+    relative = groups[0][4:]
+    if any(part in {".", ".."} for part in relative.split("/")):
+        raise CodecResourceRefusal("invalid cgroup membership")
+    root = Path("/sys/fs/cgroup")
+    current = root / relative
+    while True:
+        # Initial hierarchy roots have no memory.max; a visible namespace root
+        # may have one and its limit must not be discarded.
+        if current != root or (current / "memory.max").exists():
+            maximum = (current / "memory.max").read_text().strip()
+            used = int((current / "memory.current").read_text().strip())
+            if maximum != "max":
+                values[str(current.relative_to(root))] = max(0, int(maximum) - used)
+        if current == root:
+            break
+        current = current.parent
+    return {"available_bytes": min(values.values()), "observations": values}
+
+
+def _dump(path, record):
+    with Path(path).open("x") as handle:
+        json.dump(record, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _sha(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _fixture(path, size):
+    """A valid one-tensor BF16 safetensors file, generated without tensor APIs."""
+    header_size = 256
+    payload = size - 8 - header_size
+    if payload <= 0 or payload % 2:
+        raise ValueError("fixture size must accommodate an even BF16 payload")
+    header = json.dumps({"weight": {"dtype": "BF16", "shape": [payload // 2],
+                                    "data_offsets": [0, payload]}}).encode()
+    if len(header) > header_size:
+        raise ValueError("fixture header too large")
+    random_bytes = random.Random(12345).randbytes(1 << 19)
+    block = bytearray(1 << 20)
+    block[::2], block[1::2] = random_bytes, b"\x3f" * (1 << 19)
+    with path.open("xb") as handle:
+        handle.write(header_size.to_bytes(8, "little"))
+        handle.write(header.ljust(header_size, b" "))
+        remaining = payload
+        while remaining:
+            piece = block[:min(remaining, len(block))]
+            handle.write(piece)
+            remaining -= len(piece)
+    return _sha(path)
+
+
+def _metrics():
+    result = {"peak_rss_bytes": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024}
+    for line in Path("/proc/self/status").read_text().splitlines():
+        fields = line.split()
+        if fields[0] in {"VmPeak:", "VmSize:", "VmRSS:"}:
+            result[fields[0][:-1] + "_bytes"] = int(fields[1]) * 1024
+    return result
+
+
+def worker(request_path):
+    request = json.loads(Path(request_path).read_text())
+    policy = CodecMemoryPolicy.from_record(request["policy"])
+    policy.install_in_worker()  # before native imports, same for every operation
+    before = _metrics()
+    if request["phase"] == "allocation-refusal":
+        try:
+            bytearray(policy.address_space_bytes + 1)
+        except MemoryError:
+            _dump(request["result"], {"passed": True, "allocation_refused": True,
+                                      "policy": policy.to_record(), "metrics": _metrics()})
+            return
+        raise RuntimeError("allocation ceiling failed")
+    from modelark import compress
+    import zipnn
+
+    imported = _metrics()
+    source, encoded, restored = (Path(request[name]) for name in ("source", "encoded", "restored"))
+    phase = request["phase"]
+    if phase == "compress":
+        compress.compress_file(source, encoded, codec=request["codec"], threads=1)
+    elif phase == "canary":
+        if not compress.canary_ok(encoded, request["sha256"]):
+            raise RuntimeError("canary hash mismatch")
+    elif phase == "restore":
+        compress.decompress_file(encoded, restored)
+        if restored.stat().st_size != source.stat().st_size or _sha(restored) != request["sha256"]:
+            raise RuntimeError("restored original bytes mismatch")
+    else:
+        raise ValueError("unknown qualification phase")
+    if _sha(source) != request["sha256"]:
+        raise RuntimeError("source changed")
+    with encoded.open("rb") as handle:
+        magic = handle.read(5)
+    if request["codec"] == "streamznn":
+        if magic != b"SZNN\x01":
+            raise RuntimeError("writer did not produce StreamZNN")
+    elif request["codec"] == "zipnn-whole":
+        if magic[:4] != b"ZN\x00\x05":
+            raise RuntimeError("writer did not produce whole ZipNN 0.5")
+    else:
+        raise ValueError("unknown fixture codec")
+    _dump(request["result"], {"passed": True, "phase": phase, "policy": policy.to_record(),
+                              "metrics_before_import": before, "metrics_after_import": imported,
+                              "metrics": _metrics(), "stored_bytes": encoded.stat().st_size,
+                              "stored_sha256": _sha(encoded), "original_sha256": request["sha256"],
+                              "magic_hex": magic.hex(), "python": sys.version,
+                              "original_bytes": source.stat().st_size,
+                              "codec": request["codec"],
+                              "zipnn_version": importlib.metadata.version("zipnn"),
+                              "torch_version": importlib.metadata.version("torch"),
+                              "zipnn_module": str(Path(zipnn.__file__).name)})
+
+
+def run(*, large=False, output_parent=None):
+    policy = CodecMemoryPolicy(8 << 30, 2 << 30)
+    policy.admit(available_memory()["available_bytes"])
+    output = Path(tempfile.mkdtemp(prefix="modelark-codec-qualification-", dir=output_parent))
+    report = {"status": "running", "scope": "synthetic-codec-resource-qualification-only",
+              "policy": policy.to_record(), "results": [], "large": large,
+              "production_adoption": False, "physical_USB_or_archive_test": False}
+    checkout = Path(__file__).resolve().parent.parent
+    report["implementation_sha256"] = {
+        name: _sha(checkout / name) for name in (
+            "modelark/codec_resources.py", "modelark/compress.py", "modelark/streamznn.py",
+            "scripts/qualify_codec_resources.py")}
+    print(f"Qualification directory: {output}", flush=True)
+    index = 0
+
+    def launch(request):
+        nonlocal index
+        sample = available_memory()
+        policy.admit(sample["available_bytes"])
+        index += 1
+        result_path = output / f"{index:02d}-result.json"
+        request_path = output / f"{index:02d}-request.json"
+        request = {**request, "policy": policy.to_record(), "result": str(result_path)}
+        _dump(request_path, request)
+        # Native libraries may print: protocol is an exclusive result file, not stdout.
+        with (output / f"{index:02d}-stdout.txt").open("x") as out, \
+                (output / f"{index:02d}-stderr.txt").open("x") as err:
+            proc = subprocess.Popen([sys.executable, "-m", "scripts.qualify_codec_resources",
+                                     "--worker", str(request_path)], stdout=out, stderr=err,
+                                    close_fds=True)
+            try:
+                code = proc.wait()
+            except BaseException:
+                proc.kill()
+                proc.wait()
+                raise
+        if code != 0 or not result_path.exists():
+            raise RuntimeError(f"qualification child {index} failed with exit {code}; see {output}")
+        result = json.loads(result_path.read_text())
+        if result.get("passed") is not True or result.get("policy") != policy.to_record():
+            raise RuntimeError("child did not certify requested policy")
+        report["results"].append({"phase": request["phase"], "admission": sample, **result})
+        print(f"passed {index}: {request['phase']} {request.get('codec', '')}", flush=True)
+
+    try:
+        launch({"phase": "allocation-refusal"})
+        sizes = [99_630_640, 409_993_344] if large else [2 << 20]
+        with tempfile.TemporaryDirectory(prefix="synthetic-", dir=output) as scratch:
+            for size in sizes:
+                for codec in ("zipnn-whole", "streamznn"):
+                    case = Path(scratch) / f"{codec}-{size}"
+                    case.mkdir()
+                    source = case / "weights.safetensors"
+                    digest = _fixture(source, size)
+                    request = {"source": str(source), "encoded": str(case / "misleading.blob"),
+                               "restored": str(case / "restored.safetensors"),
+                               "codec": codec, "sha256": digest}
+                    for phase in ("compress", "canary", "restore"):
+                        launch({**request, "phase": phase})
+        if any(_sha(checkout / name) != digest
+               for name, digest in report["implementation_sha256"].items()):
+            raise RuntimeError("implementation changed during qualification; rerun unchanged code")
+        report["status"] = "passed"
+    except BaseException as exc:
+        report["status"] = "failed"
+        report["error"] = f"{type(exc).__name__}: {exc}"
+        raise
+    finally:
+        _dump(output / "result.json", report)
+    return output
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--large", action="store_true", help="qualify the two real failure sizes")
+    parser.add_argument("--output-parent", type=Path)
+    parser.add_argument("--worker", type=Path, help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.worker:
+        worker(args.worker)
+    else:
+        print(run(large=args.large, output_parent=args.output_parent))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_codec_qualification.py
+++ b/tests/test_codec_qualification.py
@@ -1,0 +1,70 @@
+"""Headroom sampling and fixture checks without invoking large native jobs."""
+import json
+from pathlib import Path
+
+import pytest
+
+from modelark.codec_resources import CodecResourceRefusal
+from scripts import qualify_codec_resources as q
+
+
+def _proc(monkeypatch, *, root_limit=False):
+    files = {
+        "/proc/meminfo": "MemFree: 1 kB\nMemAvailable: 200 kB\n",
+        "/proc/self/mountinfo": "1 2 0:3 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n",
+        "/proc/self/cgroup": "0::/a/b\n",
+        "/sys/fs/cgroup/a/b/memory.max": "max",
+        "/sys/fs/cgroup/a/b/memory.current": "20000",
+        "/sys/fs/cgroup/a/memory.max": "100000",
+        "/sys/fs/cgroup/a/memory.current": "60000",
+    }
+    if root_limit:
+        files["/sys/fs/cgroup/memory.max"] = "50000"
+        files["/sys/fs/cgroup/memory.current"] = "30000"
+    monkeypatch.setattr(Path, "read_text", lambda path, *a, **k: files[str(path)])
+    monkeypatch.setattr(Path, "exists", lambda path: str(path) in files)
+    return files
+
+
+def test_ancestor_limit_and_memavailable_not_memfree(monkeypatch):
+    _proc(monkeypatch)
+    sample = q.available_memory()
+    assert sample["available_bytes"] == 40000
+    assert sample["observations"]["host"] == 200 * 1024
+
+
+def test_visible_root_limit_is_not_ignored(monkeypatch):
+    _proc(monkeypatch, root_limit=True)
+    assert q.available_memory()["available_bytes"] == 20000
+
+
+def test_overdrawn_cgroup_has_zero_headroom(monkeypatch):
+    files = _proc(monkeypatch)
+    files["/sys/fs/cgroup/a/memory.current"] = "100001"
+    assert q.available_memory()["available_bytes"] == 0
+
+
+@pytest.mark.parametrize("path,value", [
+    ("/proc/meminfo", "MemFree: 1000000 kB\n"),
+    ("/proc/self/cgroup", "2:memory:/a\n"),
+    ("/proc/self/cgroup", "0::/../a\n"),
+    ("/proc/self/mountinfo", "1 2 0:3 /hidden /sys/fs/cgroup rw - cgroup2 cgroup rw\n"),
+])
+def test_unknown_headroom_refuses(monkeypatch, path, value):
+    files = _proc(monkeypatch)
+    files[path] = value
+    with pytest.raises(CodecResourceRefusal):
+        q.available_memory()
+
+
+def test_synthetic_fixture_is_real_safetensors_layout(tmp_path):
+    source = tmp_path / "test.safetensors"
+    digest = q._fixture(source, 4096)
+    data = source.read_bytes()
+    length = int.from_bytes(data[:8], "little")
+    header = json.loads(data[8:8 + length])
+    assert header == {"weight": {"dtype": "BF16", "shape": [1916], "data_offsets": [0, 3832]}}
+    assert len(data) == 4096
+    assert digest == q._sha(source)
+    with pytest.raises(FileExistsError):
+        q._fixture(source, 4096)

--- a/tests/test_codec_qualification.py
+++ b/tests/test_codec_qualification.py
@@ -21,7 +21,12 @@ def _proc(monkeypatch, *, root_limit=False):
     if root_limit:
         files["/sys/fs/cgroup/memory.max"] = "50000"
         files["/sys/fs/cgroup/memory.current"] = "30000"
-    monkeypatch.setattr(Path, "read_text", lambda path, *a, **k: files[str(path)])
+    def read(path, *args, **kwargs):
+        if str(path) not in files:
+            raise FileNotFoundError(str(path))
+        return files[str(path)]
+
+    monkeypatch.setattr(Path, "read_text", read)
     monkeypatch.setattr(Path, "exists", lambda path: str(path) in files)
     return files
 
@@ -48,11 +53,26 @@ def test_overdrawn_cgroup_has_zero_headroom(monkeypatch):
     ("/proc/meminfo", "MemFree: 1000000 kB\n"),
     ("/proc/self/cgroup", "2:memory:/a\n"),
     ("/proc/self/cgroup", "0::/../a\n"),
+    ("/proc/self/cgroup", "0:://a\n"),
+    ("/proc/self/cgroup", "0::/a/\n"),
     ("/proc/self/mountinfo", "1 2 0:3 /hidden /sys/fs/cgroup rw - cgroup2 cgroup rw\n"),
 ])
 def test_unknown_headroom_refuses(monkeypatch, path, value):
     files = _proc(monkeypatch)
     files[path] = value
+    with pytest.raises(CodecResourceRefusal):
+        q.available_memory()
+
+
+@pytest.mark.parametrize("value", [None, "unknown", "-1"])
+@pytest.mark.parametrize("field", ["memory.max", "memory.current"])
+def test_unreadable_or_invalid_ancestor_is_typed_refusal(monkeypatch, value, field):
+    files = _proc(monkeypatch)
+    path = f"/sys/fs/cgroup/a/{field}"
+    if value is None:
+        del files[path]
+    else:
+        files[path] = value
     with pytest.raises(CodecResourceRefusal):
         q.available_memory()
 

--- a/tests/test_codec_qualification.py
+++ b/tests/test_codec_qualification.py
@@ -35,12 +35,28 @@ def test_ancestor_limit_and_memavailable_not_memfree(monkeypatch):
     _proc(monkeypatch)
     sample = q.available_memory()
     assert sample["available_bytes"] == 40000
-    assert sample["observations"]["host"] == 200 * 1024
+    assert sample["observations"]["host_available_bytes"] == 200 * 1024
+    assert sample["observations"]["cgroup_headroom_bytes"] == {"a": 40000}
 
 
 def test_visible_root_limit_is_not_ignored(monkeypatch):
     _proc(monkeypatch, root_limit=True)
     assert q.available_memory()["available_bytes"] == 20000
+
+
+@pytest.mark.parametrize("group", ["host", "host_available_bytes", "cgroup_headroom_bytes"])
+def test_cgroup_names_cannot_replace_host_headroom(monkeypatch, group):
+    files = _proc(monkeypatch)
+    files["/proc/meminfo"] = "MemAvailable: 1 kB\n"
+    files["/proc/self/cgroup"] = f"0::/{group}\n"
+    files[f"/sys/fs/cgroup/{group}/memory.max"] = "200000"
+    files[f"/sys/fs/cgroup/{group}/memory.current"] = "0"
+    sample = q.available_memory()
+    assert sample["available_bytes"] == 1024
+    assert sample["observations"]["host_available_bytes"] == 1024
+    assert sample["observations"]["cgroup_headroom_bytes"] == {group: 200000}
+    with pytest.raises(CodecResourceRefusal):
+        q.CodecMemoryPolicy(4096, 0).admit(sample["available_bytes"])
 
 
 def test_overdrawn_cgroup_has_zero_headroom(monkeypatch):

--- a/tests/test_codec_resources.py
+++ b/tests/test_codec_resources.py
@@ -85,7 +85,7 @@ else:
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux worker guard")
-def test_native_abort_is_contained_without_core_dump(tmp_path):
+def test_abort_terminates_child_with_zero_core_limit():
     import signal
 
     program = '''

--- a/tests/test_codec_resources.py
+++ b/tests/test_codec_resources.py
@@ -1,0 +1,99 @@
+"""Stage-A policy tests never lower the pytest process's resource limits."""
+import json
+import subprocess
+import sys
+
+import pytest
+
+from modelark.codec_resources import CodecMemoryPolicy, CodecResourceRefusal
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 1.5, "1024", None])
+def test_invalid_ceiling(value):
+    with pytest.raises(ValueError):
+        CodecMemoryPolicy(value, 0)
+
+
+@pytest.mark.parametrize("value", [True, -1, 1.5, "1", None])
+def test_invalid_reserve(value):
+    with pytest.raises(ValueError):
+        CodecMemoryPolicy(1024, value)
+
+
+def test_admission_boundary_is_operation_independent():
+    policy = CodecMemoryPolicy(1024, 128)
+    policy.admit(1152)
+    policy.admit(1153)
+    with pytest.raises(CodecResourceRefusal):
+        policy.admit(1151)
+    with pytest.raises(ValueError):
+        policy.admit(True)
+
+
+def test_policy_roundtrip_and_closed_world():
+    policy = CodecMemoryPolicy(4096, 1024)
+    assert CodecMemoryPolicy.from_record(json.loads(json.dumps(policy.to_record()))) == policy
+    record = policy.to_record()
+    for changed in ({**record, "version": "future"}, {**record, "operation": "slice"},
+                    {k: v for k, v in record.items() if k != "reserve_bytes"}):
+        with pytest.raises(ValueError):
+            CodecMemoryPolicy.from_record(changed)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux worker guard")
+def test_real_child_ceiling_denies_allocation_and_does_not_change_parent():
+    import resource
+
+    before = resource.getrlimit(resource.RLIMIT_AS)
+    program = '''
+import resource
+from modelark.codec_resources import CodecMemoryPolicy
+p = CodecMemoryPolicy(256 << 20, 0)
+p.install_in_worker()
+assert resource.getrlimit(resource.RLIMIT_AS) == (256 << 20, 256 << 20)
+assert resource.getrlimit(resource.RLIMIT_CORE) == (0, 0)
+try:
+    bytearray(512 << 20)
+except MemoryError:
+    print("allocation-refused")
+else:
+    raise AssertionError("guard did not enforce allocation ceiling")
+'''
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "allocation-refused"
+    assert resource.getrlimit(resource.RLIMIT_AS) == before
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux worker guard")
+@pytest.mark.parametrize("hard_mib", [256, 1024])
+def test_inherited_lower_limit_is_not_silently_relaxed(hard_mib):
+    program = f'''
+import resource
+from modelark.codec_resources import CodecMemoryPolicy, CodecResourceRefusal
+resource.setrlimit(resource.RLIMIT_AS, (256 << 20, {hard_mib} << 20))
+try:
+    CodecMemoryPolicy(512 << 20, 0).install_in_worker()
+except CodecResourceRefusal:
+    print("refused")
+else:
+    raise AssertionError("inherited ceiling was ignored")
+'''
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "refused"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux worker guard")
+def test_native_abort_is_contained_without_core_dump(tmp_path):
+    import signal
+
+    program = '''
+import os, resource
+from modelark.codec_resources import CodecMemoryPolicy
+CodecMemoryPolicy(256 << 20, 0).install_in_worker()
+assert resource.getrlimit(resource.RLIMIT_CORE) == (0, 0)
+os.abort()
+'''
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True)
+    assert result.returncode == -signal.SIGABRT


### PR DESCRIPTION
## Stage A: shared codec RAM admission and qualification

Implements the first bounded stage of the operator-approved representation plan
(DEC-138/139). **No production writer, canary, restore or Slice caller adopts this
policy yet. The live 64 MiB Slice incompatibility is not fixed by this PR.**

### Changes

- Operation-neutral, closed-world `CodecMemoryPolicy`: one explicit AS ceiling
  and reserve, shared by compression, canary and restoration in qualification.
- Fresh workers install RLIMIT_AS before native imports, refuse lower inherited
  limits and set the core-file limit to zero. This is not an RSS reservation or
  a guarantee against unrelated concurrent host allocation.
- Disposable synthetic runner uses host MemAvailable and visible ancestor cgroup
  headroom, real whole-ZipNN/StreamZNN writer paths, actual magic (not suffix),
  independent canary/full restoration, source hashes and unchanged-code evidence.
- Tests for exact admission, serialization, real allocation refusal, inherited
  limits, child abort, unknown/negative cgroup accounting and valid safetensors
  fixture layout. Approved architecture/deferrals recorded in the canonical ledger.

### Validation

- Targeted codec/qualification/stream/compression-isolation/Slice decoder tests:
  **74 passed, 5 skipped** after the remote-review fix (optional zstd locally).
- Full-project Ruff: passed.
- Real fixtures of **99,630,640** and **409,993,344** original bytes, both whole
  and streamed, full compression/canary/restore: **13/13 checks passed** under the
  same 8 GiB AS + 2 GiB sampled-headroom policy.
- Repeated in dev Torch 2.13.0 and installed-dependency Torch 2.14.0, Python 3.10.12,
  ZipNN 0.5.4. Final reviewed-code installed run max RSS ~1.64 GiB / virtual ~6.31 GiB.
- Post-fix installed-dependency qualification: all 13 checks passed again,
  with source hashes in `/tmp/modelark-codec-qualification-9bdahflv/result.json`.
- Full core suite in a disposable user/network namespace: 3,297 passed, 6 skipped;
  seven UID-mapping permission/ACL failures all passed on ordinary-host rerun.
  This avoids sandbox socket refusal and the deliberately host-wide singleton of
  the live portal without stopping it. CI must independently pass this PR head.

### Local review

Grok CLI round 1: no blockers, nonblocking hardening suggestions.
Round 2: **ACCEPT** at `4311547` after accounting/type/path/test-wording hardening.
`d5d81d6` records the resulting evidence only; no further code change.
Remote round 1: Greptile approved (5/5); Codex found one P2 observation-key collision.
`2d9bba5` structurally separates host/cgroup evidence and adds regression coverage.
Remote round 2 at `2d9bba5`: Greptile approved; Codex reported no major issues;
all CI passed. The addressed Codex thread is resolved.
Reconciled head `f165647` incorporates merged #73 and main, with no changes to
`modelark`, `scripts` or `tests` versus the accepted code head. Fresh CI is running;
prior-head approval is not represented as approval of this new merge commit.

### Scope and merge order

#73 is merged as `13e719d` following operator-authorized documentation fixes,
mandatory CI and an explicit waiver of another review wait. This branch includes
that main merge; the remaining PR diff is Stage A only. Main remains the target.
No live service, archive, catalog, USB, host configuration or network-serving
behavior was changed. Operator retains merge control.

### Next stage

Extend the existing standalone MIT StreamZNN with a caller-owned bounded stream
API; use a thin neutral adapter instead of a duplicate decoder. Production shared
RAM admission, sealed large-frame policy and caller alignment remain staged work.
Stored-format delivery and P2P remain explicit deferrals, not public switches.
