### PR TITLE
refactor(codec): share StreamZNN reader with Slice

### DIFF
--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3019,3 +3019,16 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: AGENTS.md carries the ongoing rule. PR #74's remaining third round must cover reconciliation and this policy record. The explicit no-review-wait merge exception for already-merged PR #73 does not apply to #74 or future PRs; merge authority remains separately scoped.
 - `docs_updated`: AGENTS.md, docs/decision_log.md
 - `related`: DEC-139, BOT-008
+
+### INC-064: Slice's zstd native window setting uses a mismatched unit conversion
+- `id`: INC-064
+- `date`: 2026-09-10
+- `status`: open
+- `triggered_by`: DEC-139 Stage B expanded real optional-zstd short-read/window coverage.
+- `symptom`: A synthetic 256 KiB unknown-content-size zstd frame passes the legacy 64 MiB header-window check but returns SOURCE_DECODE_INVALID from the native decoder with zstandard 0.25.0. Direct decoding with a bytes-valued 64 MiB setting succeeds completely.
+- `root_cause`: Existing Slice code divides its byte ceiling by 1024 before passing max_window_size. The tested dependency passes that setting directly to ZSTD_DCtx_setMaxWindowSize in bytes, despite its Python documentation describing KiB; the effective native ceiling is 64 KiB under the default Slice bound.
+- `blast_radius`: Some otherwise valid zstd Slice sources refuse; this observation does not imply corruption, an unsafe allocation or a failed physical test. Existing whole/StreamZNN and standalone compression/restore policies are separate.
+- `why_not_caught_earlier`: Earlier optional-codec tests either skipped locally or used smaller windows; they checked header refusal without testing a larger accepted header against the native setting.
+- `planned_remediation`: Stage B preserves existing refusal behavior and records an executable regression. Stage C's new explicit policy must qualify the units repair, known/unknown-content windows and supported backends without widening old sealed approvals. The work item and test gate are in docs/streamznn-reader-adapter.md.
+- `docs_updated`: docs/decision_log.md, docs/streamznn-reader-adapter.md, docs/plans/slice-representation-architecture.md
+- `related`: DEC-138, DEC-139, modelark/artifact_io.py, tests/test_artifact_io.py

--- a/docs/plans/slice-representation-architecture.md
+++ b/docs/plans/slice-representation-architecture.md
@@ -350,6 +350,12 @@ mandatory shared-RAM invariant. IDs were allocated in the authoritative ledger.
 
 ## Implementation progress
 
-Stage A is in progress on `codex/codec-resource-contract`: shared policy,
-disposable real-codec qualification and tests. Production adoption is false.
-See ../codec-resource-qualification.md for evidence limits and review state.
+Stage A merged in PR #74 (`1995a4b`): shared policy, disposable real-codec
+qualification and tests; both final-head reviews and CI passed. Production
+resource-policy adoption is still false. See ../codec-resource-qualification.md.
+
+Stage B is in progress on `codex/streamznn-reader-adapter`: the standalone
+StreamZNN stream API, neutral dispatcher and Slice compatibility adapter.
+See [Stage B evidence and boundaries](../streamznn-reader-adapter.md). Expanded
+zstd coverage found the legacy native-window units mismatch (INC-064); qualify
+and correct it in Stage C's explicit policy gate, preserving old seal semantics.

--- a/docs/plans/slice-representation-architecture.md
+++ b/docs/plans/slice-representation-architecture.md
@@ -354,8 +354,10 @@ Stage A merged in PR #74 (`1995a4b`): shared policy, disposable real-codec
 qualification and tests; both final-head reviews and CI passed. Production
 resource-policy adoption is still false. See ../codec-resource-qualification.md.
 
-Stage B is in progress on `codex/streamznn-reader-adapter`: the standalone
-StreamZNN stream API, neutral dispatcher and Slice compatibility adapter.
+Stage B is implemented on `codex/streamznn-reader-adapter`: the standalone
+StreamZNN stream API, neutral dispatcher and Slice compatibility adapter. Local
+Grok CLI round 1 accepted `c272891`; local qualification passed. Remote review
+and merge remain pending; no live deployment or admission widening is claimed.
 See [Stage B evidence and boundaries](../streamznn-reader-adapter.md). Expanded
 zstd coverage found the legacy native-window units mismatch (INC-064); qualify
 and correct it in Stage C's explicit policy gate, preserving old seal semantics.

--- a/docs/streamznn-reader-adapter.md
+++ b/docs/streamznn-reader-adapter.md
@@ -1,0 +1,75 @@
+# Stage B — reusable original-byte reading
+
+Implements DEC-139's reader extraction without changing archive bytes, Slice
+seals, production RAM policy, destination transactions or filesystem admission.
+Stage A merged in PR #74. Stage B does **not** remove the large-frame Slice limit.
+
+## Shared mechanism, separate caller contracts
+
+- `streamznn.iter_decompress` owns the one StreamZNN container-framing loop.
+  It accepts a caller-owned binary stream, including non-seekable short-reading
+  streams, and yields one restored frame at a time. Input requests are bounded.
+  Iterator closure does not close the source; callback and source exceptions
+  retain their identity. No paths, subprocesses or ModelArk imports are added.
+- Standalone `decompress_to`, `decompress_file` and `verify_sha256` reuse that
+  loop. Their default frame decoder remains the historical permissive ZipNN
+  decoder, with its existing native exceptions and atomic publication wrappers.
+  No Slice allowlist or 64 MiB cap is imposed on these existing callers.
+- `streamznn.read_zipnn_frame` extracts Slice's narrower validated lossless-byte
+  frame interpretation. It checks encoded/decoded sizes, mode fields and framed
+  length agreement before payload/native decoding. Whole-ZipNN and StreamZNN
+  use the same parser. A neutral optional decoder hook receives a validated blob;
+  it does not itself create a worker or make arbitrary whole blobs streamable.
+- `modelark.artifact_io` dispatches raw/whole/StreamZNN/zstd input without source
+  acquisition or transport knowledge. Encoded-frame, decoded-frame, consumer-read
+  and zstd-window ceilings are explicit separate fields. Expected original length
+  is enforced; the consuming transaction still verifies the original digest.
+- Slice's `decoding.original_stream` is now a small compatibility/error adapter.
+  It maps neutral failures to the existing `SOURCE_DECODE_*` codes and supplies
+  the same legacy bound to every limit. Source confinement, per-read attachment
+  checks, source/destination IO attribution and fence ownership remain external.
+
+The standalone default iterator's optional decoded/total bounds are post-decode
+checks, **not native RAM protection**. Slice injects the strict frame reader so
+its declared frame bounds are checked before native decoding. Callback-provided
+frame readers are trusted code responsible for consuming exactly their frame and
+honoring their own IO/resource bounds. The same distinction applies to injected
+frame decoders: exceptions propagate; byte type/actual byte count are verified.
+The MIT header, standalone dependency boundary and on-disk container are retained.
+
+## Known zstd units mismatch — Stage C gate
+
+Expanded optional-codec coverage reproduced a pre-existing refusal, not a Stage B
+regression: a 256 KiB unknown-content-size zstd frame passes Slice's 64 MiB header
+ceiling but fails native decoding. The old `max_decode_bytes // 1024` setting
+becomes a 64 KiB native window ceiling with zstandard 0.25.0. Supplying a bytes-
+valued 64 MiB ceiling to that same native decoder restores the fixture completely.
+The [dependency implementation](https://github.com/indygreg/python-zstandard/blob/0.25.0/c-ext/decompressor.c)
+passes the setting directly to `ZSTD_DCtx_setMaxWindowSize`; its documentation's
+KiB description is inconsistent with the measured behavior.
+
+Stage B intentionally preserves the old native setting and has a regression
+asserting that known refusal. **Stage C must qualify and correct the units under
+the new explicit policy without reinterpreting old seals.** Add known/unknown
+content-size cases at/below/above the real window ceiling and exercise every
+applicable supported dependency backend. Track this as INC-064 in the ledger.
+Do not claim that zstd window compatibility or shared RAM admission is complete.
+
+## Validation and review
+
+- Codec-focused suite with optional zstandard 0.25.0: **105 passed**, no skips.
+  The dependency was installed only into a disposable test directory, not a live
+  runtime. Tests cover short/non-seekable IO, real writer dtype variants, exact
+  bounds, malformed/unsupported headers, total length, callback/source failures,
+  atomic wrapper preservation, caller ownership and dependency separation.
+- Installed-dependency synthetic qualification: **13/13 passed** at both observed
+  failure sizes, whole and streamed, compression/canary/full restoration. Report:
+  `/tmp/modelark-codec-qualification-mu8c_x8m/result.json`; source hashes identify
+  the implementation tested. This requalifies existing StreamZNN wrapper reuse,
+  not large-frame admission through Slice.
+- Full-project Ruff passed. Full Slice regression is running separately.
+- Local Grok CLI review precedes the new PR; at most three local rounds, then
+  at most three Greptile/Codex rounds for this stage, per DEC-140.
+
+No live deployment, archive/catalog access, physical USB writes, RAM-policy
+adoption, stored-export switch, P2P service or compression fallback change.

--- a/docs/streamznn-reader-adapter.md
+++ b/docs/streamznn-reader-adapter.md
@@ -67,9 +67,19 @@ Do not claim that zstd window compatibility or shared RAM admission is complete.
   `/tmp/modelark-codec-qualification-mu8c_x8m/result.json`; source hashes identify
   the implementation tested. This requalifies existing StreamZNN wrapper reuse,
   not large-frame admission through Slice.
-- Full-project Ruff passed. Full Slice regression is running separately.
-- Local Grok CLI review precedes the new PR; at most three local rounds, then
-  at most three Greptile/Codex rounds for this stage, per DEC-140.
+- Full Slice regression: **1,346 passed, 5 optional-codec skips** in 520.58 seconds.
+  The separate zstd-enabled run above covers the optional codec paths.
+- Fresh wheel, installed without dependencies into a disposable directory:
+  **93 passed** with zstd enabled and tests copied outside the checkout. Runtime
+  import locations were asserted; all three changed modules matched source bytes.
+- Full-project Ruff and diff whitespace checks passed.
+- Local Grok CLI round 1 **ACCEPTED c272891** with no actionable findings. It
+  confirmed that INC-064 stays at the Stage C policy gate, not a refactor fix.
+  Session: `f2d466e1-014e-452f-8e06-9b81ee841275`. The first CLI invocation ended
+  after review commentary; a same-session follow-up supplied its explicit verdict.
+  This is one review round, not a second code-review iteration. This evidence
+  update changes documentation only; remote review covers the pushed PR head.
+  At most three Greptile/Codex rounds remain available for Stage B, per DEC-140.
 
 No live deployment, archive/catalog access, physical USB writes, RAM-policy
 adoption, stored-export switch, P2P service or compression fallback change.

--- a/modelark/artifact_io.py
+++ b/modelark/artifact_io.py
@@ -1,0 +1,207 @@
+"""Retrieval-free original-byte streams with bounded codec allocations.
+
+The bound limits individual stored/decoded ZipNN frames and zstd windows, not
+the native codecs' total working set. No tensor input, whole-file scratch, or
+unbounded ``read()`` is accepted. Large legacy whole-ZipNN files fail closed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import streamznn
+
+
+class DecodeError(Exception):
+    """Neutral decode refusal; caller maps kind to its own error contract."""
+
+    def __init__(self, kind, detail=""):
+        self.kind, self.detail = kind, detail
+        super().__init__(f"{kind}: {detail}")
+
+
+@dataclass(frozen=True)
+class DecodeLimits:
+    """Explicit, distinct buffer bounds, not a native RAM admission policy."""
+
+    stored_frame_bytes: int
+    decoded_frame_bytes: int
+    read_bytes: int
+    zstd_window_bytes: int
+
+    def __post_init__(self):
+        if any(type(value) is not int or value <= 0 for value in (
+                self.stored_frame_bytes, self.decoded_frame_bytes,
+                self.read_bytes, self.zstd_window_bytes)):
+            raise ValueError("positive integer decoding bounds required")
+
+
+def _refuse(code="INVALID", detail=""):
+    raise DecodeError(code, detail)
+
+
+def _exact(stream, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = stream.read(size - len(data))
+        if not chunk:
+            _refuse(detail="truncated container")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def _prefix(stream, size):
+    data = b""
+    while len(data) < size:
+        chunk = stream.read(size - len(data))
+        if not chunk:
+            break
+        data += chunk
+    return data
+
+
+def _chunks(stream, compressed, expected, limits):
+    try:
+        yield from _decoded_chunks(stream, compressed, expected, limits)
+    except streamznn.DecodeLimitExceeded as exc:
+        raise DecodeError("LIMIT", str(exc)) from exc
+    except streamznn.UnsupportedFrame as exc:
+        raise DecodeError("UNSUPPORTED", str(exc)) from exc
+    except streamznn.StreamZnnError as exc:
+        raise DecodeError("INVALID", str(exc)) from exc
+
+
+def _decoded_chunks(stream, compressed, expected, limits):
+    if not compressed:
+        while chunk := stream.read(min(limits.read_bytes, 1 << 20)):
+            yield chunk
+        return
+    prefix = _prefix(stream, 5)
+
+    def frame(source, stored_length, remaining, prefix=b""):
+        return streamznn.read_zipnn_frame(
+            source, max_stored_bytes=limits.stored_frame_bytes,
+            max_decoded_bytes=limits.decoded_frame_bytes, remaining_bytes=remaining,
+            stored_length=stored_length, prefix=prefix,
+            read_size=min(limits.read_bytes, 1 << 20))
+
+    if prefix == streamznn.MAGIC:
+        yield from streamznn.iter_decompress(
+            stream, prefix=prefix, max_stored_frame_bytes=limits.stored_frame_bytes,
+            max_decoded_frame_bytes=limits.decoded_frame_bytes, max_total_bytes=expected,
+            read_size=min(limits.read_bytes, 1 << 20), frame_reader=frame)
+    elif prefix.startswith(b"ZN"):
+        yield frame(stream, None, expected, prefix)
+        if stream.read(1):
+            _refuse(detail="trailing whole-ZipNN data")
+    elif prefix.startswith(b"\x28\xb5\x2f\xfd"):
+        try:
+            import zstandard as zstd
+        except ImportError as exc:
+            raise DecodeError("UNSUPPORTED", "zstandard is not installed") from exc
+        # zstd's maximum regenerated block is 128 KiB. Feeding no more
+        # than limit/128KiB input bytes bounds even maximally dense RLE output
+        # before Python gets the opportunity to check its length.
+        if limits.decoded_frame_bytes < 128 << 10:
+            _refuse("LIMIT", "zstd requires a 128 KiB decoding bound")
+        header = prefix
+        while True:
+            try:
+                params = zstd.get_frame_parameters(header)
+                break
+            except zstd.ZstdError:
+                if len(header) >= 18:
+                    _refuse(detail="invalid zstd header")
+                header += _exact(stream, 1)
+        if (params.window_size > limits.zstd_window_bytes
+                or params.content_size not in (zstd.CONTENTSIZE_UNKNOWN, zstd.CONTENTSIZE_ERROR)
+                and params.content_size > expected):
+            _refuse("LIMIT", "zstd window/content exceeds bound")
+        # Preserve legacy Slice's native setting in this no-widening extraction.
+        # zstandard 0.25.0 actually treats this setting as bytes, despite its
+        # documentation's KiB wording. Stage C must qualify the units correction;
+        # this conversion currently refuses some frames below our header ceiling.
+        decoder = zstd.ZstdDecompressor(max_window_size=max(1, limits.zstd_window_bytes // 1024)).decompressobj()
+        pending = header
+        try:
+            while pending:
+                data = decoder.decompress(pending)
+                if len(data) > limits.decoded_frame_bytes:
+                    _refuse("LIMIT", "zstd output block exceeds bound")
+                if data:
+                    yield data
+                if decoder.eof:
+                    if decoder.unused_data or stream.read(1):
+                        _refuse(detail="trailing/concatenated zstd data")
+                    break
+                pending = stream.read(max(1, limits.decoded_frame_bytes // (128 << 10)))
+            if not decoder.eof:
+                _refuse(detail="truncated zstd frame")
+        except zstd.ZstdError as exc:
+            raise DecodeError("INVALID", "zstd decoder refused frame") from exc
+    else:
+        _refuse("UNSUPPORTED", "unknown compressed container")
+
+
+class _CheckedInput:
+    """Check every underlying read; callbacks and IO errors keep their identity."""
+
+    def __init__(self, stream, read_bytes, check):
+        self.stream, self.read_bytes, self.check = stream, read_bytes, check
+
+    def read(self, size):
+        self.check()
+        size = min(size, self.read_bytes, 1 << 20)
+        chunk = self.stream.read(size)
+        if not isinstance(chunk, bytes) or len(chunk) > size:
+            _refuse(detail="source did not honor bounded binary read")
+        self.check()
+        return chunk
+
+
+class _OriginalStream:
+    def __init__(self, stream, compressed, expected, limits, check):
+        self._chunks = iter(_chunks(_CheckedInput(stream, limits.read_bytes, check),
+                                    compressed, expected, limits))
+        self._pending = b""
+        self._offset = 0
+        self._total = 0
+        self._expected, self._limit, self._check = expected, limits.read_bytes, check
+        self._done = False
+
+    def read(self, size=-1):
+        if type(size) is not int or size < 0 or size > self._limit:
+            _refuse("LIMIT", "explicit bounded read size required")
+        self._check()
+        if not size or self._done:
+            return b""
+        if self._offset == len(self._pending):
+            try:
+                self._pending = next(self._chunks)
+                self._offset = 0
+            except StopIteration:
+                self._done = True
+                if self._total != self._expected:
+                    _refuse(detail="decoded size differs from sealed original size")
+                return b""
+            self._total += len(self._pending)
+            if self._total > self._expected:
+                _refuse("LIMIT", "decoded total exceeds sealed original size")
+        end = min(self._offset + size, len(self._pending))
+        data = self._pending[self._offset:end]
+        self._offset = end
+        self._check()
+        return data
+
+
+def original_stream(stream, *, compressed, expected_bytes, limits: DecodeLimits,
+                    check=lambda: None):
+    """Decode caller-owned bytes; no paths, source authority or output publication.
+
+    Original length is enforced here; the caller must verify the original digest.
+    Resource isolation/admission is not added by these explicit buffer limits.
+    """
+    if type(expected_bytes) is not int or expected_bytes < 0:
+        raise ValueError("nonnegative original size required")
+    if not isinstance(limits, DecodeLimits):
+        raise ValueError("explicit DecodeLimits required")
+    return _OriginalStream(stream, compressed, expected_bytes, limits, check)

--- a/modelark/slice/decoding.py
+++ b/modelark/slice/decoding.py
@@ -1,164 +1,30 @@
-"""Retrieval-free original-byte streams with bounded codec allocations.
-
-The bound limits individual stored/decoded ZipNN frames and zstd windows, not
-the native codecs' total working set. No tensor input, whole-file scratch, or
-unbounded ``read()`` is accepted. Large legacy whole-ZipNN files fail closed.
-"""
+"""Slice original-output adapter; archive authority stays in LocalArchiveReader."""
 from __future__ import annotations
 
-import struct
+from modelark import artifact_io
 
 from .transaction import TransferRefusal
 
 
-def _refuse(code="SOURCE_DECODE_INVALID", detail=""):
-    raise TransferRefusal(code, detail)
-
-
-def _exact(stream, size):
-    data = bytearray()
-    while len(data) < size:
-        chunk = stream.read(size - len(data))
-        if not chunk:
-            _refuse(detail="truncated container")
-        data.extend(chunk)
-    return bytes(data)
-
-
-def _zipnn_frame(stream, prefix, limit, remaining, stored_length=None):
-    header = prefix + _exact(stream, 32 - len(prefix))
-    original = int.from_bytes(header[16:24], "little")
-    stored = int.from_bytes(header[24:32], "little")
-    if original > limit or stored > limit or original > remaining:
-        _refuse("SOURCE_DECODE_LIMIT", "ZipNN frame exceeds configured or artifact bound")
-    # Only the byte-lossless, non-streaming 0.5 header layout used by this
-    # archive writer is supported. Tensor/shape, delta and lossy modes cannot
-    # be safely inferred from catalog SourceEvidence and must never reach C.
-    if (header[:4] != b"ZN\x00\x05" or header[8] != 1
-            or any(header[9:14]) or header[15] not in (1, 2, 4, 5, 6)
-            or header[7] not in (0, 1) or header[6] not in (0, 1)
-            or header[5] not in (10, 220)):
-        _refuse("SOURCE_DECODE_UNSUPPORTED", "unsupported ZipNN header")
-    if (stored < 32 or original == 0 or (stored_length is not None and stored != stored_length)
-            or header[14] > 26):
-        _refuse(detail="inconsistent ZipNN frame header")
-    from zipnn import ZipNN
-    blob = header + _exact(stream, stored - 32)
-    try:
-        decoded = ZipNN(input_format="byte", threads=1).decompress(blob)
-    except Exception as exc:
-        raise TransferRefusal("SOURCE_DECODE_INVALID", "ZipNN decoder refused frame") from exc
-    if not isinstance(decoded, (bytes, bytearray, memoryview)) or len(decoded) != original:
-        _refuse(detail="ZipNN decoded size differs from header")
-    return bytes(decoded)
-
-
-def _chunks(stream, compressed, expected, limit):
-    if not compressed:
-        while chunk := stream.read(min(limit, 1 << 20)):
-            yield chunk
-        return
-    prefix = stream.read(5)
-    if prefix == b"SZNN\x01":
-        remaining = expected
-        while length := stream.read(4):
-            if len(length) != 4:
-                _refuse(detail="truncated StreamZNN frame length")
-            size = struct.unpack("<I", length)[0]
-            if size > limit:
-                _refuse("SOURCE_DECODE_LIMIT", "stored StreamZNN frame exceeds bound")
-            if size < 32:
-                _refuse(detail="short StreamZNN frame")
-            data = _zipnn_frame(stream, b"", limit, remaining, size)
-            remaining -= len(data)
-            yield data
-    elif prefix.startswith(b"ZN"):
-        yield _zipnn_frame(stream, prefix, limit, expected)
-        if stream.read(1):
-            _refuse(detail="trailing whole-ZipNN data")
-    elif prefix.startswith(b"\x28\xb5\x2f\xfd"):
-        try:
-            import zstandard as zstd
-        except ImportError as exc:
-            raise TransferRefusal("SOURCE_DECODE_UNSUPPORTED", "zstandard is not installed") from exc
-        # zstd's maximum regenerated block is 128 KiB. Feeding no more
-        # than limit/128KiB input bytes bounds even maximally dense RLE output
-        # before Python gets the opportunity to check its length.
-        if limit < 128 << 10:
-            _refuse("SOURCE_DECODE_LIMIT", "zstd requires a 128 KiB decoding bound")
-        header = prefix
-        while True:
-            try:
-                params = zstd.get_frame_parameters(header)
-                break
-            except zstd.ZstdError:
-                if len(header) >= 18:
-                    _refuse(detail="invalid zstd header")
-                header += _exact(stream, 1)
-        if (params.window_size > limit
-                or params.content_size not in (zstd.CONTENTSIZE_UNKNOWN, zstd.CONTENTSIZE_ERROR)
-                and params.content_size > expected):
-            _refuse("SOURCE_DECODE_LIMIT", "zstd window/content exceeds bound")
-        decoder = zstd.ZstdDecompressor(max_window_size=max(1, limit // 1024)).decompressobj()
-        pending = header
-        try:
-            while pending:
-                data = decoder.decompress(pending)
-                if len(data) > limit:
-                    _refuse("SOURCE_DECODE_LIMIT", "zstd output block exceeds bound")
-                if data:
-                    yield data
-                if decoder.eof:
-                    if decoder.unused_data or stream.read(1):
-                        _refuse(detail="trailing/concatenated zstd data")
-                    break
-                pending = stream.read(max(1, limit // (128 << 10)))
-            if not decoder.eof:
-                _refuse(detail="truncated zstd frame")
-        except zstd.ZstdError as exc:
-            raise TransferRefusal("SOURCE_DECODE_INVALID", "zstd decoder refused frame") from exc
-    else:
-        _refuse("SOURCE_DECODE_UNSUPPORTED", "unknown compressed container")
-
-
-class _OriginalStream:
-    def __init__(self, stream, compressed, expected, limit, check):
-        self._chunks = iter(_chunks(stream, compressed, expected, limit))
-        self._pending = b""
-        self._offset = 0
-        self._total = 0
-        self._expected, self._limit, self._check = expected, limit, check
-        self._done = False
+class _SliceOriginalStream:
+    def __init__(self, reader):
+        self._reader = reader
 
     def read(self, size=-1):
-        if type(size) is not int or size < 0 or size > self._limit:
-            _refuse("SOURCE_DECODE_LIMIT", "explicit bounded read size required")
-        self._check()
-        if not size or self._done:
-            return b""
-        if self._offset == len(self._pending):
-            try:
-                self._pending = next(self._chunks)
-                self._offset = 0
-            except StopIteration:
-                self._done = True
-                if self._total != self._expected:
-                    _refuse(detail="decoded size differs from sealed original size")
-                return b""
-            self._total += len(self._pending)
-            if self._total > self._expected:
-                _refuse("SOURCE_DECODE_LIMIT", "decoded total exceeds sealed original size")
-        end = min(self._offset + size, len(self._pending))
-        data = self._pending[self._offset:end]
-        self._offset = end
-        self._check()
-        return data
+        try:
+            return self._reader.read(size)
+        except artifact_io.DecodeError as exc:
+            raise TransferRefusal(f"SOURCE_DECODE_{exc.kind}", exc.detail) from exc
 
 
 def original_stream(stream, *, compressed, expected_bytes, max_decode_bytes=64 << 20,
                     check=lambda: None):
-    """Wrap an already confined binary stream; caller retains descriptor ownership."""
-    if (type(expected_bytes) is not int or expected_bytes < 0
-            or type(max_decode_bytes) is not int or max_decode_bytes <= 0):
-        raise ValueError("nonnegative original size and positive decoding bound required")
-    return _OriginalStream(stream, compressed, expected_bytes, max_decode_bytes, check)
+    """Preserve legacy Slice limits; caller retains source descriptor ownership.
+
+    No new seal/resource policy or large-frame admission is enabled in Stage B.
+    """
+    limits = artifact_io.DecodeLimits(max_decode_bytes, max_decode_bytes,
+                                      max_decode_bytes, max_decode_bytes)
+    return _SliceOriginalStream(artifact_io.original_stream(
+        stream, compressed=compressed, expected_bytes=expected_bytes,
+        limits=limits, check=check))

--- a/modelark/streamznn.py
+++ b/modelark/streamznn.py
@@ -81,6 +81,14 @@ class OutputCapExceeded(StreamZnnError):
     """Compression would exceed the caller's guaranteed on-disk output ceiling."""
 
 
+class DecodeLimitExceeded(StreamZnnError):
+    """A frame or decoded total exceeds an explicit reader bound."""
+
+
+class UnsupportedFrame(StreamZnnError):
+    """A frame is outside the supported lossless byte-header contract."""
+
+
 def _zipnn(*, dtype: str | None = None, threads: int = 0):
     # Import only on an actual codec operation. Planning imports this module for
     # constants and must not initialize Torch or surface its dependency warnings.
@@ -92,18 +100,135 @@ def _zipnn(*, dtype: str | None = None, threads: int = 0):
     return ZipNN(**kwargs)
 
 
-def _read_exact(fh: BinaryIO, n: int) -> bytes:
+def _read_exact(fh: BinaryIO, n: int, *, read_size: int = _HASH_READ) -> bytes:
     """Read exactly `n` bytes from `fh` or raise StreamZnnError. A short read means a
     truncated/corrupt container — it is never returned as a silently-short slice."""
     if n < 0:
         raise StreamZnnError(f"negative read length {n}")
     buf = bytearray()
     while len(buf) < n:
-        piece = fh.read(n - len(buf))
+        piece = fh.read(min(read_size, n - len(buf)))
         if not piece:
             raise StreamZnnError(f"truncated container: wanted {n} bytes, got {len(buf)}")
+        if len(piece) > min(read_size, n - len(buf)):
+            raise StreamZnnError("source returned more bytes than requested")
         buf.extend(piece)
     return bytes(buf)
+
+
+def _positive_bound(value, name, *, zero=False):
+    if type(value) is not int or value < (0 if zero else 1):
+        raise ValueError(f"invalid {name}")
+
+
+def read_zipnn_frame(stream: BinaryIO, *, max_stored_bytes: int, max_decoded_bytes: int,
+                     remaining_bytes: int, stored_length: int | None = None,
+                     prefix: bytes = b"", read_size: int = _HASH_READ,
+                     decode_frame: Callable[[bytes], object] | None = None) -> bytes:
+    """Read one validated, non-streaming ZipNN 0.5 lossless byte frame.
+
+    Validate declared sizes/modes before reading the payload or calling native code.
+    `prefix` contains bytes already consumed from this frame. The optional decoder
+    receives the complete validated blob; its exceptions propagate unchanged.
+    This bounds buffers, NOT native working memory. Caller owns the input stream.
+    This deliberately narrower API does not change legacy path-wrapper support.
+    """
+    for value, name in ((max_stored_bytes, "stored bound"),
+                        (max_decoded_bytes, "decoded bound"), (read_size, "read size")):
+        _positive_bound(value, name)
+    _positive_bound(remaining_bytes, "remaining bytes", zero=True)
+    if not isinstance(prefix, bytes) or len(prefix) > 32:
+        raise ValueError("invalid frame prefix")
+    if stored_length is not None:
+        _positive_bound(stored_length, "stored length")
+        if stored_length > max_stored_bytes:
+            raise DecodeLimitExceeded("stored ZipNN frame exceeds bound")
+        if stored_length < 32:
+            raise StreamZnnError("short ZipNN frame")
+    header = prefix + _read_exact(stream, 32 - len(prefix), read_size=read_size)
+    original = int.from_bytes(header[16:24], "little")
+    stored = int.from_bytes(header[24:32], "little")
+    if original > max_decoded_bytes or stored > max_stored_bytes or original > remaining_bytes:
+        raise DecodeLimitExceeded("ZipNN frame exceeds configured or artifact bound")
+    if (header[:4] != b"ZN\x00\x05" or header[8] != 1
+            or any(header[9:14]) or header[15] not in (1, 2, 4, 5, 6)
+            or header[7] not in (0, 1) or header[6] not in (0, 1)
+            or header[5] not in (10, 220)):
+        raise UnsupportedFrame("unsupported ZipNN header")
+    if (stored < 32 or original == 0 or (stored_length is not None and stored != stored_length)
+            or header[14] > 26):
+        raise StreamZnnError("inconsistent ZipNN frame header")
+    blob = header + _read_exact(stream, stored - 32, read_size=read_size)
+    if decode_frame is None:
+        from zipnn import ZipNN
+        try:
+            decoded = ZipNN(input_format="byte", threads=1).decompress(blob)
+        except Exception as exc:
+            raise StreamZnnError("ZipNN decoder refused frame") from exc
+    else:
+        decoded = decode_frame(blob)
+    if (not isinstance(decoded, (bytes, bytearray, memoryview))
+            or (decoded.nbytes if isinstance(decoded, memoryview) else len(decoded)) != original):
+        raise StreamZnnError("ZipNN decoded size differs from header")
+    return bytes(decoded)
+
+
+def iter_decompress(stream: BinaryIO, *, max_stored_frame_bytes: int = _MAX_BLOB,
+                    max_decoded_frame_bytes: int | None = None,
+                    max_total_bytes: int | None = None, read_size: int = _HASH_READ,
+                    prefix: bytes = b"",
+                    frame_reader: Callable[[BinaryIO, int, int | None], bytes] | None = None):
+    """Yield restored frames from a caller-owned, possibly non-seekable stream.
+
+    Handles short reads and bounds each input request by `read_size`. `prefix`
+    is container magic already consumed by a dispatcher. Closing the iterator
+    never closes the supplied stream. IO and frame-reader exceptions propagate.
+
+    Default decoding preserves the historical standalone ZipNN acceptance and
+    exception behavior. Optional decoded/total limits are checked AFTER default
+    native decoding, not a native RAM guard. For untrusted byte frames, inject a
+    reader using `read_zipnn_frame` to validate headers before native allocation.
+    The callback receives (stream, stored_length, remaining_total_or_None), must
+    consume exactly that frame, and retains its own input-read/resource policy.
+    """
+    _positive_bound(max_stored_frame_bytes, "stored frame bound")
+    _positive_bound(read_size, "read size")
+    for value, name in ((max_decoded_frame_bytes, "decoded frame bound"),
+                        (max_total_bytes, "total bound")):
+        if value is not None:
+            _positive_bound(value, name, zero=True)
+    if not isinstance(prefix, bytes) or len(prefix) > len(MAGIC):
+        raise ValueError("invalid container prefix")
+    magic = prefix + _read_exact(stream, len(MAGIC) - len(prefix), read_size=read_size)
+    if magic != MAGIC:
+        raise StreamZnnError(f"bad magic {magic!r}: not a StreamZNN container")
+    total = 0
+    while True:
+        head = stream.read(1)
+        if head == b"":
+            return
+        if len(head) != 1:
+            raise StreamZnnError("source returned more bytes than requested")
+        head += _read_exact(stream, _LEN.size - 1, read_size=read_size)
+        (blob_len,) = _LEN.unpack(head)
+        if blob_len == 0:
+            raise StreamZnnError("implausible frame length 0")
+        if blob_len > max_stored_frame_bytes:
+            raise DecodeLimitExceeded("stored StreamZNN frame exceeds bound")
+        remaining = None if max_total_bytes is None else max_total_bytes - total
+        if frame_reader is None:
+            blob = _read_exact(stream, blob_len, read_size=read_size)
+            restored = bytes(_zipnn().decompress(blob))
+        else:
+            restored = frame_reader(stream, blob_len, remaining)
+        if not isinstance(restored, bytes):
+            raise StreamZnnError("frame reader must return bytes")
+        if max_decoded_frame_bytes is not None and len(restored) > max_decoded_frame_bytes:
+            raise DecodeLimitExceeded("decoded StreamZNN frame exceeds bound")
+        total += len(restored)
+        if max_total_bytes is not None and total > max_total_bytes:
+            raise DecodeLimitExceeded("decoded total exceeds bound")
+        yield restored
 
 
 def compress_file(
@@ -183,20 +308,7 @@ def decompress_to(src: StrPath, sink: Sink) -> None:
     problem; propagates ZipNN's own error on a corrupt blob.
     """
     with open(src, "rb") as fi:
-        magic = _read_exact(fi, len(MAGIC))
-        if magic != MAGIC:
-            raise StreamZnnError(f"bad magic {magic!r}: not a StreamZNN container")
-        while True:
-            head = fi.read(_LEN.size)
-            if head == b"":
-                return                          # clean EOF exactly at a frame boundary
-            if len(head) != _LEN.size:
-                raise StreamZnnError(f"truncated frame length: got {len(head)} of {_LEN.size} bytes")
-            (blob_len,) = _LEN.unpack(head)
-            if blob_len == 0 or blob_len > _MAX_BLOB:
-                raise StreamZnnError(f"implausible frame length {blob_len}")
-            blob = _read_exact(fi, blob_len)
-            restored: bytes = bytes(_zipnn().decompress(blob))
+        for restored in iter_decompress(fi):
             sink(restored)
 
 

--- a/tests/test_artifact_io.py
+++ b/tests/test_artifact_io.py
@@ -1,0 +1,215 @@
+"""Stage B: real writer compatibility, neutral boundaries, and legacy Slice policy."""
+import ast
+import hashlib
+import io
+from pathlib import Path
+import struct
+
+import pytest
+
+from modelark import artifact_io as aio, compress, streamznn as sz
+from modelark.slice.decoding import original_stream as slice_stream
+from modelark.slice.transaction import TransferRefusal
+
+
+class ShortSource:
+    """No seek/fileno/path; check every bounded input request."""
+
+    def __init__(self, data, *, piece=3, ceiling=4096):
+        self.buffer = io.BytesIO(data)
+        self.piece, self.ceiling = piece, ceiling
+        self.requests = []
+
+    def read(self, size):
+        assert 0 < size <= self.ceiling
+        self.requests.append(size)
+        return self.buffer.read(min(size, self.piece))
+
+
+def drain(reader, size=17):
+    return b"".join(iter(lambda: reader.read(size), b""))
+
+
+def frame(data):
+    return bytes(sz._zipnn(dtype="bfloat16", threads=1).compress(bytearray(data)))
+
+
+def container(*frames):
+    return sz.MAGIC + b"".join(struct.pack("<I", len(blob)) + blob for blob in frames)
+
+
+def limits(stored=4096, decoded=4096, read=17, window=1 << 20):
+    return aio.DecodeLimits(stored, decoded, read, window)
+
+
+@pytest.mark.parametrize("codec", [compress.CODEC_RAW, compress.CODEC_WHOLE, compress.CODEC_STREAM])
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16", "float32"])
+def test_real_writer_short_nonseekable_roundtrip(codec, dtype, tmp_path):
+    original = b"\0\x3f" * 512
+    src, stored, restored = (tmp_path / name for name in ("in", "misleading.blob", "out"))
+    src.write_bytes(original)
+    if codec == compress.CODEC_RAW:
+        stored.write_bytes(original)
+    else:
+        if codec == compress.CODEC_STREAM:
+            sz.compress_file(src, stored, dtype=dtype, threads=1, chunk_bytes=257)
+        else:
+            compress.compress_file(src, stored, codec=codec, dtype=dtype, threads=1)
+        assert compress.canary_ok(stored, hashlib.sha256(original).hexdigest())
+        compress.decompress_file(stored, restored)
+        assert restored.read_bytes() == original
+    source = ShortSource(stored.read_bytes())
+    reader = aio.original_stream(source, compressed=codec != compress.CODEC_RAW,
+                                 expected_bytes=len(original), limits=limits())
+    assert drain(reader) == original
+    assert max(source.requests) <= 17
+    assert not source.buffer.closed
+    assert src.read_bytes() == original
+    # The Slice adapter must use the same mechanism without new policy/seal behavior.
+    assert drain(slice_stream(ShortSource(stored.read_bytes()),
+                              compressed=codec != compress.CODEC_RAW,
+                              expected_bytes=len(original), max_decode_bytes=4096)) == original
+
+
+def test_separate_encoded_decoded_and_consumer_bounds():
+    original = bytes(range(16))
+    blob = frame(original)
+    assert len(blob) > len(original)  # framing overhead is distinct from original length
+    def reader(bound):
+        return aio.original_stream(ShortSource(blob, ceiling=2), compressed=True,
+                                   expected_bytes=len(original), limits=bound)
+    assert drain(reader(limits(len(blob), len(original), 2)), 2) == original
+    for bound in (limits(len(blob) - 1, len(original), 2),
+                  limits(len(blob), len(original) - 1, 2)):
+        with pytest.raises(aio.DecodeError, match="LIMIT"):
+            drain(reader(bound), 2)
+    with pytest.raises(aio.DecodeError, match="LIMIT"):
+        reader(limits(len(blob), len(original), 2)).read(3)
+
+
+@pytest.mark.parametrize("field,value,error", [(16, 4097, "LIMIT"), (24, 4097, "LIMIT"),
+                                               (16, 0, "INVALID"), (24, 31, "INVALID")])
+def test_frame_size_checks_precede_native(field, value, error, monkeypatch):
+    blob = bytearray(frame(bytes(128)))
+    blob[field:field + 8] = value.to_bytes(8, "little")
+    monkeypatch.setattr("zipnn.ZipNN.decompress", lambda *a, **k: pytest.fail("native reached"))
+    with pytest.raises(aio.DecodeError, match=error):
+        drain(aio.original_stream(ShortSource(blob), compressed=True,
+                                  expected_bytes=128, limits=limits()))
+
+
+@pytest.mark.parametrize("field,value", [(3, 6), (5, 0), (6, 2), (7, 2), (8, 2),
+                                        (9, 1), (10, 1), (11, 1), (12, 1), (13, 1), (15, 3)])
+def test_unsupported_byte_modes_never_reach_native(field, value, monkeypatch):
+    blob = bytearray(frame(bytes(128)))
+    blob[field] = value
+    monkeypatch.setattr("zipnn.ZipNN.decompress", lambda *a, **k: pytest.fail("native reached"))
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_UNSUPPORTED"):
+        drain(slice_stream(ShortSource(blob), compressed=True, expected_bytes=128,
+                           max_decode_bytes=4096))
+
+
+@pytest.mark.parametrize("transform", [lambda b: b[:-1], lambda b: b + b"x",
+                                       lambda b: container(b) + b"xx"])
+def test_corrupt_frame_and_trailing_content(transform):
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_INVALID"):
+        drain(slice_stream(ShortSource(transform(frame(bytes(128)))), compressed=True,
+                           expected_bytes=128, max_decode_bytes=4096))
+
+
+def test_stream_later_frame_over_total_refuses_before_second_native(monkeypatch):
+    blob = frame(bytes(128))
+    real = sz.read_zipnn_frame
+    decoded = []
+    def counted(*a, **kw):
+        value = real(*a, **kw)
+        decoded.append(value)
+        return value
+    monkeypatch.setattr(sz, "read_zipnn_frame", counted)
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_LIMIT"):
+        drain(slice_stream(ShortSource(container(blob, blob)), compressed=True,
+                           expected_bytes=128, max_decode_bytes=4096))
+    assert len(decoded) == 1
+
+
+@pytest.mark.parametrize("compressed,data,expected", [(False, b"abc", 4),
+                                                     (False, b"abc", 2),
+                                                     (True, sz.MAGIC, 1)])
+def test_total_length_mismatch(compressed, data, expected):
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE"):
+        drain(slice_stream(ShortSource(data), compressed=compressed, expected_bytes=expected,
+                           max_decode_bytes=4096))
+
+
+@pytest.mark.parametrize("where", ["source", "check"])
+def test_source_and_cancellation_exceptions_keep_identity(where):
+    problem = OSError("source changed") if where == "source" else TransferRefusal("STOP_REQUESTED")
+    events = []
+    class Source:
+        def read(self, size):
+            events.append("read")
+            if where == "source":
+                raise problem
+            return b"abc"
+    def check():
+        events.append("check")
+        if where == "check" and "read" in events:
+            raise problem
+    reader = slice_stream(Source(), compressed=False, expected_bytes=3, check=check)
+    with pytest.raises(type(problem)) as caught:
+        reader.read(3)
+    assert caught.value is problem
+
+
+def test_buffered_output_is_rechecked_without_new_source_read():
+    source = ShortSource(frame(bytes(128)))
+    stop = False
+    def check():
+        if stop:
+            raise TransferRefusal("STOP_REQUESTED")
+    reader = slice_stream(source, compressed=True, expected_bytes=128,
+                          max_decode_bytes=4096, check=check)
+    assert reader.read(1) == b"\0"
+    reads = len(source.requests)
+    stop = True
+    with pytest.raises(TransferRefusal, match="STOP_REQUESTED"):
+        reader.read(1)
+    assert len(source.requests) == reads
+
+
+def test_modules_keep_authority_and_standalone_boundaries():
+    for module in (aio, sz):
+        tree = ast.parse(Path(module.__file__).read_text())
+        imports = [name.name for node in ast.walk(tree) if isinstance(node, ast.Import)
+                   for name in node.names]
+        imports += [node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)]
+        assert not any("slice" in name or "catalog" in name or "sqlite" in name
+                       or "subprocess" in name for name in imports)
+    assert not any(isinstance(node, ast.ImportFrom) and node.level
+                   for node in ast.walk(ast.parse(Path(sz.__file__).read_text())))
+
+
+def test_optional_zstd_short_reads_and_distinct_window_limit():
+    zstd = pytest.importorskip("zstandard")
+    original = bytes(10000)
+    blob = zstd.ZstdCompressor(write_content_size=False).compress(original)
+    def reader(window):
+        return aio.original_stream(ShortSource(blob), compressed=True,
+                                   expected_bytes=len(original),
+                                   limits=limits(decoded=512 << 10, window=window))
+    assert drain(reader(64 << 20)) == original
+    with pytest.raises(aio.DecodeError, match="LIMIT"):
+        drain(reader(1024))
+
+
+def test_legacy_zstd_native_window_conversion_remains_a_known_limit():
+    """Stage B preserves legacy admission; Stage C must qualify the units repair."""
+    zstd = pytest.importorskip("zstandard")
+    original = bytes(256 << 10)
+    blob = zstd.ZstdCompressor(write_content_size=False).compress(original)
+    assert zstd.get_frame_parameters(blob).window_size == len(original)
+    # The dependency's native API accepts this bytes-valued ceiling. The existing
+    # Slice /1024 conversion is narrower than its 64 MiB header check suggests.
+    assert zstd.ZstdDecompressor(max_window_size=64 << 20).decompressobj().decompress(blob) == original
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_INVALID"):
+        drain(slice_stream(ShortSource(blob), compressed=True, expected_bytes=len(original)))

--- a/tests/test_streamznn_readers.py
+++ b/tests/test_streamznn_readers.py
@@ -1,0 +1,189 @@
+"""Caller-owned StreamZNN primitives preserve standalone wrappers and failures."""
+import hashlib
+import importlib.util
+import io
+import struct
+from array import array
+
+import pytest
+
+from modelark import streamznn as sz
+
+
+class ShortReader:
+    def __init__(self, data, piece=1):
+        self.inner = io.BytesIO(data)
+        self.piece = piece
+        self.requests = []
+
+    def read(self, size):
+        assert 0 < size <= 7
+        self.requests.append(size)
+        return self.inner.read(min(size, self.piece))
+
+
+def fake_container(*frames):
+    return sz.MAGIC + b"".join(struct.pack("<I", len(frame)) + frame for frame in frames)
+
+
+def test_default_iterator_and_all_path_wrappers_share_loop(tmp_path, monkeypatch):
+    blob = fake_container(b"abc", b"def")
+    native_calls = []
+    class Codec:
+        def decompress(self, blob):
+            native_calls.append(blob)
+            return blob.upper()
+    monkeypatch.setattr(sz, "_zipnn", lambda: Codec())
+    source = ShortReader(blob)
+    assert b"".join(sz.iter_decompress(source, read_size=7)) == b"ABCDEF"
+    assert native_calls == [b"abc", b"def"]
+    assert not source.inner.closed
+    # Permissive legacy wrappers must NOT acquire Slice's strict frame parser.
+    monkeypatch.setattr(sz, "read_zipnn_frame", lambda *a, **kw: pytest.fail("narrowed wrapper"))
+    real_iterator = sz.iter_decompress
+    calls = []
+    def iterator(*a, **kw):
+        calls.append(a[0])
+        yield from real_iterator(*a, **kw)
+    monkeypatch.setattr(sz, "iter_decompress", iterator)
+    src, out = tmp_path / "stored", tmp_path / "restored"
+    src.write_bytes(blob)
+    parts = []
+    sz.decompress_to(src, parts.append)
+    assert b"".join(parts) == b"ABCDEF"
+    assert sz.verify_sha256(src, hashlib.sha256(b"ABCDEF").hexdigest())
+    sz.decompress_file(src, out)
+    assert out.read_bytes() == b"ABCDEF"
+    assert len(calls) == 3
+    assert all(stream.closed for stream in calls)
+
+
+def test_iterator_close_does_not_read_next_frame_or_close_input():
+    source = ShortReader(fake_container(b"abc", b"def"))
+    seen = []
+    def reader(stream, length, remaining):
+        seen.append((length, remaining))
+        return sz._read_exact(stream, length, read_size=7)
+    iterator = sz.iter_decompress(source, max_total_bytes=6, read_size=7, frame_reader=reader)
+    assert next(iterator) == b"abc"
+    consumed = source.inner.tell()
+    iterator.close()
+    assert source.inner.tell() == consumed
+    assert seen == [(3, 6)]
+    assert not source.inner.closed
+
+
+@pytest.mark.parametrize("bound", [{"max_stored_frame_bytes": 2},
+                                  {"max_decoded_frame_bytes": 2}, {"max_total_bytes": 2}])
+def test_explicit_iterator_bounds(bound):
+    source = ShortReader(fake_container(b"abc"))
+    def reader(stream, length, remaining):
+        return sz._read_exact(stream, length, read_size=7)
+    with pytest.raises(sz.DecodeLimitExceeded):
+        list(sz.iter_decompress(source, read_size=7, frame_reader=reader, **bound))
+    assert not source.inner.closed
+
+
+@pytest.mark.parametrize("data", [b"", b"S", b"XXXXX", sz.MAGIC + b"\0",
+                                 sz.MAGIC + bytes(4), fake_container(b"abc")[:-1]])
+def test_short_or_invalid_container(data, monkeypatch):
+    monkeypatch.setattr(sz, "_zipnn", lambda: pytest.fail("truncation reached native"))
+    with pytest.raises(sz.StreamZnnError):
+        list(sz.iter_decompress(ShortReader(data), read_size=7))
+
+
+@pytest.mark.parametrize("value", [False, -1, 0, 1.5, "7"])
+def test_input_read_bound_is_strict(value):
+    with pytest.raises(ValueError):
+        list(sz.iter_decompress(io.BytesIO(sz.MAGIC), read_size=value))
+
+
+def test_callback_and_source_failures_keep_identity(tmp_path, monkeypatch):
+    problem = RuntimeError("codec callback failed")
+    def fail(*args):
+        raise problem
+    source = ShortReader(fake_container(b"abc"))
+    with pytest.raises(RuntimeError) as caught:
+        list(sz.iter_decompress(source, read_size=7, frame_reader=fail))
+    assert caught.value is problem
+    assert not source.inner.closed
+    class Broken:
+        def read(self, size):
+            raise problem
+    with pytest.raises(RuntimeError) as caught:
+        list(sz.iter_decompress(Broken()))
+    assert caught.value is problem
+    class Codec:
+        decompress = staticmethod(fail)
+    monkeypatch.setattr(sz, "_zipnn", lambda: Codec())
+    src, dst = tmp_path / "stored", tmp_path / "out"
+    src.write_bytes(fake_container(b"abc"))
+    dst.write_bytes(b"keep")
+    with pytest.raises(RuntimeError) as caught:
+        sz.decompress_file(src, dst)
+    assert caught.value is problem
+    assert dst.read_bytes() == b"keep"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["out", "stored"]
+
+
+def test_sink_failure_closes_owned_path_handle(tmp_path, monkeypatch):
+    src = tmp_path / "stored"
+    src.write_bytes(sz.MAGIC)
+    opened = []
+    real_open = open
+    def tracked_open(*a, **kw):
+        stream = real_open(*a, **kw)
+        opened.append(stream)
+        return stream
+    monkeypatch.setattr(sz, "open", tracked_open, raising=False)
+    monkeypatch.setattr(sz, "iter_decompress", lambda stream: iter([b"data"]))
+    problem = OSError("destination full")
+    def sink(data):
+        raise problem
+    with pytest.raises(OSError) as caught:
+        sz.decompress_to(src, sink)
+    assert caught.value is problem
+    assert opened[0].closed
+
+
+def header(original=4, stored=36):
+    value = bytearray(32)
+    value[:4] = b"ZN\x00\x05"
+    value[5], value[8], value[15] = 10, 1, 1
+    value[16:24] = original.to_bytes(8, "little")
+    value[24:32] = stored.to_bytes(8, "little")
+    return bytes(value)
+
+
+@pytest.mark.parametrize("dtype", [1, 2, 4, 5, 6])
+def test_validated_frame_supported_byte_dtype_headers(dtype):
+    data = bytearray(header() + b"abcd")
+    data[15] = dtype
+    source = ShortReader(data)
+    assert sz.read_zipnn_frame(source, max_stored_bytes=36, max_decoded_bytes=4,
+                               remaining_bytes=4, read_size=7,
+                               decode_frame=lambda blob: blob[-4:]) == b"abcd"
+    assert not source.inner.closed
+
+
+def test_validated_frame_injection_and_actual_byte_count():
+    # A typed memoryview's len counts elements, not bytes.
+    data = header(original=1, stored=33) + b"a"
+    with pytest.raises(sz.StreamZnnError, match="decoded size"):
+        sz.read_zipnn_frame(io.BytesIO(data), max_stored_bytes=33, max_decoded_bytes=1,
+                            remaining_bytes=1, decode_frame=lambda b: memoryview(array("I", [1])))
+    problem = RuntimeError("cancel decoder")
+    def fail(blob):
+        raise problem
+    with pytest.raises(RuntimeError) as caught:
+        sz.read_zipnn_frame(io.BytesIO(data), max_stored_bytes=33, max_decoded_bytes=1,
+                            remaining_bytes=1, decode_frame=fail)
+    assert caught.value is problem
+
+
+def test_standalone_import_by_file_without_modelark_package():
+    spec = importlib.util.spec_from_file_location("standalone_streamznn", sz.__file__)
+    standalone = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(standalone)
+    assert list(standalone.iter_decompress(ShortReader(sz.MAGIC), read_size=7)) == []
+    assert standalone.MAGIC == sz.MAGIC


### PR DESCRIPTION
## Stage B: reuse standalone StreamZNN reading in Slice

Follows merged Stage A PR #74 and DEC-139/140. **No large-frame admission,
new RAM policy, seal migration or live deployment.**

### What changes

- Extract one caller-owned StreamZNN iterator with short-read/non-seekable support,
  bounded input, explicit frame/total limits and neutral callbacks.
- Keep standalone MIT canary/restore wrappers on that same framing loop, retaining
  broader native ZipNN support, exceptions and atomic publication behavior.
- Extract Slice's validated lossless-byte frame reader; whole-ZipNN and StreamZNN
  now share it. Validate encoded/decoded/remaining sizes before native decoding.
- Move raw/whole/stream/zstd dispatch to neutral `artifact_io`; Slice keeps a small
  error/legacy-policy adapter. No source retrieval, catalog or destination authority
  enters the codec layer. Existing per-read attachment and IO attribution remain.

### Compatibility boundary

Slice still uses its existing 64 MiB policy. Standalone path wrappers do not adopt
that limit. Default standalone decoded/total iterator checks are post-decode, not
a native RAM guard; Slice injects the pre-native validated reader.

Expanded zstd tests found **pre-existing INC-064**: a window units conversion
means some valid frames pass the header check but fail the narrower native bound.
Stage B preserves and tests that refusal. Qualifying the correction with explicit
new policy and old-seal compatibility is a Stage C requirement, not hidden here.

### Validation

- Full Slice suite: **1,346 passed, 5 optional-codec skips**.
- Focused codec tests with zstd 0.25.0 enabled: **105 passed**, no skips.
- Independently installed wheel, copied tests, verified package imports and source
  bytes, with zstd enabled: **93 passed**.
- Installed-dependency whole/stream compression-canary-restore qualification at
  both prior failure sizes: **13/13 passed**, hashes in the private report noted
  in `docs/streamznn-reader-adapter.md`. Not a large-frame Slice delivery test.
- Full-project Ruff and whitespace checks passed.

### Review and next steps

Grok CLI **ACCEPTED c272891 in local round 1**, no actionable findings. The final
local evidence commit changes documentation only. Remote round 1 will explicitly
request both Greptile and Codex on the pushed head, up to three rounds total for
this stage, with a stop-and-summarize gate if findings remain after round 3.

Next is Stage C's guarded large-frame reader and sealed resource/admission policy,
including zstd units qualification. Broader caller adoption and full Slice delivery
qualification follow. User retains merge control. No live catalog/archive/USB,
service, filesystem allowlist, compression fallback, stored-export or P2P change.
