### PR TITLE
feat(codec): qualify guarded frame worker before Slice rollout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,14 @@ scope not covered by the described activity, or a genuinely required user choice
 Missing credentials or sudo access are execution blockers, not missing consent:
 provide the exact necessary command instead of asking for redundant authorization.
 This preference does not bypass tool permissions or safety boundaries.
+
+## Explicit merge handoff (2026-09-10)
+
+When required current-head reviews and CI establish that a PR is ready to
+merge, promptly lead with a **bold, explicit request for the operator to merge
+it**, including the PR link. Do not bury the merge request in a status summary.
+If a ready PR is still open when encountered again, stop advancing dependent
+work and **tell the operator clearly and in bold that it is awaiting their
+merge**. Do not silently let merge-ready PRs linger. Verify current readiness
+before repeating that claim; report actual blockers for PRs that are not ready.
+The operator retains merge authority unless explicitly delegated for that PR.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3019,3 +3019,16 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: AGENTS.md carries the ongoing rule. PR #74's remaining third round must cover reconciliation and this policy record. The explicit no-review-wait merge exception for already-merged PR #73 does not apply to #74 or future PRs; merge authority remains separately scoped.
 - `docs_updated`: AGENTS.md, docs/decision_log.md
 - `related`: DEC-139, BOT-008
+
+### INC-064: Slice's zstd native window setting uses a mismatched unit conversion
+- `id`: INC-064
+- `date`: 2026-09-10
+- `status`: open
+- `triggered_by`: DEC-139 Stage B expanded real optional-zstd short-read/window coverage.
+- `symptom`: A synthetic 256 KiB unknown-content-size zstd frame passes the legacy 64 MiB header-window check but returns SOURCE_DECODE_INVALID from the native decoder with zstandard 0.25.0. Direct decoding with a bytes-valued 64 MiB setting succeeds completely.
+- `root_cause`: Existing Slice code divides its byte ceiling by 1024 before passing max_window_size. The tested dependency passes that setting directly to ZSTD_DCtx_setMaxWindowSize in bytes, despite its Python documentation describing KiB; the effective native ceiling is 64 KiB under the default Slice bound.
+- `blast_radius`: Some otherwise valid zstd Slice sources refuse; this observation does not imply corruption, an unsafe allocation or a failed physical test. Existing whole/StreamZNN and standalone compression/restore policies are separate.
+- `why_not_caught_earlier`: Earlier optional-codec tests either skipped locally or used smaller windows; they checked header refusal without testing a larger accepted header against the native setting.
+- `planned_remediation`: Stage B preserves existing refusal behavior and records an executable regression. Stage C's new explicit policy must qualify the units repair, known/unknown-content windows and supported backends without widening old sealed approvals. The work item and test gate are in docs/streamznn-reader-adapter.md.
+- `docs_updated`: docs/decision_log.md, docs/streamznn-reader-adapter.md, docs/plans/slice-representation-architecture.md
+- `related`: DEC-138, DEC-139, modelark/artifact_io.py, tests/test_artifact_io.py

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3009,6 +3009,9 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 #### HYP-002 results — 2026-09-10
 - Unchanged-code synthetic runs completed all 13 checks using Python 3.10.12 / ZipNN 0.5.4 with dev Torch 2.13.0 (f336101) and installed-dependency Torch 2.14.0 (4311547). Both whole and StreamZNN compression/canary/restore passed original hashes at both observed failure sizes under one 8 GiB AS policy plus 2 GiB sampled headroom. Final report: `/tmp/modelark-codec-qualification-b8fo65k8/result.json`, with implementation fingerprints; max RSS 1,765,400,576 bytes and virtual peak 6,774,444,032 bytes. This supports feasibility for these fixtures, not general host-OOM protection, native binary attestation or production caller adoption. HYP remains open for the broader qualification/integration gates.
 
+#### HYP-002 results — Stage C1, 2026-09-10
+- The actual bounded parent/worker transport passed original hashes for 67,108,864, 99,630,640 and 409,993,344 byte whole frames on installed-dependency Python 3.10.12 / ZipNN 0.5.4 / Torch 2.14.0. The same run passed compression/canary/restore for whole and StreamZNN at all three sizes plus deliberate allocation refusal: 22 checks under the unchanged 8 GiB AS + 2 GiB sampled-headroom methodology. Report `/tmp/modelark-codec-qualification-jdbv4mjy/result.json` fingerprints the implementation. Parent output pieces were at most 65,536 bytes; live RSS snapshots stayed roughly 19–24 MB, not a peak-RSS proof or reservation. C1 is a non-production prerequisite; policy sealing, all-frame admission, zstd repair and shared production caller adoption remain open gates. See docs/guarded-codec-worker.md and the approved plan's mutable progress section.
+
 ### DEC-140: Review every pushed PR head with both reviewers within the stage's three-round budget
 - `id`: DEC-140
 - `date`: 2026-09-10

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3012,6 +3012,8 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 #### HYP-002 results — Stage C1, 2026-09-10
 - The actual bounded parent/worker transport passed original hashes for 67,108,864, 99,630,640 and 409,993,344 byte whole frames on installed-dependency Python 3.10.12 / ZipNN 0.5.4 / Torch 2.14.0. The same run passed compression/canary/restore for whole and StreamZNN at all three sizes plus deliberate allocation refusal: 22 checks under the unchanged 8 GiB AS + 2 GiB sampled-headroom methodology. Report `/tmp/modelark-codec-qualification-jdbv4mjy/result.json` fingerprints the implementation. Parent output pieces were at most 65,536 bytes; live RSS snapshots stayed roughly 19–24 MB, not a peak-RSS proof or reservation. C1 is a non-production prerequisite; policy sealing, all-frame admission, zstd repair and shared production caller adoption remain open gates. See docs/guarded-codec-worker.md and the approved plan's mutable progress section.
 
+- Follow-up unchanged-code qualification after pinning the worker bootstrap against cwd shadow packages and separating error emission from output emission also passed all 22 checks: `/tmp/modelark-codec-qualification-_8of6ito/result.json`. Parent live RSS snapshots remained roughly 19–24 MB; current-exec virtual peak stayed below 48 MB. These corrections preserve the same memory-policy methodology and no-production-rollout boundary; the earlier result remains historical evidence for its fingerprint, not attestation of later code.
+
 ### DEC-140: Review every pushed PR head with both reviewers within the stage's three-round budget
 - `id`: DEC-140
 - `date`: 2026-09-10

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3014,6 +3014,8 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 
 - Follow-up unchanged-code qualification after pinning the worker bootstrap against cwd shadow packages and separating error emission from output emission also passed all 22 checks: `/tmp/modelark-codec-qualification-_8of6ito/result.json`. Parent live RSS snapshots remained roughly 19–24 MB; current-exec virtual peak stayed below 48 MB. These corrections preserve the same memory-policy methodology and no-production-rollout boundary; the earlier result remains historical evidence for its fingerprint, not attestation of later code.
 
+- DEC-142's startup/session correction passed all 22 checks in `/tmp/modelark-codec-qualification-lg9hbfo8/result.json`, fingerprinting seven implementation files. Every guarded decode now records its own exact admission observation and actual child Python 3.10.12 / ZipNN 0.5.4 / Torch 2.14.0 identity, observed 8 GiB AS ceiling and parent-death signal. The three original hashes and 65,536-byte output ceiling passed; parent live RSS snapshots remained approximately 19–24 MB. Previous reports lack this per-child provenance and do not prove guards preceded site hooks; their earlier hash/output observations remain historical evidence. Separate disposable hook tests pass on Python 3.10.12 and 3.12.12. No production adoption, arbitrary-input safety or physical acceptance is inferred.
+
 ### DEC-140: Review every pushed PR head with both reviewers within the stage's three-round budget
 - `id`: DEC-140
 - `date`: 2026-09-10
@@ -3037,3 +3039,25 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `planned_remediation`: Stage B preserves existing refusal behavior and records an executable regression. Stage C's new explicit policy must qualify the units repair, known/unknown-content windows and supported backends without widening old sealed approvals. The work item and test gate are in docs/streamznn-reader-adapter.md.
 - `docs_updated`: docs/decision_log.md, docs/streamznn-reader-adapter.md, docs/plans/slice-representation-architecture.md
 - `related`: DEC-138, DEC-139, modelark/artifact_io.py, tests/test_artifact_io.py
+
+### DEC-141: Explicitly hand off merge-ready PRs and stop when they linger
+- `id`: DEC-141
+- `date`: 2026-09-10
+- `status`: accepted
+- `triggered_by`: Operator merged PR #75 and corrected the workflow: promptly request merges in bold, and stop and call out ready PRs left open instead of letting them hang.
+- `decision`: After verifying required reviews and CI against the current head, lead with a bold merge request and the PR link. If that ready PR remains open when encountered later, stop advancing dependent work and issue a clear bold reminder that it awaits the operator's merge. Do not describe blocked or unreviewed PRs as ready. Merge authority remains with the operator unless separately delegated for the specific PR.
+- `rationale`: Review completion needs an unmistakable human handoff; quietly reporting status or continuing dependent work leaves approved stages stranded.
+- `impact`: Project agent guidance and the active review monitor carry the same handoff rule; existing review budgets and exact-head requirements remain unchanged.
+- `docs_updated`: AGENTS.md, docs/decision_log.md
+- `related`: DEC-139, DEC-140, BOT-008
+
+### DEC-142: Own the complete codec-worker startup and evidence boundary
+- `id`: DEC-142
+- `date`: 2026-09-10
+- `status`: accepted
+- `triggered_by`: Operator approved the architectural correction after PR #76 Codex findings 3984989491, 3984989497 and 3984989506 exposed startup-hook ordering, stdio collision and actual-worker provenance gaps.
+- `decision`: Use one isolated no-site startup routine for the decoder and compression/canary/restore qualification children. Bind parent lifetime and install the existing shared memory policy before dependency site initialization. Keep the protocol writer above stdio descriptors. Frame and validate bounded actual-child runtime/guard evidence separately from original bytes, and publish completion evidence with the exact parent admission sample only after successful full consumption and child exit.
+- `rationale`: An isolated interpreter and guarded decode were insufficient while startup behavior and qualification provenance remained implicit. Own this bounded launch/session contract instead of accumulating consumer-specific patches or new RAM formulas.
+- `impact`: C1 worker protocol moves to internal v2; no archive-format, live data, old-seal, production Slice or compression rollout changes. The approved fix may proceed locally despite the partial first remote round; both reviewers remain required, cumulative review caps remain unchanged and the operator retains merge authority.
+- `docs_updated`: docs/decision_log.md, docs/guarded-codec-worker.md, docs/plans/slice-representation-architecture.md
+- `related`: DEC-138, DEC-139, DEC-140, DEC-141, HYP-002

--- a/docs/guarded-codec-worker.md
+++ b/docs/guarded-codec-worker.md
@@ -18,16 +18,28 @@ stdout/stderr share a separately drained diagnostics pipe. No source path,
 archive/catalog/destination handle or fence FD is passed. `close_fds=True` closes
 unrelated inheritable handles. This is descriptor confinement, not a filesystem
 or credential sandbox: the worker still runs under the caller's OS account.
-Python starts with an isolated search path and an explicit root for the package
+Python starts with `-I -S`, an isolated search path and an explicit root for the package
 the parent imported. The caller's current directory/PYTHONPATH cannot substitute
 a different `modelark.codec_worker` and bypass the intended guard/protocol.
+Automatic site initialization is suppressed: the shared `codec_process` startup
+installs parent-death and memory guards before explicitly calling `site.main()`.
+That restores the intended virtualenv/dependency paths on Python 3.10/3.12 while
+ensuring `.pth` and `sitecustomize` hooks run under the guards. Compression,
+canary and restore qualification children use this same startup routine. Trusted
+stdlib/project bootstrap imports still precede the guards; this is not protection
+against malicious installed code. The dedicated writer is duplicated above fd 2
+when necessary, so closed standard descriptors cannot redirect it into diagnostics.
 
 The child installs Linux parent-death SIGKILL and the irreversible AS/core-file
 limits before importing ZipNN. It validates the frame again and requires input
 EOF before native decoding. Native code holds the indivisible frame in the
-child; the parent transfers at most 64 KiB at a time. Only a checked 9-byte
-status/length header controls output: success must match the original size;
-errors are capped at 4096 bytes. Diagnostic reads are bounded and retain at most
+child; the parent transfers at most 64 KiB at a time. Internal protocol v2 has a
+checked 9-byte status/length header per record. Success is one runtime record
+(at most 8192 bytes), then original output whose length must match the frame;
+failure is one error record capped at 4096 bytes. Missing, repeated, malformed or
+out-of-order metadata refuses. A failure after either success record starts
+produces a nonzero exit, never an appended error frame inside original bytes.
+Diagnostic reads are bounded and retain at most
 8192 bytes; arbitrary native diagnostics are not reflected into refusal text.
 
 Nonblocking input/output/diagnostic pipes share one selector. Attachment/stop
@@ -37,6 +49,12 @@ deadline. Synchronous caller-owned source reads can still block in the kernel;
 the helper does not promise to interrupt a stalled filesystem syscall.
 
 Iterator EOF requires exact output length, protocol EOF and zero child exit.
+Only then does `on_complete` receive the exact parent admission sample and the
+validated runtime record from this child: interpreter/venv identity, observed AS
+limits and parent-death signal, and loaded ZipNN/Torch module paths plus their
+installed distribution versions. These observations are not binary attestation.
+The callback is not invoked on early close, incomplete output or child failure;
+metadata never becomes part of the original-byte iterator or digest.
 Context exit alone is never success. Early close or any consumer/source failure
 kills and reaps the worker before returning; source ownership is not transferred.
 The caller must still verify the complete original digest and control publication.
@@ -52,7 +70,7 @@ Command (from the checkout, using the installed candidate's dependency Python):
 python -m scripts.qualify_codec_resources --large --guarded-reader
 ```
 
-Final local report: `/tmp/modelark-codec-qualification-_8of6ito/result.json`.
+Current local report: `/tmp/modelark-codec-qualification-lg9hbfo8/result.json`.
 All **22 checks passed** on Python 3.10.12 / ZipNN 0.5.4 / Torch 2.14.0:
 
 - Deliberate allocation refusal under the shared guard.
@@ -66,20 +84,27 @@ Parent live RSS snapshots were approximately 19–24 MB and unchanged across eac
 guarded decode; current-exec virtual peak stayed below 48 MB. These are not a
 sampling proof of peak resident allocation. `ru_maxrss` also includes inherited
 pre-exec history and is not attributed to this worker transport. The report
-fingerprints all six relevant implementation files and refuses changes during
+fingerprints all seven relevant implementation files and refuses changes during
 the run. This is measured support for these fixtures/runtime, not arbitrary
 input safety, host-wide memory reservation or a physical USB qualification.
 
 Transport tests cover short input, noisy diagnostics, malformed/oversize/short/
 trailing worker messages, exit failure after output, native abort, resource
 refusal, cancellation during input/compute/output, consumer ENOSPC, source EIO,
-early close, descriptor inheritance, spawn failure and parent death. Existing
+early close, descriptor inheritance, spawn failure and parent death. New coverage
+includes all eight closed-stdio combinations, metadata failure phases, exact
+admission provenance, guarded site hooks and parent death/cancellation inside a
+blocking startup hook. Existing
 standalone/Slice codec tests remain the compatibility gate.
 
-Local tests: **170 passed** with optional zstd installed, including 28 supervisor/
-worker tests. The complete existing Slice suite passed **1346**, with 5 optional
-skips. Ruff passed across the project. A rebuilt wheel exercises the real isolated
-worker bootstrap outside the checkout as well as the neutral/standalone readers.
+Local tests after the startup refactor: **208 passed** with optional zstd installed.
+The four disposable startup tests also pass on Python 3.12.12 (the main local suite
+uses 3.10.12). The complete existing Slice suite previously passed **1346**, with
+5 optional skips, on the preceding C1 head; production Slice code is unchanged.
+Ruff passed across the project. A rebuilt wheel passed **196 tests** outside the
+checkout, including the actual isolated worker and the new startup tests; package
+origin was asserted before testing. The final local review is tracked separately;
+previous-head results are not new-head approval.
 
 Grok CLI round 1 accepted its inspected C1 boundary and reported two low-severity
 failure-reporting observations: appending a second status after output begins,
@@ -87,8 +112,14 @@ and labelling parent-guard initialization as RAM refusal. Both were corrected by
 separating decoding from response emission and distinguishing initialization
 failure. An independent local probe also found cwd package shadowing at worker
 launch; the pinned isolated bootstrap and its regression address it. The final
-report above was rerun after all three corrections. Round 2 reviews these changes;
-no final local/remote approval or complete Stage C acceptance is implied here.
+earlier report `_8of6ito` was rerun after all three corrections; Grok round 2
+accepted that head. Codex's first remote pass then exposed site hooks preceding
+guards, a closed-stdio protocol collision and missing actual-child provenance.
+DEC-142 records the approved common startup/session correction, now requalified
+in `lg9hbfo8`. The earlier reports remain historical hash/output evidence but do
+not establish this stronger startup ordering or per-child provenance. Greptile's
+quota refusal is not review acceptance. Stage C counters remain cumulative; no
+final new-head local/remote approval or complete Stage C acceptance is implied.
 
 ## Remaining Stage C2 gate
 

--- a/docs/guarded-codec-worker.md
+++ b/docs/guarded-codec-worker.md
@@ -1,0 +1,92 @@
+# Guarded codec worker — Stage C1
+
+This is the worker/transport prerequisite of DEC-139 Stage C, not a Slice rollout.
+No production caller imports `codec_supervisor`. Existing direct/native/FAT seals,
+64 MiB decoding, zstd behavior, restore and compression remain unchanged.
+
+## Boundary
+
+`codec_supervisor.guarded_zipnn_frame` is a context-managed iterator for one
+ZipNN work unit. The caller retains its source and must enclose this context in
+its source/fence lifetime. It checks the shared standalone 32-byte header before
+payload IO or spawning, observes current host/visible-cgroup headroom with the
+same function used by compression qualification, and applies the explicit
+`CodecMemoryPolicy` admission. There is no production default numeric profile.
+
+The fresh worker receives only frame data on stdin and a dedicated protocol FD;
+stdout/stderr share a separately drained diagnostics pipe. No source path,
+archive/catalog/destination handle or fence FD is passed. `close_fds=True` closes
+unrelated inheritable handles. This is descriptor confinement, not a filesystem
+or credential sandbox: the worker still runs under the caller's OS account.
+
+The child installs Linux parent-death SIGKILL and the irreversible AS/core-file
+limits before importing ZipNN. It validates the frame again and requires input
+EOF before native decoding. Native code holds the indivisible frame in the
+child; the parent transfers at most 64 KiB at a time. Only a checked 9-byte
+status/length header controls output: success must match the original size;
+errors are capped at 4096 bytes. Diagnostic reads are bounded and retain at most
+8192 bytes; arbitrary native diagnostics are not reflected into refusal text.
+
+Nonblocking input/output/diagnostic pipes share one selector. Attachment/stop
+checks run between source reads, IO events and output chunks, and every 50 ms
+while native work or a pipe is idle. This is a polling interval, not a job
+deadline. Synchronous caller-owned source reads can still block in the kernel;
+the helper does not promise to interrupt a stalled filesystem syscall.
+
+Iterator EOF requires exact output length, protocol EOF and zero child exit.
+Context exit alone is never success. Early close or any consumer/source failure
+kills and reaps the worker before returning; source ownership is not transferred.
+The caller must still verify the complete original digest and control publication.
+Linux parent-death signaling follows the spawning **thread**, which must stay
+alive throughout the context. No persistent worker, nested canary worker, scratch
+file, GPU workflow or unbounded parent accumulation is introduced.
+
+## Qualification
+
+Command (from the checkout, using the installed candidate's dependency Python):
+
+```text
+python -m scripts.qualify_codec_resources --large --guarded-reader
+```
+
+Disposable report: `/tmp/modelark-codec-qualification-jdbv4mjy/result.json`.
+All **22 checks passed** on Python 3.10.12 / ZipNN 0.5.4 / Torch 2.14.0:
+
+- Deliberate allocation refusal under the shared guard.
+- Compression, canary and restore of whole/StreamZNN fixtures at 67,108,864,
+  99,630,640 and 409,993,344 original bytes under 8 GiB AS + 2 GiB sampled headroom.
+- The new parent/worker path decoded each whole fixture to the original digest,
+  delivering pieces no larger than 65,536 bytes. The 64 MiB fixture exercises a
+  default StreamZNN-sized native work unit, not integrated container traversal.
+
+Parent live RSS snapshots were approximately 19–24 MB and unchanged across each
+guarded decode; current-exec virtual peak was 47,804,416 bytes. These are not a
+sampling proof of peak resident allocation. `ru_maxrss` also includes inherited
+pre-exec history and is not attributed to this worker transport. The report
+fingerprints all six relevant implementation files and refuses changes during
+the run. This is measured support for these fixtures/runtime, not arbitrary
+input safety, host-wide memory reservation or a physical USB qualification.
+
+Transport tests cover short input, noisy diagnostics, malformed/oversize/short/
+trailing worker messages, exit failure after output, native abort, resource
+refusal, cancellation during input/compute/output, consumer ENOSPC, source EIO,
+early close, descriptor inheritance, spawn failure and parent death. Existing
+standalone/Slice codec tests remain the compatibility gate.
+
+## Remaining Stage C2 gate
+
+Before any larger Slice approval becomes executable:
+
+- Integrate bounded frame chunks into the shared StreamZNN traversal and neutral
+  dispatcher; do not accumulate a whole frame back in the parent.
+- Bind a qualified versioned policy into all direct/native/FAT canonical seals.
+  Keep legacy approvals and their legacy zstd-window conversion unchanged.
+- Qualify the corrected zstd units (INC-064) under the new policy.
+- Inspect every relevant attached candidate/frame before destination mutation or
+  FAT attempt consumption, preserving alternatives, waiting and native resume.
+- Prove helper lifetime stays inside real source fences on stop, unplug and
+  destination failure; then exercise the full transaction/public CLI path.
+
+Production writer/canary/restore RAM-policy adoption and the separately gated
+decoder consolidation remain required before claiming the overall parity arc is
+complete. Stage C1 alone is not permission to retest compressed Slice on the USB.

--- a/docs/guarded-codec-worker.md
+++ b/docs/guarded-codec-worker.md
@@ -18,6 +18,9 @@ stdout/stderr share a separately drained diagnostics pipe. No source path,
 archive/catalog/destination handle or fence FD is passed. `close_fds=True` closes
 unrelated inheritable handles. This is descriptor confinement, not a filesystem
 or credential sandbox: the worker still runs under the caller's OS account.
+Python starts with an isolated search path and an explicit root for the package
+the parent imported. The caller's current directory/PYTHONPATH cannot substitute
+a different `modelark.codec_worker` and bypass the intended guard/protocol.
 
 The child installs Linux parent-death SIGKILL and the irreversible AS/core-file
 limits before importing ZipNN. It validates the frame again and requires input
@@ -49,7 +52,7 @@ Command (from the checkout, using the installed candidate's dependency Python):
 python -m scripts.qualify_codec_resources --large --guarded-reader
 ```
 
-Disposable report: `/tmp/modelark-codec-qualification-jdbv4mjy/result.json`.
+Final local report: `/tmp/modelark-codec-qualification-_8of6ito/result.json`.
 All **22 checks passed** on Python 3.10.12 / ZipNN 0.5.4 / Torch 2.14.0:
 
 - Deliberate allocation refusal under the shared guard.
@@ -60,7 +63,7 @@ All **22 checks passed** on Python 3.10.12 / ZipNN 0.5.4 / Torch 2.14.0:
   default StreamZNN-sized native work unit, not integrated container traversal.
 
 Parent live RSS snapshots were approximately 19–24 MB and unchanged across each
-guarded decode; current-exec virtual peak was 47,804,416 bytes. These are not a
+guarded decode; current-exec virtual peak stayed below 48 MB. These are not a
 sampling proof of peak resident allocation. `ru_maxrss` also includes inherited
 pre-exec history and is not attributed to this worker transport. The report
 fingerprints all six relevant implementation files and refuses changes during
@@ -72,6 +75,20 @@ trailing worker messages, exit failure after output, native abort, resource
 refusal, cancellation during input/compute/output, consumer ENOSPC, source EIO,
 early close, descriptor inheritance, spawn failure and parent death. Existing
 standalone/Slice codec tests remain the compatibility gate.
+
+Local tests: **170 passed** with optional zstd installed, including 28 supervisor/
+worker tests. The complete existing Slice suite passed **1346**, with 5 optional
+skips. Ruff passed across the project. A rebuilt wheel exercises the real isolated
+worker bootstrap outside the checkout as well as the neutral/standalone readers.
+
+Grok CLI round 1 accepted its inspected C1 boundary and reported two low-severity
+failure-reporting observations: appending a second status after output begins,
+and labelling parent-guard initialization as RAM refusal. Both were corrected by
+separating decoding from response emission and distinguishing initialization
+failure. An independent local probe also found cwd package shadowing at worker
+launch; the pinned isolated bootstrap and its regression address it. The final
+report above was rerun after all three corrections. Round 2 reviews these changes;
+no final local/remote approval or complete Stage C acceptance is implied here.
 
 ## Remaining Stage C2 gate
 

--- a/docs/plans/slice-representation-architecture.md
+++ b/docs/plans/slice-representation-architecture.md
@@ -356,8 +356,17 @@ resource-policy adoption is still false. See ../codec-resource-qualification.md.
 
 Stage B is implemented on `codex/streamznn-reader-adapter`: the standalone
 StreamZNN stream API, neutral dispatcher and Slice compatibility adapter. Local
-Grok CLI round 1 accepted `c272891`; local qualification passed. Remote review
-and merge remain pending; no live deployment or admission widening is claimed.
+Grok CLI round 1 accepted `c272891`; local qualification passed. Both remote
+reviewers and all CI accepted final head `204c487`; PR #75 is still open as of
+the Stage C start. No live deployment or admission widening is claimed.
 See [Stage B evidence and boundaries](../streamznn-reader-adapter.md). Expanded
 zstd coverage found the legacy native-window units mismatch (INC-064); qualify
 and correct it in Stage C's explicit policy gate, preserving old seal semantics.
+
+Stage C is split at a non-executable integration boundary: C1 builds and qualifies
+the single-frame guarded worker; C2 wires bounded container output, all three
+approval policies and early candidate admission. C1 alone leaves every Slice
+limit unchanged. The Stage C review counter is retained across its incremental
+pushes; subdivision does not reset three fix/review rounds. See
+[C1 boundary and evidence](../guarded-codec-worker.md). No C2 implementation or
+complete Stage C acceptance is claimed yet.

--- a/docs/plans/slice-representation-architecture.md
+++ b/docs/plans/slice-representation-architecture.md
@@ -350,6 +350,12 @@ mandatory shared-RAM invariant. IDs were allocated in the authoritative ledger.
 
 ## Implementation progress
 
-Stage A is in progress on `codex/codec-resource-contract`: shared policy,
-disposable real-codec qualification and tests. Production adoption is false.
-See ../codec-resource-qualification.md for evidence limits and review state.
+Stage A merged in PR #74 (`1995a4b`): shared policy, disposable real-codec
+qualification and tests; both final-head reviews and CI passed. Production
+resource-policy adoption is still false. See ../codec-resource-qualification.md.
+
+Stage B is in progress on `codex/streamznn-reader-adapter`: the standalone
+StreamZNN stream API, neutral dispatcher and Slice compatibility adapter.
+See [Stage B evidence and boundaries](../streamznn-reader-adapter.md). Expanded
+zstd coverage found the legacy native-window units mismatch (INC-064); qualify
+and correct it in Stage C's explicit policy gate, preserving old seal semantics.

--- a/docs/plans/slice-representation-architecture.md
+++ b/docs/plans/slice-representation-architecture.md
@@ -357,8 +357,8 @@ resource-policy adoption is still false. See ../codec-resource-qualification.md.
 Stage B is implemented on `codex/streamznn-reader-adapter`: the standalone
 StreamZNN stream API, neutral dispatcher and Slice compatibility adapter. Local
 Grok CLI round 1 accepted `c272891`; local qualification passed. Both remote
-reviewers and all CI accepted final head `204c487`; PR #75 is still open as of
-the Stage C start. No live deployment or admission widening is claimed.
+reviewers and all CI accepted final head `204c487`; the operator merged PR #75
+as `37f0e1d`. No live deployment or admission widening is claimed.
 See [Stage B evidence and boundaries](../streamznn-reader-adapter.md). Expanded
 zstd coverage found the legacy native-window units mismatch (INC-064); qualify
 and correct it in Stage C's explicit policy gate, preserving old seal semantics.
@@ -370,3 +370,12 @@ limit unchanged. The Stage C review counter is retained across its incremental
 pushes; subdivision does not reset three fix/review rounds. See
 [C1 boundary and evidence](../guarded-codec-worker.md). No C2 implementation or
 complete Stage C acceptance is claimed yet.
+
+DEC-142 adds the approved shared startup/session correction within C1: no-site
+isolated bootstrap, guards before dependency initialization for decoder and
+qualification workers, protocol descriptors outside stdio, and bounded actual
+worker evidence paired with the exact admission sample. This changes neither
+archive formats nor old Slice approvals; C2 and production writer adoption remain
+separate gates. The operator approved implementing this correction while the
+first remote pass remains partial due to Greptile quota; that does not waive
+either reviewer, grant merge authority or reset the stage's counters.

--- a/docs/plans/slice-representation-architecture.md
+++ b/docs/plans/slice-representation-architecture.md
@@ -354,8 +354,10 @@ Stage A merged in PR #74 (`1995a4b`): shared policy, disposable real-codec
 qualification and tests; both final-head reviews and CI passed. Production
 resource-policy adoption is still false. See ../codec-resource-qualification.md.
 
-Stage B is in progress on `codex/streamznn-reader-adapter`: the standalone
-StreamZNN stream API, neutral dispatcher and Slice compatibility adapter.
+Stage B is implemented on `codex/streamznn-reader-adapter`: the standalone
+StreamZNN stream API, neutral dispatcher and Slice compatibility adapter. Local
+Grok CLI round 1 accepted `c272891`; local qualification passed. Remote review
+and merge remain pending; no live deployment or admission widening is claimed.
 See [Stage B evidence and boundaries](../streamznn-reader-adapter.md). Expanded
 zstd coverage found the legacy native-window units mismatch (INC-064); qualify
 and correct it in Stage C's explicit policy gate, preserving old seal semantics.

--- a/docs/streamznn-reader-adapter.md
+++ b/docs/streamznn-reader-adapter.md
@@ -1,0 +1,75 @@
+# Stage B — reusable original-byte reading
+
+Implements DEC-139's reader extraction without changing archive bytes, Slice
+seals, production RAM policy, destination transactions or filesystem admission.
+Stage A merged in PR #74. Stage B does **not** remove the large-frame Slice limit.
+
+## Shared mechanism, separate caller contracts
+
+- `streamznn.iter_decompress` owns the one StreamZNN container-framing loop.
+  It accepts a caller-owned binary stream, including non-seekable short-reading
+  streams, and yields one restored frame at a time. Input requests are bounded.
+  Iterator closure does not close the source; callback and source exceptions
+  retain their identity. No paths, subprocesses or ModelArk imports are added.
+- Standalone `decompress_to`, `decompress_file` and `verify_sha256` reuse that
+  loop. Their default frame decoder remains the historical permissive ZipNN
+  decoder, with its existing native exceptions and atomic publication wrappers.
+  No Slice allowlist or 64 MiB cap is imposed on these existing callers.
+- `streamznn.read_zipnn_frame` extracts Slice's narrower validated lossless-byte
+  frame interpretation. It checks encoded/decoded sizes, mode fields and framed
+  length agreement before payload/native decoding. Whole-ZipNN and StreamZNN
+  use the same parser. A neutral optional decoder hook receives a validated blob;
+  it does not itself create a worker or make arbitrary whole blobs streamable.
+- `modelark.artifact_io` dispatches raw/whole/StreamZNN/zstd input without source
+  acquisition or transport knowledge. Encoded-frame, decoded-frame, consumer-read
+  and zstd-window ceilings are explicit separate fields. Expected original length
+  is enforced; the consuming transaction still verifies the original digest.
+- Slice's `decoding.original_stream` is now a small compatibility/error adapter.
+  It maps neutral failures to the existing `SOURCE_DECODE_*` codes and supplies
+  the same legacy bound to every limit. Source confinement, per-read attachment
+  checks, source/destination IO attribution and fence ownership remain external.
+
+The standalone default iterator's optional decoded/total bounds are post-decode
+checks, **not native RAM protection**. Slice injects the strict frame reader so
+its declared frame bounds are checked before native decoding. Callback-provided
+frame readers are trusted code responsible for consuming exactly their frame and
+honoring their own IO/resource bounds. The same distinction applies to injected
+frame decoders: exceptions propagate; byte type/actual byte count are verified.
+The MIT header, standalone dependency boundary and on-disk container are retained.
+
+## Known zstd units mismatch — Stage C gate
+
+Expanded optional-codec coverage reproduced a pre-existing refusal, not a Stage B
+regression: a 256 KiB unknown-content-size zstd frame passes Slice's 64 MiB header
+ceiling but fails native decoding. The old `max_decode_bytes // 1024` setting
+becomes a 64 KiB native window ceiling with zstandard 0.25.0. Supplying a bytes-
+valued 64 MiB ceiling to that same native decoder restores the fixture completely.
+The [dependency implementation](https://github.com/indygreg/python-zstandard/blob/0.25.0/c-ext/decompressor.c)
+passes the setting directly to `ZSTD_DCtx_setMaxWindowSize`; its documentation's
+KiB description is inconsistent with the measured behavior.
+
+Stage B intentionally preserves the old native setting and has a regression
+asserting that known refusal. **Stage C must qualify and correct the units under
+the new explicit policy without reinterpreting old seals.** Add known/unknown
+content-size cases at/below/above the real window ceiling and exercise every
+applicable supported dependency backend. Track this as INC-064 in the ledger.
+Do not claim that zstd window compatibility or shared RAM admission is complete.
+
+## Validation and review
+
+- Codec-focused suite with optional zstandard 0.25.0: **105 passed**, no skips.
+  The dependency was installed only into a disposable test directory, not a live
+  runtime. Tests cover short/non-seekable IO, real writer dtype variants, exact
+  bounds, malformed/unsupported headers, total length, callback/source failures,
+  atomic wrapper preservation, caller ownership and dependency separation.
+- Installed-dependency synthetic qualification: **13/13 passed** at both observed
+  failure sizes, whole and streamed, compression/canary/full restoration. Report:
+  `/tmp/modelark-codec-qualification-mu8c_x8m/result.json`; source hashes identify
+  the implementation tested. This requalifies existing StreamZNN wrapper reuse,
+  not large-frame admission through Slice.
+- Full-project Ruff passed. Full Slice regression is running separately.
+- Local Grok CLI review precedes the new PR; at most three local rounds, then
+  at most three Greptile/Codex rounds for this stage, per DEC-140.
+
+No live deployment, archive/catalog access, physical USB writes, RAM-policy
+adoption, stored-export switch, P2P service or compression fallback change.

--- a/docs/streamznn-reader-adapter.md
+++ b/docs/streamznn-reader-adapter.md
@@ -67,9 +67,19 @@ Do not claim that zstd window compatibility or shared RAM admission is complete.
   `/tmp/modelark-codec-qualification-mu8c_x8m/result.json`; source hashes identify
   the implementation tested. This requalifies existing StreamZNN wrapper reuse,
   not large-frame admission through Slice.
-- Full-project Ruff passed. Full Slice regression is running separately.
-- Local Grok CLI review precedes the new PR; at most three local rounds, then
-  at most three Greptile/Codex rounds for this stage, per DEC-140.
+- Full Slice regression: **1,346 passed, 5 optional-codec skips** in 520.58 seconds.
+  The separate zstd-enabled run above covers the optional codec paths.
+- Fresh wheel, installed without dependencies into a disposable directory:
+  **93 passed** with zstd enabled and tests copied outside the checkout. Runtime
+  import locations were asserted; all three changed modules matched source bytes.
+- Full-project Ruff and diff whitespace checks passed.
+- Local Grok CLI round 1 **ACCEPTED c272891** with no actionable findings. It
+  confirmed that INC-064 stays at the Stage C policy gate, not a refactor fix.
+  Session: `f2d466e1-014e-452f-8e06-9b81ee841275`. The first CLI invocation ended
+  after review commentary; a same-session follow-up supplied its explicit verdict.
+  This is one review round, not a second code-review iteration. This evidence
+  update changes documentation only; remote review covers the pushed PR head.
+  At most three Greptile/Codex rounds remain available for Stage B, per DEC-140.
 
 No live deployment, archive/catalog access, physical USB writes, RAM-policy
 adoption, stored-export switch, P2P service or compression fallback change.

--- a/modelark/artifact_io.py
+++ b/modelark/artifact_io.py
@@ -1,0 +1,207 @@
+"""Retrieval-free original-byte streams with bounded codec allocations.
+
+The bound limits individual stored/decoded ZipNN frames and zstd windows, not
+the native codecs' total working set. No tensor input, whole-file scratch, or
+unbounded ``read()`` is accepted. Large legacy whole-ZipNN files fail closed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import streamznn
+
+
+class DecodeError(Exception):
+    """Neutral decode refusal; caller maps kind to its own error contract."""
+
+    def __init__(self, kind, detail=""):
+        self.kind, self.detail = kind, detail
+        super().__init__(f"{kind}: {detail}")
+
+
+@dataclass(frozen=True)
+class DecodeLimits:
+    """Explicit, distinct buffer bounds, not a native RAM admission policy."""
+
+    stored_frame_bytes: int
+    decoded_frame_bytes: int
+    read_bytes: int
+    zstd_window_bytes: int
+
+    def __post_init__(self):
+        if any(type(value) is not int or value <= 0 for value in (
+                self.stored_frame_bytes, self.decoded_frame_bytes,
+                self.read_bytes, self.zstd_window_bytes)):
+            raise ValueError("positive integer decoding bounds required")
+
+
+def _refuse(code="INVALID", detail=""):
+    raise DecodeError(code, detail)
+
+
+def _exact(stream, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = stream.read(size - len(data))
+        if not chunk:
+            _refuse(detail="truncated container")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def _prefix(stream, size):
+    data = b""
+    while len(data) < size:
+        chunk = stream.read(size - len(data))
+        if not chunk:
+            break
+        data += chunk
+    return data
+
+
+def _chunks(stream, compressed, expected, limits):
+    try:
+        yield from _decoded_chunks(stream, compressed, expected, limits)
+    except streamznn.DecodeLimitExceeded as exc:
+        raise DecodeError("LIMIT", str(exc)) from exc
+    except streamznn.UnsupportedFrame as exc:
+        raise DecodeError("UNSUPPORTED", str(exc)) from exc
+    except streamznn.StreamZnnError as exc:
+        raise DecodeError("INVALID", str(exc)) from exc
+
+
+def _decoded_chunks(stream, compressed, expected, limits):
+    if not compressed:
+        while chunk := stream.read(min(limits.read_bytes, 1 << 20)):
+            yield chunk
+        return
+    prefix = _prefix(stream, 5)
+
+    def frame(source, stored_length, remaining, prefix=b""):
+        return streamznn.read_zipnn_frame(
+            source, max_stored_bytes=limits.stored_frame_bytes,
+            max_decoded_bytes=limits.decoded_frame_bytes, remaining_bytes=remaining,
+            stored_length=stored_length, prefix=prefix,
+            read_size=min(limits.read_bytes, 1 << 20))
+
+    if prefix == streamznn.MAGIC:
+        yield from streamznn.iter_decompress(
+            stream, prefix=prefix, max_stored_frame_bytes=limits.stored_frame_bytes,
+            max_decoded_frame_bytes=limits.decoded_frame_bytes, max_total_bytes=expected,
+            read_size=min(limits.read_bytes, 1 << 20), frame_reader=frame)
+    elif prefix.startswith(b"ZN"):
+        yield frame(stream, None, expected, prefix)
+        if stream.read(1):
+            _refuse(detail="trailing whole-ZipNN data")
+    elif prefix.startswith(b"\x28\xb5\x2f\xfd"):
+        try:
+            import zstandard as zstd
+        except ImportError as exc:
+            raise DecodeError("UNSUPPORTED", "zstandard is not installed") from exc
+        # zstd's maximum regenerated block is 128 KiB. Feeding no more
+        # than limit/128KiB input bytes bounds even maximally dense RLE output
+        # before Python gets the opportunity to check its length.
+        if limits.decoded_frame_bytes < 128 << 10:
+            _refuse("LIMIT", "zstd requires a 128 KiB decoding bound")
+        header = prefix
+        while True:
+            try:
+                params = zstd.get_frame_parameters(header)
+                break
+            except zstd.ZstdError:
+                if len(header) >= 18:
+                    _refuse(detail="invalid zstd header")
+                header += _exact(stream, 1)
+        if (params.window_size > limits.zstd_window_bytes
+                or params.content_size not in (zstd.CONTENTSIZE_UNKNOWN, zstd.CONTENTSIZE_ERROR)
+                and params.content_size > expected):
+            _refuse("LIMIT", "zstd window/content exceeds bound")
+        # Preserve legacy Slice's native setting in this no-widening extraction.
+        # zstandard 0.25.0 actually treats this setting as bytes, despite its
+        # documentation's KiB wording. Stage C must qualify the units correction;
+        # this conversion currently refuses some frames below our header ceiling.
+        decoder = zstd.ZstdDecompressor(max_window_size=max(1, limits.zstd_window_bytes // 1024)).decompressobj()
+        pending = header
+        try:
+            while pending:
+                data = decoder.decompress(pending)
+                if len(data) > limits.decoded_frame_bytes:
+                    _refuse("LIMIT", "zstd output block exceeds bound")
+                if data:
+                    yield data
+                if decoder.eof:
+                    if decoder.unused_data or stream.read(1):
+                        _refuse(detail="trailing/concatenated zstd data")
+                    break
+                pending = stream.read(max(1, limits.decoded_frame_bytes // (128 << 10)))
+            if not decoder.eof:
+                _refuse(detail="truncated zstd frame")
+        except zstd.ZstdError as exc:
+            raise DecodeError("INVALID", "zstd decoder refused frame") from exc
+    else:
+        _refuse("UNSUPPORTED", "unknown compressed container")
+
+
+class _CheckedInput:
+    """Check every underlying read; callbacks and IO errors keep their identity."""
+
+    def __init__(self, stream, read_bytes, check):
+        self.stream, self.read_bytes, self.check = stream, read_bytes, check
+
+    def read(self, size):
+        self.check()
+        size = min(size, self.read_bytes, 1 << 20)
+        chunk = self.stream.read(size)
+        if not isinstance(chunk, bytes) or len(chunk) > size:
+            _refuse(detail="source did not honor bounded binary read")
+        self.check()
+        return chunk
+
+
+class _OriginalStream:
+    def __init__(self, stream, compressed, expected, limits, check):
+        self._chunks = iter(_chunks(_CheckedInput(stream, limits.read_bytes, check),
+                                    compressed, expected, limits))
+        self._pending = b""
+        self._offset = 0
+        self._total = 0
+        self._expected, self._limit, self._check = expected, limits.read_bytes, check
+        self._done = False
+
+    def read(self, size=-1):
+        if type(size) is not int or size < 0 or size > self._limit:
+            _refuse("LIMIT", "explicit bounded read size required")
+        self._check()
+        if not size or self._done:
+            return b""
+        if self._offset == len(self._pending):
+            try:
+                self._pending = next(self._chunks)
+                self._offset = 0
+            except StopIteration:
+                self._done = True
+                if self._total != self._expected:
+                    _refuse(detail="decoded size differs from sealed original size")
+                return b""
+            self._total += len(self._pending)
+            if self._total > self._expected:
+                _refuse("LIMIT", "decoded total exceeds sealed original size")
+        end = min(self._offset + size, len(self._pending))
+        data = self._pending[self._offset:end]
+        self._offset = end
+        self._check()
+        return data
+
+
+def original_stream(stream, *, compressed, expected_bytes, limits: DecodeLimits,
+                    check=lambda: None):
+    """Decode caller-owned bytes; no paths, source authority or output publication.
+
+    Original length is enforced here; the caller must verify the original digest.
+    Resource isolation/admission is not added by these explicit buffer limits.
+    """
+    if type(expected_bytes) is not int or expected_bytes < 0:
+        raise ValueError("nonnegative original size required")
+    if not isinstance(limits, DecodeLimits):
+        raise ValueError("explicit DecodeLimits required")
+    return _OriginalStream(stream, compressed, expected_bytes, limits, check)

--- a/modelark/codec_process.py
+++ b/modelark/codec_process.py
@@ -1,0 +1,105 @@
+"""Explicit startup boundary shared by codec and qualification children.
+
+Only trusted stdlib/project bootstrap code runs before the guards. Dependency
+site hooks run afterwards, including virtualenv discovery on Python 3.10/3.12.
+This is not an OS sandbox or protection against malicious installed code.
+"""
+from __future__ import annotations
+
+import ctypes
+import os
+from pathlib import Path
+import signal
+import sys
+
+
+class WorkerInitializationError(RuntimeError):
+    """The required child startup/lifetime contract could not be established."""
+
+
+def isolated_command(module, *args):
+    """Pin project imports and suppress automatic site initialization."""
+    root = str(Path(__file__).resolve().parent.parent)
+    bootstrap = ("import sys; sys.path.insert(0, sys.argv.pop(1)); "
+                 "import runpy; runpy.run_module(sys.argv.pop(1), run_name='__main__')")
+    return [sys.executable, "-I", "-S", "-c", bootstrap, root, module, *map(str, args)]
+
+
+def bind_parent(parent_pid):
+    """Kill on spawning-thread death; check the race before installing prctl."""
+    if sys.platform != "linux" or type(parent_pid) is not int or parent_pid <= 0:
+        raise WorkerInitializationError("codec parent-death guard requires Linux and parent PID")
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(1, signal.SIGKILL, 0, 0, 0) != 0:
+        raise WorkerInitializationError("could not install codec parent-death guard")
+    if os.getppid() != parent_pid:
+        raise WorkerInitializationError("codec parent exited before worker initialization")
+
+
+def initialize_worker(policy, parent_pid):
+    """Fresh -I -S child only: lifetime, memory, then dependency initialization."""
+    if not sys.flags.isolated or not sys.flags.no_site:
+        raise WorkerInitializationError("codec worker requires isolated no-site startup")
+    bind_parent(parent_pid)
+    policy.install_in_worker()
+    # -S prevents even `import site` from running hooks automatically. Explicit
+    # main() restores virtualenv paths before 3.14 as well as normal site hooks,
+    # but only after the irreversible memory guard and parent binding exist.
+    import site
+    site.main()
+
+
+def runtime_record():
+    """Actual child observations, not binary attestation or another process's versions."""
+    import importlib.metadata
+    import resource
+    import torch
+    import zipnn
+
+    parent_signal = ctypes.c_int()
+    if ctypes.CDLL(None, use_errno=True).prctl(2, ctypes.byref(parent_signal), 0, 0, 0) != 0:
+        raise WorkerInitializationError("could not observe parent-death guard")
+    return {
+        "version": "modelark.codec-runtime.v1",
+        "startup": "isolated-no-site-guard-then-site.v1",
+        "python": sys.version, "executable": sys.executable,
+        "prefix": sys.prefix, "base_prefix": sys.base_prefix,
+        "address_space_bytes": list(resource.getrlimit(resource.RLIMIT_AS)),
+        "parent_death_signal": parent_signal.value,
+        "zipnn": {"distribution_version": importlib.metadata.version("zipnn"),
+                  "module": str(Path(zipnn.__file__).resolve())},
+        "torch": {"distribution_version": importlib.metadata.version("torch"),
+                  "module": str(Path(torch.__file__).resolve())},
+    }
+
+
+def validate_runtime(record, policy):
+    """Closed-world, bounded identity and observed-guard record for this session."""
+    if type(record) is not dict or set(record) != {
+            "version", "startup", "python", "executable", "prefix", "base_prefix",
+            "address_space_bytes", "parent_death_signal", "zipnn", "torch"}:
+        raise ValueError("invalid worker runtime fields")
+    if (record["version"] != "modelark.codec-runtime.v1"
+            or record["startup"] != "isolated-no-site-guard-then-site.v1"):
+        raise ValueError("unknown worker runtime version")
+    for name in ("python", "executable", "prefix", "base_prefix"):
+        value = record[name]
+        if type(value) is not str or not 0 < len(value) <= 1024:
+            raise ValueError("invalid worker runtime identity")
+        if name != "python" and not os.path.isabs(value):
+            raise ValueError("worker runtime path must be absolute")
+    limits = record["address_space_bytes"]
+    if (type(limits) is not list or len(limits) != 2
+            or any(type(limit) is not int or limit != policy.address_space_bytes for limit in limits)
+            or type(record["parent_death_signal"]) is not int
+            or record["parent_death_signal"] != signal.SIGKILL):
+        raise ValueError("worker guard evidence differs from request")
+    for name in ("zipnn", "torch"):
+        identity = record[name]
+        if type(identity) is not dict or set(identity) != {"distribution_version", "module"}:
+            raise ValueError("invalid worker dependency fields")
+        if any(type(value) is not str or not 0 < len(value) <= 1024 for value in identity.values()):
+            raise ValueError("invalid worker dependency identity")
+        if not os.path.isabs(identity["module"]):
+            raise ValueError("worker dependency path must be absolute")
+    return record

--- a/modelark/codec_resources.py
+++ b/modelark/codec_resources.py
@@ -1,6 +1,6 @@
 """Shared, operation-neutral memory admission for isolated codec workers.
 
-Stage A: qualification consumers only. No live writer/reader policy changes.
+Shared by qualification and the opt-in codec supervisor. No live caller rollout.
 RLIMIT_AS is a hard virtual-address-space ceiling, NOT an RSS reservation.
 Available memory is a fresh caller observation of the smallest host/cgroup
 headroom, not MemFree and not a promise against unrelated concurrent allocation.
@@ -8,11 +8,63 @@ headroom, not MemFree and not a promise against unrelated concurrent allocation.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from pathlib import Path
 import sys
 
 
 class CodecResourceRefusal(RuntimeError):
     """The requested resource envelope cannot be admitted or enforced."""
+
+
+def available_memory() -> dict:
+    """Conservative visible Linux memory headroom; unknown accounting refuses."""
+    try:
+        return _available_memory()
+    except (OSError, ValueError, OverflowError) as exc:
+        raise CodecResourceRefusal("could not establish memory headroom") from exc
+
+
+def _available_memory():
+    host_available = None
+    for line in Path("/proc/meminfo").read_text().splitlines():
+        fields = line.split()
+        if fields and fields[0] == "MemAvailable:":
+            if len(fields) != 3 or fields[2] != "kB":
+                raise CodecResourceRefusal("unrecognized MemAvailable accounting")
+            host_available = int(fields[1]) * 1024
+            if host_available < 0:
+                raise CodecResourceRefusal("negative host memory accounting")
+    if host_available is None:
+        raise CodecResourceRefusal("host available memory is unknown")
+    mounts = [line.split() for line in Path("/proc/self/mountinfo").read_text().splitlines()
+              if " - cgroup2 " in line]
+    if len(mounts) != 1 or mounts[0][3:5] != ["/", "/sys/fs/cgroup"]:
+        raise CodecResourceRefusal("full cgroup2 hierarchy is not visible")
+    groups = Path("/proc/self/cgroup").read_text().splitlines()
+    if len(groups) != 1 or not groups[0].startswith("0::/"):
+        raise CodecResourceRefusal("unrecognized unified cgroup membership")
+    relative = groups[0][4:]
+    if relative and any(part in {"", ".", ".."} for part in relative.split("/")):
+        raise CodecResourceRefusal("invalid cgroup membership")
+    root = Path("/sys/fs/cgroup")
+    current = root / relative
+    cgroup_headroom = {}
+    while True:
+        # Initial hierarchy roots have no memory.max; a visible namespace root
+        # may have one and its limit must not be discarded.
+        if current != root or (current / "memory.max").exists():
+            maximum = (current / "memory.max").read_text().strip()
+            used = int((current / "memory.current").read_text().strip())
+            if used < 0 or maximum != "max" and int(maximum) < 0:
+                raise CodecResourceRefusal("negative cgroup memory accounting")
+            if maximum != "max":
+                cgroup_headroom[str(current.relative_to(root))] = max(0, int(maximum) - used)
+        if current == root:
+            break
+        current = current.parent
+    return {"available_bytes": min([host_available, *cgroup_headroom.values()]),
+            "observations": {"host_available_bytes": host_available,
+                             "cgroup_headroom_bytes": cgroup_headroom}}
 
 
 def _bytes(value, name, *, zero=False):

--- a/modelark/codec_supervisor.py
+++ b/modelark/codec_supervisor.py
@@ -1,0 +1,199 @@
+"""Bounded parent-side transport for a single guarded ZipNN frame.
+
+Not yet wired to Slice approvals. Caller owns source acquisition, fences and
+original digest verification. Mandatory context exit kills/reaps the child before
+returning, including consumer failure; no whole-frame buffers exist in this parent.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+import os
+import selectors
+import subprocess
+import sys
+
+from .codec_resources import CodecMemoryPolicy, available_memory
+from . import streamznn
+
+IO_BYTES = 64 << 10
+DIAGNOSTIC_BYTES = 8192
+ERROR_BYTES = 4096
+POLL_SECONDS = 0.05  # Cancellation responsiveness, not a decode deadline.
+
+
+class WorkerRefusal(Exception):
+    """Neutral worker failure, distinct from caller IO/cancellation exceptions."""
+
+    def __init__(self, kind, detail):
+        self.kind, self.detail = kind, detail
+        super().__init__(f"{kind}: {detail}")
+
+
+class _Input:
+    def __init__(self, source, check):
+        self.source, self.check = source, check
+
+    def read(self, size):
+        self.check()
+        size = min(size, IO_BYTES)
+        data = self.source.read(size)
+        if not isinstance(data, bytes) or len(data) > size:
+            raise streamznn.StreamZnnError("source did not honor bounded binary read")
+        self.check()
+        return data
+
+
+def _launch(request, output):
+    return subprocess.Popen(
+        [sys.executable, "-m", "modelark.codec_worker", str(output), str(os.getpid()),
+         json.dumps(request, separators=(",", ":"))],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        close_fds=True, pass_fds=(output,), bufsize=0)
+
+
+def _transfer(proc, output, source, header, check):
+    """Nonblocking full-duplex supervision, bounded even for noisy native code."""
+    original = int.from_bytes(header[16:24], "little")
+    remaining = int.from_bytes(header[24:32], "little") - len(header)
+    pending = header
+    response = bytearray()
+    detail = bytearray()
+    diagnostics = bytearray()
+    status = None
+    left = None
+    output_eof = False
+    with selectors.DefaultSelector() as poll:
+        for handle, events, tag in ((proc.stdin, selectors.EVENT_WRITE, "input"),
+                                    (proc.stdout, selectors.EVENT_READ, "diagnostic"),
+                                    (output, selectors.EVENT_READ, "output")):
+            os.set_blocking(handle if isinstance(handle, int) else handle.fileno(), False)
+            poll.register(handle, events, tag)
+        while True:
+            check()
+            for key, _ in poll.select(POLL_SECONDS):
+                check()
+                if key.data == "input":
+                    if not pending and remaining:
+                        pending = source.read(min(IO_BYTES, remaining))
+                        if not pending:
+                            raise streamznn.StreamZnnError("truncated worker frame input")
+                        remaining -= len(pending)
+                    if pending:
+                        try:
+                            count = os.write(key.fd, pending)
+                        except BlockingIOError:
+                            continue
+                        except BrokenPipeError:
+                            # Drain the dedicated result to preserve a typed early
+                            # guard refusal instead of reporting generic pipe failure.
+                            poll.unregister(key.fileobj)
+                            proc.stdin.close()
+                            continue
+                        pending = pending[count:]
+                    if not pending and not remaining:
+                        poll.unregister(key.fileobj)
+                        proc.stdin.close()
+                elif key.data == "diagnostic":
+                    try:
+                        data = os.read(key.fd, IO_BYTES)
+                    except BlockingIOError:
+                        continue
+                    if not data:
+                        poll.unregister(key.fileobj)
+                        continue
+                    diagnostics.extend(data)
+                    del diagnostics[:-DIAGNOSTIC_BYTES]
+                else:
+                    # Never read across response phases or allocate from an
+                    # unchecked worker-declared length.
+                    size = 9 - len(response) if status is None else min(IO_BYTES, left or 1)
+                    try:
+                        data = os.read(key.fd, size)
+                    except BlockingIOError:
+                        continue
+                    if not data:
+                        output_eof = True
+                        poll.unregister(key.fileobj)
+                        continue
+                    if status is None:
+                        response.extend(data)
+                        if len(response) != 9:
+                            continue
+                        status = bytes(response[:1])
+                        left = int.from_bytes(response[1:], "little")
+                        if status == b"O":
+                            if left != original or not proc.stdin.closed:
+                                raise WorkerRefusal("INVALID", "invalid worker success header")
+                        elif status not in (b"R", b"I", b"U", b"L") or left > ERROR_BYTES:
+                            raise WorkerRefusal("INVALID", "invalid worker error header")
+                    else:
+                        if len(data) > left:
+                            raise WorkerRefusal("INVALID", "trailing worker output")
+                        left -= len(data)
+                        if status == b"O":
+                            check()
+                            yield data
+                            check()
+                        else:
+                            detail.extend(data)
+            code = proc.poll()
+            if code is not None and output_eof:
+                if status is None or left != 0:
+                    raise WorkerRefusal("WORKER_FAILED", f"incomplete worker result (exit {code})")
+                if status != b"O":
+                    kind = {b"R": "RESOURCE", b"I": "INVALID", b"U": "UNSUPPORTED", b"L": "LIMIT"}[status]
+                    raise WorkerRefusal(kind, detail.decode("utf-8", errors="replace"))
+                if code != 0:
+                    raise WorkerRefusal("WORKER_FAILED", f"worker failed after output (exit {code})")
+                return
+
+
+@contextmanager
+def guarded_zipnn_frame(source, *, policy: CodecMemoryPolicy, max_stored_bytes,
+                        max_decoded_bytes, remaining_bytes, stored_length=None,
+                        prefix=b"", check=lambda: None):
+    """Yield a bounded iterator of original-byte chunks for exactly one frame.
+
+    Consume to EOF for worker certification; context exit alone never certifies
+    success. Always nest this context inside source/fence ownership. Closing on a
+    destination error preserves that error and reaps before the caller can release
+    its fence. Input IO/check exceptions retain identity. No source is closed here.
+    Memory observation/admission is identical to the writer qualification; a sample
+    is not a reservation against unrelated processes. Only Linux is qualified.
+    """
+    if not isinstance(policy, CodecMemoryPolicy):
+        raise ValueError("explicit codec memory policy required")
+    checked = _Input(source, check)
+    header = streamznn.read_zipnn_header(
+        checked, max_stored_bytes=max_stored_bytes, max_decoded_bytes=max_decoded_bytes,
+        remaining_bytes=remaining_bytes, stored_length=stored_length, prefix=prefix,
+        read_size=IO_BYTES)
+    policy.admit(available_memory()["available_bytes"])
+    check()
+    request = {"version": "modelark.codec-worker.v1", "policy": policy.to_record(),
+               "stored_bytes": int.from_bytes(header[24:32], "little"),
+               "original_bytes": int.from_bytes(header[16:24], "little")}
+    output, writer = os.pipe()
+    proc = chunks = None
+    try:
+        try:
+            proc = _launch(request, writer)
+        finally:
+            os.close(writer)
+        chunks = _transfer(proc, output, checked, header, check)
+        yield chunks
+    finally:
+        # Kill first: no new source reads/output are attempted during unwinding.
+        # SIGKILL avoids waiting for native code to cooperate with cancellation.
+        if proc is not None:
+            try:
+                if proc.poll() is None:
+                    proc.kill()
+            finally:
+                proc.wait()
+                proc.stdin.close()
+                proc.stdout.close()
+        if chunks is not None:
+            chunks.close()
+        os.close(output)

--- a/modelark/codec_supervisor.py
+++ b/modelark/codec_supervisor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 import json
 import os
+from pathlib import Path
 import selectors
 import subprocess
 import sys
@@ -45,8 +46,14 @@ class _Input:
 
 
 def _launch(request, output):
+    # -m alone resolves against cwd/PYTHONPATH again, which can select a different
+    # modelark than the parent imported. Isolate Python's search path, then bind
+    # the bootstrap to this package root. No caller/archive path is used as code.
+    root = str(Path(__file__).resolve().parent.parent)
+    bootstrap = ("import sys; sys.path.insert(0, sys.argv.pop(1)); "
+                 "from modelark.codec_worker import main; raise SystemExit(main(sys.argv))")
     return subprocess.Popen(
-        [sys.executable, "-m", "modelark.codec_worker", str(output), str(os.getpid()),
+        [sys.executable, "-I", "-c", bootstrap, root, str(output), str(os.getpid()),
          json.dumps(request, separators=(",", ":"))],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         close_fds=True, pass_fds=(output,), bufsize=0)

--- a/modelark/codec_supervisor.py
+++ b/modelark/codec_supervisor.py
@@ -9,17 +9,17 @@ from __future__ import annotations
 from contextlib import contextmanager
 import json
 import os
-from pathlib import Path
 import selectors
 import subprocess
-import sys
 
 from .codec_resources import CodecMemoryPolicy, available_memory
+from .codec_process import isolated_command, validate_runtime
 from . import streamznn
 
 IO_BYTES = 64 << 10
 DIAGNOSTIC_BYTES = 8192
 ERROR_BYTES = 4096
+METADATA_BYTES = 8192
 POLL_SECONDS = 0.05  # Cancellation responsiveness, not a decode deadline.
 
 
@@ -46,20 +46,14 @@ class _Input:
 
 
 def _launch(request, output):
-    # -m alone resolves against cwd/PYTHONPATH again, which can select a different
-    # modelark than the parent imported. Isolate Python's search path, then bind
-    # the bootstrap to this package root. No caller/archive path is used as code.
-    root = str(Path(__file__).resolve().parent.parent)
-    bootstrap = ("import sys; sys.path.insert(0, sys.argv.pop(1)); "
-                 "from modelark.codec_worker import main; raise SystemExit(main(sys.argv))")
     return subprocess.Popen(
-        [sys.executable, "-I", "-c", bootstrap, root, str(output), str(os.getpid()),
-         json.dumps(request, separators=(",", ":"))],
+        isolated_command("modelark.codec_worker", output, os.getpid(),
+                         json.dumps(request, separators=(",", ":"))),
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         close_fds=True, pass_fds=(output,), bufsize=0)
 
 
-def _transfer(proc, output, source, header, check):
+def _transfer(proc, output, source, header, check, policy, admission, on_complete):
     """Nonblocking full-duplex supervision, bounded even for noisy native code."""
     original = int.from_bytes(header[16:24], "little")
     remaining = int.from_bytes(header[24:32], "little") - len(header)
@@ -67,6 +61,8 @@ def _transfer(proc, output, source, header, check):
     response = bytearray()
     detail = bytearray()
     diagnostics = bytearray()
+    metadata = bytearray()
+    runtime = None
     status = None
     left = None
     output_eof = False
@@ -129,16 +125,28 @@ def _transfer(proc, output, source, header, check):
                             continue
                         status = bytes(response[:1])
                         left = int.from_bytes(response[1:], "little")
-                        if status == b"O":
-                            if left != original or not proc.stdin.closed:
+                        if status == b"M":
+                            if runtime is not None or not 0 < left <= METADATA_BYTES or not proc.stdin.closed:
+                                raise WorkerRefusal("INVALID", "invalid worker metadata header")
+                        elif status == b"O":
+                            if runtime is None or left != original or not proc.stdin.closed:
                                 raise WorkerRefusal("INVALID", "invalid worker success header")
-                        elif status not in (b"R", b"I", b"U", b"L") or left > ERROR_BYTES:
+                        elif runtime is not None or status not in (b"R", b"I", b"U", b"L") or left > ERROR_BYTES:
                             raise WorkerRefusal("INVALID", "invalid worker error header")
                     else:
                         if len(data) > left:
                             raise WorkerRefusal("INVALID", "trailing worker output")
                         left -= len(data)
-                        if status == b"O":
+                        if status == b"M":
+                            metadata.extend(data)
+                            if left == 0:
+                                try:
+                                    runtime = validate_runtime(json.loads(metadata), policy)
+                                except (ValueError, UnicodeError, RecursionError) as exc:
+                                    raise WorkerRefusal("INVALID", "invalid worker runtime evidence") from exc
+                                status = None
+                                response.clear()
+                        elif status == b"O":
                             check()
                             yield data
                             check()
@@ -153,13 +161,15 @@ def _transfer(proc, output, source, header, check):
                     raise WorkerRefusal(kind, detail.decode("utf-8", errors="replace"))
                 if code != 0:
                     raise WorkerRefusal("WORKER_FAILED", f"worker failed after output (exit {code})")
+                check()
+                on_complete({"admission": admission, "worker": runtime})
                 return
 
 
 @contextmanager
 def guarded_zipnn_frame(source, *, policy: CodecMemoryPolicy, max_stored_bytes,
                         max_decoded_bytes, remaining_bytes, stored_length=None,
-                        prefix=b"", check=lambda: None):
+                        prefix=b"", check=lambda: None, on_complete=lambda evidence: None):
     """Yield a bounded iterator of original-byte chunks for exactly one frame.
 
     Consume to EOF for worker certification; context exit alone never certifies
@@ -168,6 +178,8 @@ def guarded_zipnn_frame(source, *, policy: CodecMemoryPolicy, max_stored_bytes,
     its fence. Input IO/check exceptions retain identity. No source is closed here.
     Memory observation/admission is identical to the writer qualification; a sample
     is not a reservation against unrelated processes. Only Linux is qualified.
+    on_complete receives the exact admission sample and validated child runtime
+    only after exact output, protocol EOF and zero child exit; never on early close.
     """
     if not isinstance(policy, CodecMemoryPolicy):
         raise ValueError("explicit codec memory policy required")
@@ -176,19 +188,27 @@ def guarded_zipnn_frame(source, *, policy: CodecMemoryPolicy, max_stored_bytes,
         checked, max_stored_bytes=max_stored_bytes, max_decoded_bytes=max_decoded_bytes,
         remaining_bytes=remaining_bytes, stored_length=stored_length, prefix=prefix,
         read_size=IO_BYTES)
-    policy.admit(available_memory()["available_bytes"])
+    admission = available_memory()
+    policy.admit(admission["available_bytes"])
     check()
-    request = {"version": "modelark.codec-worker.v1", "policy": policy.to_record(),
+    request = {"version": "modelark.codec-worker.v2", "policy": policy.to_record(),
                "stored_bytes": int.from_bytes(header[24:32], "little"),
                "original_bytes": int.from_bytes(header[16:24], "little")}
     output, writer = os.pipe()
     proc = chunks = None
     try:
         try:
+            # Popen replaces child stdio. A pipe allocated into a closed stdio
+            # slot must not be the protocol writer passed through that setup.
+            if writer < 3:
+                import fcntl
+                moved = fcntl.fcntl(writer, fcntl.F_DUPFD_CLOEXEC, 3)
+                os.close(writer)
+                writer = moved
             proc = _launch(request, writer)
         finally:
             os.close(writer)
-        chunks = _transfer(proc, output, checked, header, check)
+        chunks = _transfer(proc, output, checked, header, check, policy, admission, on_complete)
         yield chunks
     finally:
         # Kill first: no new source reads/output are attempted during unwinding.

--- a/modelark/codec_worker.py
+++ b/modelark/codec_worker.py
@@ -1,42 +1,24 @@
 """One-shot, read-only ZipNN child; no archive paths or publication authority.
 
-Internal protocol v1: stdin is exactly one frame followed by EOF; a dedicated
-FD carries a one-byte status + uint64 length + payload. stdout/stderr are only
-diagnostics. Limits and parent-death handling precede every native import.
+Internal protocol v2: success is bounded runtime metadata followed by original
+bytes, each framed by status + uint64 length. Failure is one error frame.
+stdout/stderr are only diagnostics; dependency hooks run after the guards.
 """
 from __future__ import annotations
 
-import ctypes
 import json
 import os
-import signal
 import sys
 
 from modelark.codec_resources import CodecMemoryPolicy, CodecResourceRefusal
+from modelark.codec_process import (
+    WorkerInitializationError, initialize_worker, runtime_record, validate_runtime,
+)
 from modelark import streamznn
 
 IO_BYTES = 64 << 10
 ERROR_BYTES = 4096
-
-
-class WorkerInitializationError(RuntimeError):
-    """Parent-lifetime protection failed, distinct from memory admission."""
-
-
-def bind_parent(parent_pid):
-    """Linux kills the worker if its spawning thread dies, including mid-codec.
-
-    Check after prctl to cover death between spawn and installing the signal.
-    Linux PDEATHSIG follows the parent *thread*, not just the process; a caller
-    must keep that thread alive for the entire context-managed decode.
-    """
-    if sys.platform != "linux":
-        raise WorkerInitializationError("codec parent-death guard requires Linux")
-    libc = ctypes.CDLL(None, use_errno=True)
-    if libc.prctl(1, signal.SIGKILL, 0, 0, 0) != 0:  # PR_SET_PDEATHSIG
-        raise WorkerInitializationError("could not install codec parent-death guard")
-    if os.getppid() != parent_pid:
-        raise WorkerInitializationError("codec parent exited before worker initialization")
+METADATA_BYTES = 8192
 
 
 def _send(fd, data):
@@ -48,17 +30,21 @@ def _send(fd, data):
         view = view[count:]
 
 
-def run(request, source):
-    """The process entrypoint is the only production caller of this function."""
+def _policy(request):
     if type(request) is not dict or set(request) != {
             "version", "policy", "stored_bytes", "original_bytes"}:
         raise ValueError("invalid worker request fields")
-    if request["version"] != "modelark.codec-worker.v1":
+    if request["version"] != "modelark.codec-worker.v2":
         raise ValueError("unknown worker protocol")
     for key in ("stored_bytes", "original_bytes"):
         if type(request[key]) is not int or request[key] <= 0:
             raise ValueError("invalid worker frame size")
-    CodecMemoryPolicy.from_record(request["policy"]).install_in_worker()
+    return CodecMemoryPolicy.from_record(request["policy"])
+
+
+def run(request, source):
+    """Called only after guarded initialization by the process entrypoint."""
+    _policy(request)
 
     def decode(blob):
         # Do not start native work until the parent has closed the input pipe.
@@ -80,11 +66,16 @@ def run(request, source):
 def main(argv):
     output, parent_pid = int(argv[1]), int(argv[2])
     try:
-        bind_parent(parent_pid)
         if len(argv[3]) > ERROR_BYTES:
             raise ValueError("oversize worker request")
         request = json.loads(argv[3])
+        policy = _policy(request)
+        initialize_worker(policy, parent_pid)
         restored = run(request, sys.stdin.buffer)
+        metadata = json.dumps(validate_runtime(runtime_record(), policy),
+                              separators=(",", ":")).encode("utf-8")
+        if not 0 < len(metadata) <= METADATA_BYTES:
+            raise ValueError("oversize worker runtime evidence")
     except WorkerInitializationError:
         status, detail = b"I", b"codec worker initialization failed"
     except (CodecResourceRefusal, MemoryError):
@@ -97,10 +88,12 @@ def main(argv):
         # No paths or arbitrary exception contents are sent across this boundary.
         status, detail = b"I", b"codec worker refused frame"
     else:
-        # A response is exactly one status frame. Once success emission begins,
+        # Success is metadata then bytes. Once either emission begins,
         # any output failure is represented only by an unsuccessful process exit;
         # never append an error frame where the parent expects original bytes.
         try:
+            _send(output, b"M" + len(metadata).to_bytes(8, "little"))
+            _send(output, metadata)
             _send(output, b"O" + len(restored).to_bytes(8, "little"))
             _send(output, restored)
             return 0

--- a/modelark/codec_worker.py
+++ b/modelark/codec_worker.py
@@ -1,0 +1,103 @@
+"""One-shot, read-only ZipNN child; no archive paths or publication authority.
+
+Internal protocol v1: stdin is exactly one frame followed by EOF; a dedicated
+FD carries a one-byte status + uint64 length + payload. stdout/stderr are only
+diagnostics. Limits and parent-death handling precede every native import.
+"""
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import signal
+import sys
+
+from modelark.codec_resources import CodecMemoryPolicy, CodecResourceRefusal
+from modelark import streamznn
+
+IO_BYTES = 64 << 10
+ERROR_BYTES = 4096
+
+
+def bind_parent(parent_pid):
+    """Linux kills the worker if its spawning thread dies, including mid-codec.
+
+    Check after prctl to cover death between spawn and installing the signal.
+    Linux PDEATHSIG follows the parent *thread*, not just the process; a caller
+    must keep that thread alive for the entire context-managed decode.
+    """
+    if sys.platform != "linux":
+        raise CodecResourceRefusal("codec parent-death guard requires Linux")
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(1, signal.SIGKILL, 0, 0, 0) != 0:  # PR_SET_PDEATHSIG
+        raise CodecResourceRefusal("could not install codec parent-death guard")
+    if os.getppid() != parent_pid:
+        raise CodecResourceRefusal("codec parent exited before worker initialization")
+
+
+def _send(fd, data):
+    view = memoryview(data)
+    while view:
+        count = os.write(fd, view[:IO_BYTES])
+        if count <= 0:
+            raise BrokenPipeError("codec output closed")
+        view = view[count:]
+
+
+def run(request, source, output):
+    """The process entrypoint is the only production caller of this function."""
+    if type(request) is not dict or set(request) != {
+            "version", "policy", "stored_bytes", "original_bytes"}:
+        raise ValueError("invalid worker request fields")
+    if request["version"] != "modelark.codec-worker.v1":
+        raise ValueError("unknown worker protocol")
+    for key in ("stored_bytes", "original_bytes"):
+        if type(request[key]) is not int or request[key] <= 0:
+            raise ValueError("invalid worker frame size")
+    CodecMemoryPolicy.from_record(request["policy"]).install_in_worker()
+
+    def decode(blob):
+        # Do not start native work until the parent has closed the input pipe.
+        if source.read(1):
+            raise streamznn.StreamZnnError("trailing worker input")
+        from zipnn import ZipNN
+        return ZipNN(input_format="byte", threads=1).decompress(blob)
+
+    restored = streamznn.read_zipnn_frame(
+        source, max_stored_bytes=request["stored_bytes"],
+        max_decoded_bytes=request["original_bytes"],
+        remaining_bytes=request["original_bytes"], stored_length=request["stored_bytes"],
+        read_size=IO_BYTES, decode_frame=decode)
+    if len(restored) != request["original_bytes"]:
+        raise streamznn.StreamZnnError("worker decoded length differs from request")
+    _send(output, b"O" + len(restored).to_bytes(8, "little"))
+    _send(output, restored)
+
+
+def main(argv):
+    output, parent_pid = int(argv[1]), int(argv[2])
+    try:
+        bind_parent(parent_pid)
+        if len(argv[3]) > ERROR_BYTES:
+            raise ValueError("oversize worker request")
+        request = json.loads(argv[3])
+        run(request, sys.stdin.buffer, output)
+        return 0
+    except (CodecResourceRefusal, MemoryError):
+        status, detail = b"R", b"codec memory guard refused work"
+    except streamznn.DecodeLimitExceeded:
+        status, detail = b"L", b"codec frame exceeds bound"
+    except streamznn.UnsupportedFrame:
+        status, detail = b"U", b"unsupported codec frame"
+    except Exception:
+        # No paths or arbitrary exception contents are sent across this boundary.
+        status, detail = b"I", b"codec worker refused frame"
+    try:
+        _send(output, status + len(detail).to_bytes(8, "little") + detail)
+    except OSError:
+        pass
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/modelark/codec_worker.py
+++ b/modelark/codec_worker.py
@@ -19,6 +19,10 @@ IO_BYTES = 64 << 10
 ERROR_BYTES = 4096
 
 
+class WorkerInitializationError(RuntimeError):
+    """Parent-lifetime protection failed, distinct from memory admission."""
+
+
 def bind_parent(parent_pid):
     """Linux kills the worker if its spawning thread dies, including mid-codec.
 
@@ -27,12 +31,12 @@ def bind_parent(parent_pid):
     must keep that thread alive for the entire context-managed decode.
     """
     if sys.platform != "linux":
-        raise CodecResourceRefusal("codec parent-death guard requires Linux")
+        raise WorkerInitializationError("codec parent-death guard requires Linux")
     libc = ctypes.CDLL(None, use_errno=True)
     if libc.prctl(1, signal.SIGKILL, 0, 0, 0) != 0:  # PR_SET_PDEATHSIG
-        raise CodecResourceRefusal("could not install codec parent-death guard")
+        raise WorkerInitializationError("could not install codec parent-death guard")
     if os.getppid() != parent_pid:
-        raise CodecResourceRefusal("codec parent exited before worker initialization")
+        raise WorkerInitializationError("codec parent exited before worker initialization")
 
 
 def _send(fd, data):
@@ -44,7 +48,7 @@ def _send(fd, data):
         view = view[count:]
 
 
-def run(request, source, output):
+def run(request, source):
     """The process entrypoint is the only production caller of this function."""
     if type(request) is not dict or set(request) != {
             "version", "policy", "stored_bytes", "original_bytes"}:
@@ -70,8 +74,7 @@ def run(request, source, output):
         read_size=IO_BYTES, decode_frame=decode)
     if len(restored) != request["original_bytes"]:
         raise streamznn.StreamZnnError("worker decoded length differs from request")
-    _send(output, b"O" + len(restored).to_bytes(8, "little"))
-    _send(output, restored)
+    return restored
 
 
 def main(argv):
@@ -81,8 +84,9 @@ def main(argv):
         if len(argv[3]) > ERROR_BYTES:
             raise ValueError("oversize worker request")
         request = json.loads(argv[3])
-        run(request, sys.stdin.buffer, output)
-        return 0
+        restored = run(request, sys.stdin.buffer)
+    except WorkerInitializationError:
+        status, detail = b"I", b"codec worker initialization failed"
     except (CodecResourceRefusal, MemoryError):
         status, detail = b"R", b"codec memory guard refused work"
     except streamznn.DecodeLimitExceeded:
@@ -92,6 +96,16 @@ def main(argv):
     except Exception:
         # No paths or arbitrary exception contents are sent across this boundary.
         status, detail = b"I", b"codec worker refused frame"
+    else:
+        # A response is exactly one status frame. Once success emission begins,
+        # any output failure is represented only by an unsuccessful process exit;
+        # never append an error frame where the parent expects original bytes.
+        try:
+            _send(output, b"O" + len(restored).to_bytes(8, "little"))
+            _send(output, restored)
+            return 0
+        except Exception:
+            return 1
     try:
         _send(output, status + len(detail).to_bytes(8, "little") + detail)
     except OSError:

--- a/modelark/slice/decoding.py
+++ b/modelark/slice/decoding.py
@@ -1,164 +1,30 @@
-"""Retrieval-free original-byte streams with bounded codec allocations.
-
-The bound limits individual stored/decoded ZipNN frames and zstd windows, not
-the native codecs' total working set. No tensor input, whole-file scratch, or
-unbounded ``read()`` is accepted. Large legacy whole-ZipNN files fail closed.
-"""
+"""Slice original-output adapter; archive authority stays in LocalArchiveReader."""
 from __future__ import annotations
 
-import struct
+from modelark import artifact_io
 
 from .transaction import TransferRefusal
 
 
-def _refuse(code="SOURCE_DECODE_INVALID", detail=""):
-    raise TransferRefusal(code, detail)
-
-
-def _exact(stream, size):
-    data = bytearray()
-    while len(data) < size:
-        chunk = stream.read(size - len(data))
-        if not chunk:
-            _refuse(detail="truncated container")
-        data.extend(chunk)
-    return bytes(data)
-
-
-def _zipnn_frame(stream, prefix, limit, remaining, stored_length=None):
-    header = prefix + _exact(stream, 32 - len(prefix))
-    original = int.from_bytes(header[16:24], "little")
-    stored = int.from_bytes(header[24:32], "little")
-    if original > limit or stored > limit or original > remaining:
-        _refuse("SOURCE_DECODE_LIMIT", "ZipNN frame exceeds configured or artifact bound")
-    # Only the byte-lossless, non-streaming 0.5 header layout used by this
-    # archive writer is supported. Tensor/shape, delta and lossy modes cannot
-    # be safely inferred from catalog SourceEvidence and must never reach C.
-    if (header[:4] != b"ZN\x00\x05" or header[8] != 1
-            or any(header[9:14]) or header[15] not in (1, 2, 4, 5, 6)
-            or header[7] not in (0, 1) or header[6] not in (0, 1)
-            or header[5] not in (10, 220)):
-        _refuse("SOURCE_DECODE_UNSUPPORTED", "unsupported ZipNN header")
-    if (stored < 32 or original == 0 or (stored_length is not None and stored != stored_length)
-            or header[14] > 26):
-        _refuse(detail="inconsistent ZipNN frame header")
-    from zipnn import ZipNN
-    blob = header + _exact(stream, stored - 32)
-    try:
-        decoded = ZipNN(input_format="byte", threads=1).decompress(blob)
-    except Exception as exc:
-        raise TransferRefusal("SOURCE_DECODE_INVALID", "ZipNN decoder refused frame") from exc
-    if not isinstance(decoded, (bytes, bytearray, memoryview)) or len(decoded) != original:
-        _refuse(detail="ZipNN decoded size differs from header")
-    return bytes(decoded)
-
-
-def _chunks(stream, compressed, expected, limit):
-    if not compressed:
-        while chunk := stream.read(min(limit, 1 << 20)):
-            yield chunk
-        return
-    prefix = stream.read(5)
-    if prefix == b"SZNN\x01":
-        remaining = expected
-        while length := stream.read(4):
-            if len(length) != 4:
-                _refuse(detail="truncated StreamZNN frame length")
-            size = struct.unpack("<I", length)[0]
-            if size > limit:
-                _refuse("SOURCE_DECODE_LIMIT", "stored StreamZNN frame exceeds bound")
-            if size < 32:
-                _refuse(detail="short StreamZNN frame")
-            data = _zipnn_frame(stream, b"", limit, remaining, size)
-            remaining -= len(data)
-            yield data
-    elif prefix.startswith(b"ZN"):
-        yield _zipnn_frame(stream, prefix, limit, expected)
-        if stream.read(1):
-            _refuse(detail="trailing whole-ZipNN data")
-    elif prefix.startswith(b"\x28\xb5\x2f\xfd"):
-        try:
-            import zstandard as zstd
-        except ImportError as exc:
-            raise TransferRefusal("SOURCE_DECODE_UNSUPPORTED", "zstandard is not installed") from exc
-        # zstd's maximum regenerated block is 128 KiB. Feeding no more
-        # than limit/128KiB input bytes bounds even maximally dense RLE output
-        # before Python gets the opportunity to check its length.
-        if limit < 128 << 10:
-            _refuse("SOURCE_DECODE_LIMIT", "zstd requires a 128 KiB decoding bound")
-        header = prefix
-        while True:
-            try:
-                params = zstd.get_frame_parameters(header)
-                break
-            except zstd.ZstdError:
-                if len(header) >= 18:
-                    _refuse(detail="invalid zstd header")
-                header += _exact(stream, 1)
-        if (params.window_size > limit
-                or params.content_size not in (zstd.CONTENTSIZE_UNKNOWN, zstd.CONTENTSIZE_ERROR)
-                and params.content_size > expected):
-            _refuse("SOURCE_DECODE_LIMIT", "zstd window/content exceeds bound")
-        decoder = zstd.ZstdDecompressor(max_window_size=max(1, limit // 1024)).decompressobj()
-        pending = header
-        try:
-            while pending:
-                data = decoder.decompress(pending)
-                if len(data) > limit:
-                    _refuse("SOURCE_DECODE_LIMIT", "zstd output block exceeds bound")
-                if data:
-                    yield data
-                if decoder.eof:
-                    if decoder.unused_data or stream.read(1):
-                        _refuse(detail="trailing/concatenated zstd data")
-                    break
-                pending = stream.read(max(1, limit // (128 << 10)))
-            if not decoder.eof:
-                _refuse(detail="truncated zstd frame")
-        except zstd.ZstdError as exc:
-            raise TransferRefusal("SOURCE_DECODE_INVALID", "zstd decoder refused frame") from exc
-    else:
-        _refuse("SOURCE_DECODE_UNSUPPORTED", "unknown compressed container")
-
-
-class _OriginalStream:
-    def __init__(self, stream, compressed, expected, limit, check):
-        self._chunks = iter(_chunks(stream, compressed, expected, limit))
-        self._pending = b""
-        self._offset = 0
-        self._total = 0
-        self._expected, self._limit, self._check = expected, limit, check
-        self._done = False
+class _SliceOriginalStream:
+    def __init__(self, reader):
+        self._reader = reader
 
     def read(self, size=-1):
-        if type(size) is not int or size < 0 or size > self._limit:
-            _refuse("SOURCE_DECODE_LIMIT", "explicit bounded read size required")
-        self._check()
-        if not size or self._done:
-            return b""
-        if self._offset == len(self._pending):
-            try:
-                self._pending = next(self._chunks)
-                self._offset = 0
-            except StopIteration:
-                self._done = True
-                if self._total != self._expected:
-                    _refuse(detail="decoded size differs from sealed original size")
-                return b""
-            self._total += len(self._pending)
-            if self._total > self._expected:
-                _refuse("SOURCE_DECODE_LIMIT", "decoded total exceeds sealed original size")
-        end = min(self._offset + size, len(self._pending))
-        data = self._pending[self._offset:end]
-        self._offset = end
-        self._check()
-        return data
+        try:
+            return self._reader.read(size)
+        except artifact_io.DecodeError as exc:
+            raise TransferRefusal(f"SOURCE_DECODE_{exc.kind}", exc.detail) from exc
 
 
 def original_stream(stream, *, compressed, expected_bytes, max_decode_bytes=64 << 20,
                     check=lambda: None):
-    """Wrap an already confined binary stream; caller retains descriptor ownership."""
-    if (type(expected_bytes) is not int or expected_bytes < 0
-            or type(max_decode_bytes) is not int or max_decode_bytes <= 0):
-        raise ValueError("nonnegative original size and positive decoding bound required")
-    return _OriginalStream(stream, compressed, expected_bytes, max_decode_bytes, check)
+    """Preserve legacy Slice limits; caller retains source descriptor ownership.
+
+    No new seal/resource policy or large-frame admission is enabled in Stage B.
+    """
+    limits = artifact_io.DecodeLimits(max_decode_bytes, max_decode_bytes,
+                                      max_decode_bytes, max_decode_bytes)
+    return _SliceOriginalStream(artifact_io.original_stream(
+        stream, compressed=compressed, expected_bytes=expected_bytes,
+        limits=limits, check=check))

--- a/modelark/streamznn.py
+++ b/modelark/streamznn.py
@@ -81,6 +81,14 @@ class OutputCapExceeded(StreamZnnError):
     """Compression would exceed the caller's guaranteed on-disk output ceiling."""
 
 
+class DecodeLimitExceeded(StreamZnnError):
+    """A frame or decoded total exceeds an explicit reader bound."""
+
+
+class UnsupportedFrame(StreamZnnError):
+    """A frame is outside the supported lossless byte-header contract."""
+
+
 def _zipnn(*, dtype: str | None = None, threads: int = 0):
     # Import only on an actual codec operation. Planning imports this module for
     # constants and must not initialize Torch or surface its dependency warnings.
@@ -92,18 +100,135 @@ def _zipnn(*, dtype: str | None = None, threads: int = 0):
     return ZipNN(**kwargs)
 
 
-def _read_exact(fh: BinaryIO, n: int) -> bytes:
+def _read_exact(fh: BinaryIO, n: int, *, read_size: int = _HASH_READ) -> bytes:
     """Read exactly `n` bytes from `fh` or raise StreamZnnError. A short read means a
     truncated/corrupt container — it is never returned as a silently-short slice."""
     if n < 0:
         raise StreamZnnError(f"negative read length {n}")
     buf = bytearray()
     while len(buf) < n:
-        piece = fh.read(n - len(buf))
+        piece = fh.read(min(read_size, n - len(buf)))
         if not piece:
             raise StreamZnnError(f"truncated container: wanted {n} bytes, got {len(buf)}")
+        if len(piece) > min(read_size, n - len(buf)):
+            raise StreamZnnError("source returned more bytes than requested")
         buf.extend(piece)
     return bytes(buf)
+
+
+def _positive_bound(value, name, *, zero=False):
+    if type(value) is not int or value < (0 if zero else 1):
+        raise ValueError(f"invalid {name}")
+
+
+def read_zipnn_frame(stream: BinaryIO, *, max_stored_bytes: int, max_decoded_bytes: int,
+                     remaining_bytes: int, stored_length: int | None = None,
+                     prefix: bytes = b"", read_size: int = _HASH_READ,
+                     decode_frame: Callable[[bytes], object] | None = None) -> bytes:
+    """Read one validated, non-streaming ZipNN 0.5 lossless byte frame.
+
+    Validate declared sizes/modes before reading the payload or calling native code.
+    `prefix` contains bytes already consumed from this frame. The optional decoder
+    receives the complete validated blob; its exceptions propagate unchanged.
+    This bounds buffers, NOT native working memory. Caller owns the input stream.
+    This deliberately narrower API does not change legacy path-wrapper support.
+    """
+    for value, name in ((max_stored_bytes, "stored bound"),
+                        (max_decoded_bytes, "decoded bound"), (read_size, "read size")):
+        _positive_bound(value, name)
+    _positive_bound(remaining_bytes, "remaining bytes", zero=True)
+    if not isinstance(prefix, bytes) or len(prefix) > 32:
+        raise ValueError("invalid frame prefix")
+    if stored_length is not None:
+        _positive_bound(stored_length, "stored length")
+        if stored_length > max_stored_bytes:
+            raise DecodeLimitExceeded("stored ZipNN frame exceeds bound")
+        if stored_length < 32:
+            raise StreamZnnError("short ZipNN frame")
+    header = prefix + _read_exact(stream, 32 - len(prefix), read_size=read_size)
+    original = int.from_bytes(header[16:24], "little")
+    stored = int.from_bytes(header[24:32], "little")
+    if original > max_decoded_bytes or stored > max_stored_bytes or original > remaining_bytes:
+        raise DecodeLimitExceeded("ZipNN frame exceeds configured or artifact bound")
+    if (header[:4] != b"ZN\x00\x05" or header[8] != 1
+            or any(header[9:14]) or header[15] not in (1, 2, 4, 5, 6)
+            or header[7] not in (0, 1) or header[6] not in (0, 1)
+            or header[5] not in (10, 220)):
+        raise UnsupportedFrame("unsupported ZipNN header")
+    if (stored < 32 or original == 0 or (stored_length is not None and stored != stored_length)
+            or header[14] > 26):
+        raise StreamZnnError("inconsistent ZipNN frame header")
+    blob = header + _read_exact(stream, stored - 32, read_size=read_size)
+    if decode_frame is None:
+        from zipnn import ZipNN
+        try:
+            decoded = ZipNN(input_format="byte", threads=1).decompress(blob)
+        except Exception as exc:
+            raise StreamZnnError("ZipNN decoder refused frame") from exc
+    else:
+        decoded = decode_frame(blob)
+    if (not isinstance(decoded, (bytes, bytearray, memoryview))
+            or (decoded.nbytes if isinstance(decoded, memoryview) else len(decoded)) != original):
+        raise StreamZnnError("ZipNN decoded size differs from header")
+    return bytes(decoded)
+
+
+def iter_decompress(stream: BinaryIO, *, max_stored_frame_bytes: int = _MAX_BLOB,
+                    max_decoded_frame_bytes: int | None = None,
+                    max_total_bytes: int | None = None, read_size: int = _HASH_READ,
+                    prefix: bytes = b"",
+                    frame_reader: Callable[[BinaryIO, int, int | None], bytes] | None = None):
+    """Yield restored frames from a caller-owned, possibly non-seekable stream.
+
+    Handles short reads and bounds each input request by `read_size`. `prefix`
+    is container magic already consumed by a dispatcher. Closing the iterator
+    never closes the supplied stream. IO and frame-reader exceptions propagate.
+
+    Default decoding preserves the historical standalone ZipNN acceptance and
+    exception behavior. Optional decoded/total limits are checked AFTER default
+    native decoding, not a native RAM guard. For untrusted byte frames, inject a
+    reader using `read_zipnn_frame` to validate headers before native allocation.
+    The callback receives (stream, stored_length, remaining_total_or_None), must
+    consume exactly that frame, and retains its own input-read/resource policy.
+    """
+    _positive_bound(max_stored_frame_bytes, "stored frame bound")
+    _positive_bound(read_size, "read size")
+    for value, name in ((max_decoded_frame_bytes, "decoded frame bound"),
+                        (max_total_bytes, "total bound")):
+        if value is not None:
+            _positive_bound(value, name, zero=True)
+    if not isinstance(prefix, bytes) or len(prefix) > len(MAGIC):
+        raise ValueError("invalid container prefix")
+    magic = prefix + _read_exact(stream, len(MAGIC) - len(prefix), read_size=read_size)
+    if magic != MAGIC:
+        raise StreamZnnError(f"bad magic {magic!r}: not a StreamZNN container")
+    total = 0
+    while True:
+        head = stream.read(1)
+        if head == b"":
+            return
+        if len(head) != 1:
+            raise StreamZnnError("source returned more bytes than requested")
+        head += _read_exact(stream, _LEN.size - 1, read_size=read_size)
+        (blob_len,) = _LEN.unpack(head)
+        if blob_len == 0:
+            raise StreamZnnError("implausible frame length 0")
+        if blob_len > max_stored_frame_bytes:
+            raise DecodeLimitExceeded("stored StreamZNN frame exceeds bound")
+        remaining = None if max_total_bytes is None else max_total_bytes - total
+        if frame_reader is None:
+            blob = _read_exact(stream, blob_len, read_size=read_size)
+            restored = bytes(_zipnn().decompress(blob))
+        else:
+            restored = frame_reader(stream, blob_len, remaining)
+        if not isinstance(restored, bytes):
+            raise StreamZnnError("frame reader must return bytes")
+        if max_decoded_frame_bytes is not None and len(restored) > max_decoded_frame_bytes:
+            raise DecodeLimitExceeded("decoded StreamZNN frame exceeds bound")
+        total += len(restored)
+        if max_total_bytes is not None and total > max_total_bytes:
+            raise DecodeLimitExceeded("decoded total exceeds bound")
+        yield restored
 
 
 def compress_file(
@@ -183,20 +308,7 @@ def decompress_to(src: StrPath, sink: Sink) -> None:
     problem; propagates ZipNN's own error on a corrupt blob.
     """
     with open(src, "rb") as fi:
-        magic = _read_exact(fi, len(MAGIC))
-        if magic != MAGIC:
-            raise StreamZnnError(f"bad magic {magic!r}: not a StreamZNN container")
-        while True:
-            head = fi.read(_LEN.size)
-            if head == b"":
-                return                          # clean EOF exactly at a frame boundary
-            if len(head) != _LEN.size:
-                raise StreamZnnError(f"truncated frame length: got {len(head)} of {_LEN.size} bytes")
-            (blob_len,) = _LEN.unpack(head)
-            if blob_len == 0 or blob_len > _MAX_BLOB:
-                raise StreamZnnError(f"implausible frame length {blob_len}")
-            blob = _read_exact(fi, blob_len)
-            restored: bytes = bytes(_zipnn().decompress(blob))
+        for restored in iter_decompress(fi):
             sink(restored)
 
 

--- a/modelark/streamznn.py
+++ b/modelark/streamznn.py
@@ -121,17 +121,14 @@ def _positive_bound(value, name, *, zero=False):
         raise ValueError(f"invalid {name}")
 
 
-def read_zipnn_frame(stream: BinaryIO, *, max_stored_bytes: int, max_decoded_bytes: int,
-                     remaining_bytes: int, stored_length: int | None = None,
-                     prefix: bytes = b"", read_size: int = _HASH_READ,
-                     decode_frame: Callable[[bytes], object] | None = None) -> bytes:
-    """Read one validated, non-streaming ZipNN 0.5 lossless byte frame.
+def read_zipnn_header(stream: BinaryIO, *, max_stored_bytes: int, max_decoded_bytes: int,
+                      remaining_bytes: int, stored_length: int | None = None,
+                      prefix: bytes = b"", read_size: int = _HASH_READ) -> bytes:
+    """Read/validate only the fixed header, leaving payload in the caller's stream.
 
-    Validate declared sizes/modes before reading the payload or calling native code.
-    `prefix` contains bytes already consumed from this frame. The optional decoder
-    receives the complete validated blob; its exceptions propagate unchanged.
-    This bounds buffers, NOT native working memory. Caller owns the input stream.
-    This deliberately narrower API does not change legacy path-wrapper support.
+    Shared interpretation for in-process readers, guarded workers and preflight.
+    No native import, payload allocation, process management or source ownership.
+    The returned header carries original/stored sizes at offsets 16/24 (uint64 LE).
     """
     for value, name in ((max_stored_bytes, "stored bound"),
                         (max_decoded_bytes, "decoded bound"), (read_size, "read size")):
@@ -158,6 +155,25 @@ def read_zipnn_frame(stream: BinaryIO, *, max_stored_bytes: int, max_decoded_byt
     if (stored < 32 or original == 0 or (stored_length is not None and stored != stored_length)
             or header[14] > 26):
         raise StreamZnnError("inconsistent ZipNN frame header")
+    return header
+
+
+def read_zipnn_frame(stream: BinaryIO, *, max_stored_bytes: int, max_decoded_bytes: int,
+                     remaining_bytes: int, stored_length: int | None = None,
+                     prefix: bytes = b"", read_size: int = _HASH_READ,
+                     decode_frame: Callable[[bytes], object] | None = None) -> bytes:
+    """Read one validated, non-streaming ZipNN 0.5 lossless byte frame.
+
+    The optional decoder receives the complete validated blob; its exceptions
+    propagate unchanged. Bounds buffers, NOT native working memory. Caller owns
+    the stream. Legacy path-wrapper format support is deliberately unchanged.
+    """
+    header = read_zipnn_header(
+        stream, max_stored_bytes=max_stored_bytes, max_decoded_bytes=max_decoded_bytes,
+        remaining_bytes=remaining_bytes, stored_length=stored_length,
+        prefix=prefix, read_size=read_size)
+    original = int.from_bytes(header[16:24], "little")
+    stored = int.from_bytes(header[24:32], "little")
     blob = header + _read_exact(stream, stored - 32, read_size=read_size)
     if decode_frame is None:
         from zipnn import ZipNN

--- a/scripts/qualify_codec_resources.py
+++ b/scripts/qualify_codec_resources.py
@@ -13,6 +13,7 @@ import argparse
 import hashlib
 import importlib.metadata
 import json
+import os
 from pathlib import Path
 import random
 import resource
@@ -21,9 +22,7 @@ import sys
 import tempfile
 
 from modelark.codec_resources import CodecMemoryPolicy, available_memory
-
-
-
+from modelark.codec_process import isolated_command, initialize_worker, runtime_record, validate_runtime
 
 def _dump(path, record):
     with Path(path).open("x") as handle:
@@ -72,10 +71,10 @@ def _metrics():
     return result
 
 
-def worker(request_path):
+def worker(request_path, parent_pid):
     request = json.loads(Path(request_path).read_text())
     policy = CodecMemoryPolicy.from_record(request["policy"])
-    policy.install_in_worker()  # before native imports, same for every operation
+    initialize_worker(policy, parent_pid)  # same guarded startup as the decoder
     before = _metrics()
     if request["phase"] == "allocation-refusal":
         try:
@@ -123,6 +122,7 @@ def worker(request_path):
                               "codec": request["codec"],
                               "zipnn_version": importlib.metadata.version("zipnn"),
                               "torch_version": importlib.metadata.version("torch"),
+                              "worker": validate_runtime(runtime_record(), policy),
                               "zipnn_module": str(Path(zipnn.__file__).name)})
 
 
@@ -133,10 +133,12 @@ def _guarded_roundtrip(encoded, size, expected_hash, policy):
     before = _metrics()
     digest = hashlib.sha256()
     total = maximum_piece = 0
+    evidence = {}
     with encoded.open("rb") as source:
         with guarded_zipnn_frame(source, policy=policy,
                                   max_stored_bytes=encoded.stat().st_size,
-                                  max_decoded_bytes=size, remaining_bytes=size) as chunks:
+                                  max_decoded_bytes=size, remaining_bytes=size,
+                                  on_complete=evidence.update) as chunks:
             for piece in chunks:
                 maximum_piece = max(maximum_piece, len(piece))
                 total += len(piece)
@@ -148,6 +150,7 @@ def _guarded_roundtrip(encoded, size, expected_hash, policy):
     return {"passed": True, "phase": "guarded-reader", "codec": "zipnn-whole",
             "policy": policy.to_record(), "original_bytes": size,
             "original_sha256": digest.hexdigest(), "maximum_output_piece": maximum_piece,
+            **evidence,
             "parent_metrics_before": before, "parent_metrics_after": _metrics()}
 
 
@@ -164,6 +167,7 @@ def run(*, large=False, output_parent=None, guarded_reader=False):
         name: _sha(checkout / name) for name in (
             "modelark/codec_resources.py", "modelark/compress.py", "modelark/streamznn.py",
             "modelark/codec_worker.py", "modelark/codec_supervisor.py",
+            "modelark/codec_process.py",
             "scripts/qualify_codec_resources.py")}
     print(f"Qualification directory: {output}", flush=True)
     index = 0
@@ -180,8 +184,8 @@ def run(*, large=False, output_parent=None, guarded_reader=False):
         # Native libraries may print: protocol is an exclusive result file, not stdout.
         with (output / f"{index:02d}-stdout.txt").open("x") as out, \
                 (output / f"{index:02d}-stderr.txt").open("x") as err:
-            proc = subprocess.Popen([sys.executable, "-m", "scripts.qualify_codec_resources",
-                                     "--worker", str(request_path)], stdout=out, stderr=err,
+            proc = subprocess.Popen(isolated_command("scripts.qualify_codec_resources",
+                                     "--worker", request_path, "--parent-pid", os.getpid()), stdout=out, stderr=err,
                                     close_fds=True)
             try:
                 code = proc.wait()
@@ -238,9 +242,10 @@ def main():
     parser.add_argument("--guarded-reader", action="store_true",
                         help="also qualify bounded parent/worker whole-frame transport")
     parser.add_argument("--worker", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--parent-pid", type=int, help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.worker:
-        worker(args.worker)
+        worker(args.worker, args.parent_pid)
     else:
         print(run(large=args.large, output_parent=args.output_parent, guarded_reader=args.guarded_reader))
 

--- a/scripts/qualify_codec_resources.py
+++ b/scripts/qualify_codec_resources.py
@@ -20,58 +20,9 @@ import subprocess
 import sys
 import tempfile
 
-from modelark.codec_resources import CodecMemoryPolicy, CodecResourceRefusal
+from modelark.codec_resources import CodecMemoryPolicy, available_memory
 
 
-def available_memory() -> dict:
-    """Conservative visible Linux memory headroom; unknown accounting refuses."""
-    try:
-        return _available_memory()
-    except (OSError, ValueError, OverflowError) as exc:
-        raise CodecResourceRefusal("could not establish memory headroom") from exc
-
-
-def _available_memory():
-    host_available = None
-    for line in Path("/proc/meminfo").read_text().splitlines():
-        fields = line.split()
-        if fields and fields[0] == "MemAvailable:":
-            if len(fields) != 3 or fields[2] != "kB":
-                raise CodecResourceRefusal("unrecognized MemAvailable accounting")
-            host_available = int(fields[1]) * 1024
-            if host_available < 0:
-                raise CodecResourceRefusal("negative host memory accounting")
-    if host_available is None:
-        raise CodecResourceRefusal("host available memory is unknown")
-    mounts = [line.split() for line in Path("/proc/self/mountinfo").read_text().splitlines()
-              if " - cgroup2 " in line]
-    if len(mounts) != 1 or mounts[0][3:5] != ["/", "/sys/fs/cgroup"]:
-        raise CodecResourceRefusal("full cgroup2 hierarchy is not visible")
-    groups = Path("/proc/self/cgroup").read_text().splitlines()
-    if len(groups) != 1 or not groups[0].startswith("0::/"):
-        raise CodecResourceRefusal("unrecognized unified cgroup membership")
-    relative = groups[0][4:]
-    if relative and any(part in {"", ".", ".."} for part in relative.split("/")):
-        raise CodecResourceRefusal("invalid cgroup membership")
-    root = Path("/sys/fs/cgroup")
-    current = root / relative
-    cgroup_headroom = {}
-    while True:
-        # Initial hierarchy roots have no memory.max; a visible namespace root
-        # may have one and its limit must not be discarded.
-        if current != root or (current / "memory.max").exists():
-            maximum = (current / "memory.max").read_text().strip()
-            used = int((current / "memory.current").read_text().strip())
-            if used < 0 or maximum != "max" and int(maximum) < 0:
-                raise CodecResourceRefusal("negative cgroup memory accounting")
-            if maximum != "max":
-                cgroup_headroom[str(current.relative_to(root))] = max(0, int(maximum) - used)
-        if current == root:
-            break
-        current = current.parent
-    return {"available_bytes": min([host_available, *cgroup_headroom.values()]),
-            "observations": {"host_available_bytes": host_available,
-                             "cgroup_headroom_bytes": cgroup_headroom}}
 
 
 def _dump(path, record):
@@ -175,17 +126,44 @@ def worker(request_path):
                               "zipnn_module": str(Path(zipnn.__file__).name)})
 
 
-def run(*, large=False, output_parent=None):
+def _guarded_roundtrip(encoded, size, expected_hash, policy):
+    """Exercise the actual bounded parent transport, not a buffered stand-in."""
+    from modelark.codec_supervisor import guarded_zipnn_frame, IO_BYTES
+
+    before = _metrics()
+    digest = hashlib.sha256()
+    total = maximum_piece = 0
+    with encoded.open("rb") as source:
+        with guarded_zipnn_frame(source, policy=policy,
+                                  max_stored_bytes=encoded.stat().st_size,
+                                  max_decoded_bytes=size, remaining_bytes=size) as chunks:
+            for piece in chunks:
+                maximum_piece = max(maximum_piece, len(piece))
+                total += len(piece)
+                digest.update(piece)
+        if source.read(1):
+            raise RuntimeError("guarded whole-frame fixture has trailing content")
+    if total != size or digest.hexdigest() != expected_hash or maximum_piece > IO_BYTES:
+        raise RuntimeError("guarded round trip differs from original or IO ceiling")
+    return {"passed": True, "phase": "guarded-reader", "codec": "zipnn-whole",
+            "policy": policy.to_record(), "original_bytes": size,
+            "original_sha256": digest.hexdigest(), "maximum_output_piece": maximum_piece,
+            "parent_metrics_before": before, "parent_metrics_after": _metrics()}
+
+
+def run(*, large=False, output_parent=None, guarded_reader=False):
     policy = CodecMemoryPolicy(8 << 30, 2 << 30)
     policy.admit(available_memory()["available_bytes"])
     output = Path(tempfile.mkdtemp(prefix="modelark-codec-qualification-", dir=output_parent))
     report = {"status": "running", "scope": "synthetic-codec-resource-qualification-only",
               "policy": policy.to_record(), "results": [], "large": large,
+              "guarded_reader": guarded_reader,
               "production_adoption": False, "physical_USB_or_archive_test": False}
     checkout = Path(__file__).resolve().parent.parent
     report["implementation_sha256"] = {
         name: _sha(checkout / name) for name in (
             "modelark/codec_resources.py", "modelark/compress.py", "modelark/streamznn.py",
+            "modelark/codec_worker.py", "modelark/codec_supervisor.py",
             "scripts/qualify_codec_resources.py")}
     print(f"Qualification directory: {output}", flush=True)
     index = 0
@@ -222,6 +200,8 @@ def run(*, large=False, output_parent=None):
     try:
         launch({"phase": "allocation-refusal"})
         sizes = [99_630_640, 409_993_344] if large else [2 << 20]
+        if large and guarded_reader:
+            sizes.insert(0, 64 << 20)  # Default StreamZNN-sized native work unit too.
         with tempfile.TemporaryDirectory(prefix="synthetic-", dir=output) as scratch:
             for size in sizes:
                 for codec in ("zipnn-whole", "streamznn"):
@@ -234,6 +214,10 @@ def run(*, large=False, output_parent=None):
                                "codec": codec, "sha256": digest}
                     for phase in ("compress", "canary", "restore"):
                         launch({**request, "phase": phase})
+                    if guarded_reader and codec == "zipnn-whole":
+                        result = _guarded_roundtrip(case / "misleading.blob", size, digest, policy)
+                        report["results"].append(result)
+                        print(f"passed guarded reader: {size} original bytes", flush=True)
         if any(_sha(checkout / name) != digest
                for name, digest in report["implementation_sha256"].items()):
             raise RuntimeError("implementation changed during qualification; rerun unchanged code")
@@ -251,12 +235,14 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--large", action="store_true", help="qualify the two real failure sizes")
     parser.add_argument("--output-parent", type=Path)
+    parser.add_argument("--guarded-reader", action="store_true",
+                        help="also qualify bounded parent/worker whole-frame transport")
     parser.add_argument("--worker", type=Path, help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.worker:
         worker(args.worker)
     else:
-        print(run(large=args.large, output_parent=args.output_parent))
+        print(run(large=args.large, output_parent=args.output_parent, guarded_reader=args.guarded_reader))
 
 
 if __name__ == "__main__":

--- a/tests/test_artifact_io.py
+++ b/tests/test_artifact_io.py
@@ -1,0 +1,215 @@
+"""Stage B: real writer compatibility, neutral boundaries, and legacy Slice policy."""
+import ast
+import hashlib
+import io
+from pathlib import Path
+import struct
+
+import pytest
+
+from modelark import artifact_io as aio, compress, streamznn as sz
+from modelark.slice.decoding import original_stream as slice_stream
+from modelark.slice.transaction import TransferRefusal
+
+
+class ShortSource:
+    """No seek/fileno/path; check every bounded input request."""
+
+    def __init__(self, data, *, piece=3, ceiling=4096):
+        self.buffer = io.BytesIO(data)
+        self.piece, self.ceiling = piece, ceiling
+        self.requests = []
+
+    def read(self, size):
+        assert 0 < size <= self.ceiling
+        self.requests.append(size)
+        return self.buffer.read(min(size, self.piece))
+
+
+def drain(reader, size=17):
+    return b"".join(iter(lambda: reader.read(size), b""))
+
+
+def frame(data):
+    return bytes(sz._zipnn(dtype="bfloat16", threads=1).compress(bytearray(data)))
+
+
+def container(*frames):
+    return sz.MAGIC + b"".join(struct.pack("<I", len(blob)) + blob for blob in frames)
+
+
+def limits(stored=4096, decoded=4096, read=17, window=1 << 20):
+    return aio.DecodeLimits(stored, decoded, read, window)
+
+
+@pytest.mark.parametrize("codec", [compress.CODEC_RAW, compress.CODEC_WHOLE, compress.CODEC_STREAM])
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16", "float32"])
+def test_real_writer_short_nonseekable_roundtrip(codec, dtype, tmp_path):
+    original = b"\0\x3f" * 512
+    src, stored, restored = (tmp_path / name for name in ("in", "misleading.blob", "out"))
+    src.write_bytes(original)
+    if codec == compress.CODEC_RAW:
+        stored.write_bytes(original)
+    else:
+        if codec == compress.CODEC_STREAM:
+            sz.compress_file(src, stored, dtype=dtype, threads=1, chunk_bytes=257)
+        else:
+            compress.compress_file(src, stored, codec=codec, dtype=dtype, threads=1)
+        assert compress.canary_ok(stored, hashlib.sha256(original).hexdigest())
+        compress.decompress_file(stored, restored)
+        assert restored.read_bytes() == original
+    source = ShortSource(stored.read_bytes())
+    reader = aio.original_stream(source, compressed=codec != compress.CODEC_RAW,
+                                 expected_bytes=len(original), limits=limits())
+    assert drain(reader) == original
+    assert max(source.requests) <= 17
+    assert not source.buffer.closed
+    assert src.read_bytes() == original
+    # The Slice adapter must use the same mechanism without new policy/seal behavior.
+    assert drain(slice_stream(ShortSource(stored.read_bytes()),
+                              compressed=codec != compress.CODEC_RAW,
+                              expected_bytes=len(original), max_decode_bytes=4096)) == original
+
+
+def test_separate_encoded_decoded_and_consumer_bounds():
+    original = bytes(range(16))
+    blob = frame(original)
+    assert len(blob) > len(original)  # framing overhead is distinct from original length
+    def reader(bound):
+        return aio.original_stream(ShortSource(blob, ceiling=2), compressed=True,
+                                   expected_bytes=len(original), limits=bound)
+    assert drain(reader(limits(len(blob), len(original), 2)), 2) == original
+    for bound in (limits(len(blob) - 1, len(original), 2),
+                  limits(len(blob), len(original) - 1, 2)):
+        with pytest.raises(aio.DecodeError, match="LIMIT"):
+            drain(reader(bound), 2)
+    with pytest.raises(aio.DecodeError, match="LIMIT"):
+        reader(limits(len(blob), len(original), 2)).read(3)
+
+
+@pytest.mark.parametrize("field,value,error", [(16, 4097, "LIMIT"), (24, 4097, "LIMIT"),
+                                               (16, 0, "INVALID"), (24, 31, "INVALID")])
+def test_frame_size_checks_precede_native(field, value, error, monkeypatch):
+    blob = bytearray(frame(bytes(128)))
+    blob[field:field + 8] = value.to_bytes(8, "little")
+    monkeypatch.setattr("zipnn.ZipNN.decompress", lambda *a, **k: pytest.fail("native reached"))
+    with pytest.raises(aio.DecodeError, match=error):
+        drain(aio.original_stream(ShortSource(blob), compressed=True,
+                                  expected_bytes=128, limits=limits()))
+
+
+@pytest.mark.parametrize("field,value", [(3, 6), (5, 0), (6, 2), (7, 2), (8, 2),
+                                        (9, 1), (10, 1), (11, 1), (12, 1), (13, 1), (15, 3)])
+def test_unsupported_byte_modes_never_reach_native(field, value, monkeypatch):
+    blob = bytearray(frame(bytes(128)))
+    blob[field] = value
+    monkeypatch.setattr("zipnn.ZipNN.decompress", lambda *a, **k: pytest.fail("native reached"))
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_UNSUPPORTED"):
+        drain(slice_stream(ShortSource(blob), compressed=True, expected_bytes=128,
+                           max_decode_bytes=4096))
+
+
+@pytest.mark.parametrize("transform", [lambda b: b[:-1], lambda b: b + b"x",
+                                       lambda b: container(b) + b"xx"])
+def test_corrupt_frame_and_trailing_content(transform):
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_INVALID"):
+        drain(slice_stream(ShortSource(transform(frame(bytes(128)))), compressed=True,
+                           expected_bytes=128, max_decode_bytes=4096))
+
+
+def test_stream_later_frame_over_total_refuses_before_second_native(monkeypatch):
+    blob = frame(bytes(128))
+    real = sz.read_zipnn_frame
+    decoded = []
+    def counted(*a, **kw):
+        value = real(*a, **kw)
+        decoded.append(value)
+        return value
+    monkeypatch.setattr(sz, "read_zipnn_frame", counted)
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_LIMIT"):
+        drain(slice_stream(ShortSource(container(blob, blob)), compressed=True,
+                           expected_bytes=128, max_decode_bytes=4096))
+    assert len(decoded) == 1
+
+
+@pytest.mark.parametrize("compressed,data,expected", [(False, b"abc", 4),
+                                                     (False, b"abc", 2),
+                                                     (True, sz.MAGIC, 1)])
+def test_total_length_mismatch(compressed, data, expected):
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE"):
+        drain(slice_stream(ShortSource(data), compressed=compressed, expected_bytes=expected,
+                           max_decode_bytes=4096))
+
+
+@pytest.mark.parametrize("where", ["source", "check"])
+def test_source_and_cancellation_exceptions_keep_identity(where):
+    problem = OSError("source changed") if where == "source" else TransferRefusal("STOP_REQUESTED")
+    events = []
+    class Source:
+        def read(self, size):
+            events.append("read")
+            if where == "source":
+                raise problem
+            return b"abc"
+    def check():
+        events.append("check")
+        if where == "check" and "read" in events:
+            raise problem
+    reader = slice_stream(Source(), compressed=False, expected_bytes=3, check=check)
+    with pytest.raises(type(problem)) as caught:
+        reader.read(3)
+    assert caught.value is problem
+
+
+def test_buffered_output_is_rechecked_without_new_source_read():
+    source = ShortSource(frame(bytes(128)))
+    stop = False
+    def check():
+        if stop:
+            raise TransferRefusal("STOP_REQUESTED")
+    reader = slice_stream(source, compressed=True, expected_bytes=128,
+                          max_decode_bytes=4096, check=check)
+    assert reader.read(1) == b"\0"
+    reads = len(source.requests)
+    stop = True
+    with pytest.raises(TransferRefusal, match="STOP_REQUESTED"):
+        reader.read(1)
+    assert len(source.requests) == reads
+
+
+def test_modules_keep_authority_and_standalone_boundaries():
+    for module in (aio, sz):
+        tree = ast.parse(Path(module.__file__).read_text())
+        imports = [name.name for node in ast.walk(tree) if isinstance(node, ast.Import)
+                   for name in node.names]
+        imports += [node.module or "" for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)]
+        assert not any("slice" in name or "catalog" in name or "sqlite" in name
+                       or "subprocess" in name for name in imports)
+    assert not any(isinstance(node, ast.ImportFrom) and node.level
+                   for node in ast.walk(ast.parse(Path(sz.__file__).read_text())))
+
+
+def test_optional_zstd_short_reads_and_distinct_window_limit():
+    zstd = pytest.importorskip("zstandard")
+    original = bytes(10000)
+    blob = zstd.ZstdCompressor(write_content_size=False).compress(original)
+    def reader(window):
+        return aio.original_stream(ShortSource(blob), compressed=True,
+                                   expected_bytes=len(original),
+                                   limits=limits(decoded=512 << 10, window=window))
+    assert drain(reader(64 << 20)) == original
+    with pytest.raises(aio.DecodeError, match="LIMIT"):
+        drain(reader(1024))
+
+
+def test_legacy_zstd_native_window_conversion_remains_a_known_limit():
+    """Stage B preserves legacy admission; Stage C must qualify the units repair."""
+    zstd = pytest.importorskip("zstandard")
+    original = bytes(256 << 10)
+    blob = zstd.ZstdCompressor(write_content_size=False).compress(original)
+    assert zstd.get_frame_parameters(blob).window_size == len(original)
+    # The dependency's native API accepts this bytes-valued ceiling. The existing
+    # Slice /1024 conversion is narrower than its 64 MiB header check suggests.
+    assert zstd.ZstdDecompressor(max_window_size=64 << 20).decompressobj().decompress(blob) == original
+    with pytest.raises(TransferRefusal, match="SOURCE_DECODE_INVALID"):
+        drain(slice_stream(ShortSource(blob), compressed=True, expected_bytes=len(original)))

--- a/tests/test_codec_process.py
+++ b/tests/test_codec_process.py
@@ -1,0 +1,148 @@
+"""Disposable venv startup proofs; no host hooks, settings or live data changed."""
+import json
+import io
+import os
+import subprocess
+import sys
+import time
+import venv
+
+import pytest
+
+from modelark.codec_process import isolated_command
+from modelark import codec_supervisor as cs
+from modelark.codec_resources import CodecMemoryPolicy
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Linux guard")
+
+
+@pytest.fixture
+def hooked_venv(tmp_path):
+    target = tmp_path / "venv"
+    venv.EnvBuilder(with_pip=False).create(target)
+    packages = target / f"lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages"
+    record = tmp_path / "hooks.jsonl"
+    (packages / "modelark_probe.py").write_text(
+        "import ctypes,json,os,resource,signal,sys\n"
+        "sig=ctypes.c_int()\n"
+        "assert ctypes.CDLL(None).prctl(2,ctypes.byref(sig),0,0,0)==0\n"
+        f"with open({str(record)!r},'a') as f:\n"
+        " f.write(json.dumps({'as':resource.getrlimit(resource.RLIMIT_AS),"
+        "'signal':sig.value,'prefix':sys.prefix,'pid':os.getpid()})+'\\n')\n")
+    (packages / "zz_modelark_probe.pth").write_text("import modelark_probe\n")
+    return target, packages, record
+
+
+@pytest.mark.parametrize("module", ["modelark.codec_worker", "scripts.qualify_codec_resources"])
+def test_both_workers_guard_before_site_hooks_and_restore_venv(hooked_venv, tmp_path, module, monkeypatch):
+    target, packages, record = hooked_venv
+    monkeypatch.setattr(sys, "executable", str(target / "bin/python"))
+    policy = {"version": "modelark.codec-memory.v1", "address_space_bytes": 128 << 20, "reserve_bytes": 0}
+    if module == "modelark.codec_worker":
+        request = {"version": "modelark.codec-worker.v2", "policy": policy,
+                   "stored_bytes": 36, "original_bytes": 4}
+        read, write = os.pipe()
+        try:
+            result = subprocess.run(isolated_command(module, write, os.getpid(), json.dumps(request)),
+                                    input=b"", capture_output=True, pass_fds=(write,))
+        finally:
+            os.close(write)
+        response = os.read(read, 8192)
+        os.close(read)
+        assert result.returncode == 1
+        assert response[:1] == b"I", result.stderr
+    else:
+        request = tmp_path / "request.json"
+        output = tmp_path / "result.json"
+        request.write_text(json.dumps({"policy": policy, "phase": "allocation-refusal", "result": str(output)}))
+        result = subprocess.run(isolated_command(module, "--worker", request, "--parent-pid", os.getpid()),
+                                capture_output=True)
+        assert result.returncode == 0, result.stderr
+        assert json.loads(output.read_text())["allocation_refused"]
+    records = [json.loads(line) for line in record.read_text().splitlines()]
+    assert records
+    assert all(r["as"] == [128 << 20] * 2 and r["signal"] == 9 for r in records)
+    assert all(r["prefix"] == str(target) for r in records)
+
+
+def test_parent_death_during_actual_site_hook(hooked_venv):
+    target, packages, record = hooked_venv
+    # Hook announces that it has reached guarded site initialization, then blocks
+    # in libc, so no Python cooperation can make the lifetime test pass.
+    with (packages / "modelark_probe.py").open("a") as handle:
+        handle.write("ctypes.CDLL(None).pause()\n")
+    program = r'''
+import ctypes, json, os, signal, subprocess, sys, time
+from pathlib import Path
+from modelark.codec_process import isolated_command
+assert ctypes.CDLL(None).prctl(36,1,0,0,0)==0
+parent=os.fork()
+if parent==0:
+    sys.executable=sys.argv[1]
+    r,w=os.pipe()
+    request={"version":"modelark.codec-worker.v2","stored_bytes":36,"original_bytes":4,
+             "policy":{"version":"modelark.codec-memory.v1","address_space_bytes":128<<20,"reserve_bytes":0}}
+    proc=subprocess.Popen(isolated_command('modelark.codec_worker',w,os.getpid(),json.dumps(request)),
+          stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE,pass_fds=(w,))
+    proc.wait()
+    os._exit(2)
+worker=None
+try:
+    deadline=time.monotonic()+10
+    marker=Path(sys.argv[2])
+    while not marker.exists():
+        assert time.monotonic()<deadline, 'site hook never started'
+        time.sleep(.01)
+    # File existence alone is not the synchronization signal; wait for its line.
+    while not marker.read_text().endswith('\n'):
+        assert time.monotonic()<deadline
+        time.sleep(.01)
+    worker=json.loads(marker.read_text().splitlines()[0])['pid']
+finally:
+    os.kill(parent,signal.SIGKILL)
+    os.waitpid(parent,0)
+if worker is not None:
+    pid,status=os.waitpid(worker,0)
+    assert pid==worker and os.WIFSIGNALED(status) and os.WTERMSIG(status)==signal.SIGKILL
+print('startup-parent-death-contained')
+'''
+    result = subprocess.run([sys.executable, "-c", program, str(target / "bin/python"), str(record)],
+                            capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "startup-parent-death-contained"
+
+
+def test_cancellation_during_actual_site_hook(hooked_venv, monkeypatch):
+    target, packages, record = hooked_venv
+    with (packages / "modelark_probe.py").open("a") as handle:
+        handle.write("ctypes.CDLL(None).pause()\n")
+    monkeypatch.setattr(sys, "executable", str(target / "bin/python"))
+    monkeypatch.setattr(cs, "available_memory", lambda: {"available_bytes": 10 << 30})
+    children = []
+    real = cs._launch
+    def launch(request, output):
+        child = real(request, output)
+        children.append(child)
+        return child
+    monkeypatch.setattr(cs, "_launch", launch)
+    failure = RuntimeError("operator stop during startup")
+    deadline = time.monotonic() + 10
+    def check():
+        if record.exists() and record.read_text().endswith("\n"):
+            raise failure
+        assert time.monotonic() < deadline, "site hook never started"
+    header = bytearray(32)
+    header[:4] = b"ZN\x00\x05"
+    header[5], header[8], header[15] = 10, 1, 1
+    header[16:24], header[24:32] = (4).to_bytes(8, "little"), (36).to_bytes(8, "little")
+    with pytest.raises(RuntimeError) as caught:
+        with cs.guarded_zipnn_frame(io.BytesIO(header + b"abcd"), policy=CodecMemoryPolicy(128 << 20, 0),
+                                    max_stored_bytes=36, max_decoded_bytes=4, remaining_bytes=4,
+                                    check=check) as parts:
+            list(parts)
+    assert caught.value is failure
+    assert len(children) == 1
+    child = children[0]
+    assert child.poll() is not None and child.stdin.closed and child.stdout.closed
+    with pytest.raises(ChildProcessError):
+        os.waitpid(child.pid, os.WNOHANG)

--- a/tests/test_codec_supervisor.py
+++ b/tests/test_codec_supervisor.py
@@ -18,6 +18,16 @@ pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Linux guard")
 POLICY = CodecMemoryPolicy(8 << 30, 0)
 
 
+def runtime():
+    return {"version": "modelark.codec-runtime.v1",
+            "startup": "isolated-no-site-guard-then-site.v1",
+            "python": "test", "executable": "/test/python", "prefix": "/test",
+            "base_prefix": "/base", "address_space_bytes": [8 << 30, 8 << 30],
+            "parent_death_signal": 9,
+            "zipnn": {"distribution_version": "test", "module": "/test/zipnn.py"},
+            "torch": {"distribution_version": "test", "module": "/test/torch.py"}}
+
+
 def header(original=4, stored=36):
     value = bytearray(32)
     value[:4] = b"ZN\x00\x05"
@@ -41,13 +51,26 @@ def decode(source=None, **kwargs):
                                   **{**defaults, **kwargs})
 
 
-def launch_fake(monkeypatch, body):
+def launch_fake(monkeypatch, body, *, add_metadata=True):
     children = []
     def launch(request, output):
         program = ("import os,sys,signal,time,json\n"
-                   "from modelark.codec_worker import bind_parent\n"
+                   "from modelark.codec_process import bind_parent\n"
                    "bind_parent(int(sys.argv[2]))\n"
-                   "output=int(sys.argv[1])\n" + body)
+                   "output=int(sys.argv[1])\n")
+        if add_metadata:
+            program += f"metadata={json.dumps(runtime()).encode()!r}\n" + '''
+real_write=os.write
+metadata_sent=False
+def write(fd, data):
+    global metadata_sent
+    if fd==output and data[:1]==b'O' and not metadata_sent:
+        real_write(fd,b'M'+len(metadata).to_bytes(8,'little')+metadata)
+        metadata_sent=True
+    return real_write(fd,data)
+os.write=write
+'''
+        program += body
         proc = subprocess.Popen([sys.executable, "-c", program, str(output), str(os.getpid())],
                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT, close_fds=True,
@@ -247,8 +270,9 @@ def test_real_writer_frame_decodes_hash_and_closes_without_source_ownership():
     # Give it an owned copy so the expected original remains an independent oracle.
     stored = zipnn.ZipNN(input_format="byte", bytearray_dtype="bfloat16", threads=1).compress(bytearray(original))
     source = io.BytesIO(stored)
+    evidence = []
     with decode(source, max_stored_bytes=len(stored), max_decoded_bytes=len(original),
-                remaining_bytes=len(original)) as parts:
+                remaining_bytes=len(original), on_complete=evidence.append) as parts:
         digest = hashlib.sha256()
         total = 0
         for block in parts:
@@ -258,6 +282,13 @@ def test_real_writer_frame_decodes_hash_and_closes_without_source_ownership():
     assert total == len(original)
     assert digest.digest() == hashlib.sha256(original).digest()
     assert not source.closed
+    assert len(evidence) == 1
+    assert evidence[0]["admission"] == {"available_bytes": 10 << 30}
+    actual = evidence[0]["worker"]
+    assert actual["executable"] == sys.executable
+    assert actual["prefix"] == sys.prefix
+    assert actual["zipnn"]["module"] == str(Path(zipnn.__file__).resolve())
+    assert actual["address_space_bytes"] == [POLICY.address_space_bytes] * 2
 
 
 def test_worker_origin_is_not_resolved_from_untrusted_cwd(monkeypatch, tmp_path):
@@ -295,12 +326,12 @@ if parent==0:
         if phase=='input':
             proc=real(request,output)
         else:
-            body="import ctypes,os,sys\nfrom modelark.codec_worker import bind_parent\nbind_parent(int(sys.argv[2]))\nsys.stdin.buffer.read()\n"
+            body="import ctypes,os,sys\nfrom modelark.codec_process import bind_parent\nbind_parent(int(sys.argv[2]))\nsys.stdin.buffer.read()\n"
             if phase=='compute':
                 body+="ctypes.CDLL(None).pause()\n"
             else:
-                body+="os.write(int(sys.argv[1]),b'O'+(1<<20).to_bytes(8,'little'))\nwhile True: os.write(int(sys.argv[1]),b'x'*65536)\n"
-            proc=subprocess.Popen([sys.executable,'-c',body,str(output),str(os.getpid())],
+                body+="import json\nm=sys.argv[3].encode()\nos.write(int(sys.argv[1]),b'M'+len(m).to_bytes(8,'little')+m)\nos.write(int(sys.argv[1]),b'O'+(1<<20).to_bytes(8,'little'))\nwhile True: os.write(int(sys.argv[1]),b'x'*65536)\n"
+            proc=subprocess.Popen([sys.executable,'-c',body,str(output),str(os.getpid()),sys.argv[2]],
                 stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.STDOUT,
                 close_fds=True,pass_fds=(output,),bufsize=0)
         os.write(w,str(proc.pid).encode()+b'\n')
@@ -323,7 +354,7 @@ pid,status=os.waitpid(worker,0)
 assert pid==worker and os.WIFSIGNALED(status) and os.WTERMSIG(status)==signal.SIGKILL
 print('parent-death-contained')
 '''
-    result = subprocess.run([sys.executable, "-c", program, phase], capture_output=True, text=True)
+    result = subprocess.run([sys.executable, "-c", program, phase, json.dumps(runtime())], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "parent-death-contained"
 
@@ -344,32 +375,174 @@ def test_launch_failure_closes_pipes(monkeypatch):
 def test_worker_request_is_closed_world():
     from modelark.codec_worker import run
     with pytest.raises(ValueError, match="fields"):
-        run({"version": "modelark.codec-worker.v1", "source_path": "/unauthorized"}, None)
+        run({"version": "modelark.codec-worker.v2", "source_path": "/unauthorized"}, None)
     assert json.loads(json.dumps(POLICY.to_record())) == POLICY.to_record()
 
 
 @pytest.mark.parametrize("failure", [BrokenPipeError(), MemoryError()])
-def test_worker_never_appends_error_after_success_header(monkeypatch, failure):
+@pytest.mark.parametrize("fail_at", [1, 2, 3, 4])
+def test_worker_never_appends_error_after_success_header(monkeypatch, failure, fail_at):
     from modelark import codec_worker as worker
-    monkeypatch.setattr(worker, "bind_parent", lambda pid: None)
+    monkeypatch.setattr(worker, "initialize_worker", lambda policy, pid: None)
+    monkeypatch.setattr(worker, "_policy", lambda request: POLICY)
     monkeypatch.setattr(worker, "run", lambda request, source: b"abcd")
+    monkeypatch.setattr(worker, "runtime_record", runtime)
     sent = []
     def send(fd, data):
         sent.append(data)
-        if len(sent) >= 2:
+        if len(sent) >= fail_at:
             raise failure
     monkeypatch.setattr(worker, "_send", send)
     assert worker.main(["worker", "99", str(os.getpid()), "{}"]) == 1
-    assert sent == [b"O" + (4).to_bytes(8, "little"), b"abcd"]
+    metadata = json.dumps(runtime(), separators=(",", ":")).encode()
+    assert sent == [b"M" + len(metadata).to_bytes(8, "little"), metadata,
+                    b"O" + (4).to_bytes(8, "little"), b"abcd"][:fail_at]
 
 
 def test_parent_guard_failure_is_not_reported_as_ram(monkeypatch):
     from modelark import codec_worker as worker
-    def fail(pid):
+    def fail(policy, pid):
         raise worker.WorkerInitializationError("no parent guard")
-    monkeypatch.setattr(worker, "bind_parent", fail)
+    monkeypatch.setattr(worker, "initialize_worker", fail)
+    monkeypatch.setattr(worker, "_policy", lambda request: POLICY)
     sent = []
     monkeypatch.setattr(worker, "_send", lambda fd, data: sent.append(data))
     assert worker.main(["worker", "99", str(os.getpid()), "{}"]) == 1
     assert len(sent) == 1 and sent[0][:1] == b"I"
     assert sent[0][9:] == b"codec worker initialization failed"
+
+
+@pytest.mark.parametrize("payload", [
+    b"", b"{}", b"[]", b"null", b"\xff", b"[" * 1500 + b"]" * 1500,
+    json.dumps({**runtime(), "address_space_bytes": [1, 1]}).encode(),
+    json.dumps({**runtime(), "parent_death_signal": True}).encode(),
+    json.dumps({**runtime(), "extra": "not permitted"}).encode(),
+    json.dumps({**runtime(), "zipnn": {"distribution_version": "x", "module": "relative"}}).encode(),
+])
+def test_malformed_metadata_never_reaches_original_output(monkeypatch, payload):
+    children = launch_fake(monkeypatch,
+        f"sys.stdin.buffer.read(); m={payload!r}\n"
+        "os.write(output,b'M'+len(m).to_bytes(8,'little')+m+b'O'+(4).to_bytes(8,'little')+b'abcd')",
+        add_metadata=False)
+    completed = []
+    yielded = []
+    with pytest.raises(cs.WorkerRefusal) as caught:
+        with decode(on_complete=completed.append) as parts:
+            for piece in parts:
+                yielded.append(piece)
+    assert caught.value.kind == "INVALID"
+    assert not completed and not yielded
+    assert_reaped(children)
+
+
+@pytest.mark.parametrize("suffix", [
+    "b'M'+(8193).to_bytes(8,'little')",
+    "b'M'+(2).to_bytes(8,'little')+b'{'",
+    "b'O'+(4).to_bytes(8,'little')+b'abcd'",  # missing metadata
+    "frame",  # no original response
+    "frame+frame",  # repeated metadata
+    "frame+b'R'+(3).to_bytes(8,'little')+b'ram'",  # error after metadata
+])
+def test_metadata_protocol_phase_failures(monkeypatch, suffix):
+    body = (f"sys.stdin.buffer.read(); m={json.dumps(runtime()).encode()!r}\n"
+            "frame=b'M'+len(m).to_bytes(8,'little')+m\n"
+            f"os.write(output,{suffix})")
+    children = launch_fake(monkeypatch, body, add_metadata=False)
+    completed = []
+    with pytest.raises(cs.WorkerRefusal):
+        with decode(on_complete=completed.append) as parts:
+            list(parts)
+    assert not completed
+    assert_reaped(children)
+
+
+@pytest.mark.parametrize("finish", ["close", "nonzero", "success"])
+def test_completion_evidence_requires_exhaustion_and_success(monkeypatch, finish):
+    children = launch_fake(monkeypatch,
+        "sys.stdin.buffer.read(); os.write(output,b'O'+(4).to_bytes(8,'little')+b'abcd')\n"
+        + ("sys.exit(2)" if finish == "nonzero" else ""))
+    sample = {"available_bytes": 10 << 30, "observations": {"sample": "this launch only"}}
+    monkeypatch.setattr(cs, "available_memory", lambda: sample)
+    completed = []
+    def consume():
+        with decode(on_complete=completed.append) as parts:
+            assert next(parts) == b"abcd"
+            assert not completed
+            if finish != "close":
+                assert list(parts) == []
+    if finish == "nonzero":
+        with pytest.raises(cs.WorkerRefusal):
+            consume()
+    else:
+        consume()
+    if finish == "success":
+        assert completed == [{"admission": sample, "worker": runtime()}]
+        assert completed[0]["admission"] is sample
+    else:
+        assert not completed
+    assert_reaped(children)
+
+
+@pytest.mark.parametrize("closed", [[], [0], [1], [2], [0, 1], [0, 2], [1, 2], [0, 1, 2]])
+def test_real_launch_with_closed_standard_descriptors(closed):
+    # Close only disposable process descriptors; preserve a private result FD.
+    program = r'''
+import io, os, sys
+from modelark import codec_supervisor as cs
+from modelark.codec_resources import CodecMemoryPolicy
+result=os.dup(1)
+assert result>2
+for fd in map(int, sys.argv[1:]): os.close(fd)
+cs.available_memory=lambda: {"available_bytes": 10<<30}
+real_launch=cs._launch
+def mismatch(request, writer):
+    # Force a deterministic header refusal before any native import/allocation;
+    # this test qualifies the real launch/FD path, not malformed codec behavior.
+    return real_launch({**request, 'stored_bytes':request['stored_bytes']+1}, writer)
+cs._launch=mismatch
+h=bytearray(32); h[:4]=b'ZN\x00\x05'; h[5]=10; h[8]=h[15]=1
+h[16:24]=(4).to_bytes(8,'little'); h[24:32]=(36).to_bytes(8,'little')
+try:
+    with cs.guarded_zipnn_frame(io.BytesIO(h+b'abcd'),policy=CodecMemoryPolicy(8<<30,0),
+            max_stored_bytes=36,max_decoded_bytes=4,remaining_bytes=4) as parts:
+        list(parts)
+except cs.WorkerRefusal as exc:
+    # Only the actual worker's typed refusal proves the result pipe survived.
+    assert exc.kind=='INVALID', exc
+else:
+    raise AssertionError('malformed frame accepted')
+os.write(result,b'closed-stdio-contained')
+os._exit(0)
+'''
+    result = subprocess.run([sys.executable, "-c", program, *map(str, closed)], capture_output=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == b"closed-stdio-contained"
+
+
+def test_descriptor_normalization_failure_closes_original_pipe(monkeypatch):
+    import fcntl
+    real_pipe = os.pipe
+    pipes = []
+    def pipe():
+        result = real_pipe()
+        pipes.extend(result)
+        return result
+    # Force this branch without changing the process's real stdio descriptors.
+    class LowDescriptor(int):
+        def __lt__(self, other):
+            return other == 3
+    def low_pipe():
+        read, write = pipe()
+        return read, LowDescriptor(write)
+    failure = OSError(errno.EMFILE, "no descriptors")
+    def fail(*args):
+        raise failure
+    monkeypatch.setattr(cs.os, "pipe", low_pipe)
+    monkeypatch.setattr(fcntl, "fcntl", fail)
+    with pytest.raises(OSError) as caught:
+        with decode():
+            pass
+    assert caught.value is failure
+    for fd in pipes:
+        with pytest.raises(OSError):
+            os.fstat(fd)

--- a/tests/test_codec_supervisor.py
+++ b/tests/test_codec_supervisor.py
@@ -1,0 +1,333 @@
+"""Real pipes/children with synthetic protocols; no live sources or destinations."""
+import errno
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+import pytest
+
+from modelark import codec_supervisor as cs, streamznn as sz
+from modelark.codec_resources import CodecMemoryPolicy, CodecResourceRefusal
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Linux guard")
+POLICY = CodecMemoryPolicy(8 << 30, 0)
+
+
+def header(original=4, stored=36):
+    value = bytearray(32)
+    value[:4] = b"ZN\x00\x05"
+    value[5], value[8], value[15] = 10, 1, 1
+    value[16:24] = original.to_bytes(8, "little")
+    value[24:32] = stored.to_bytes(8, "little")
+    return bytes(value)
+
+
+@pytest.fixture(autouse=True)
+def synthetic_admission(monkeypatch):
+    # Transport tests do not qualify host RAM. The qualification CLI samples
+    # real headroom. The real child AS guard is NOT patched or disabled here.
+    monkeypatch.setattr(cs, "available_memory", lambda: {"available_bytes": 10 << 30})
+
+
+def decode(source=None, **kwargs):
+    defaults = dict(policy=POLICY, max_stored_bytes=1 << 20,
+                    max_decoded_bytes=1 << 20, remaining_bytes=1 << 20)
+    return cs.guarded_zipnn_frame(source if source is not None else io.BytesIO(header() + b"abcd"),
+                                  **{**defaults, **kwargs})
+
+
+def launch_fake(monkeypatch, body):
+    children = []
+    def launch(request, output):
+        program = ("import os,sys,signal,time,json\n"
+                   "from modelark.codec_worker import bind_parent\n"
+                   "bind_parent(int(sys.argv[2]))\n"
+                   "output=int(sys.argv[1])\n" + body)
+        proc = subprocess.Popen([sys.executable, "-c", program, str(output), str(os.getpid())],
+                                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, close_fds=True,
+                                pass_fds=(output,), bufsize=0)
+        children.append(proc)
+        return proc
+    monkeypatch.setattr(cs, "_launch", launch)
+    return children
+
+
+def assert_reaped(children):
+    assert children
+    for child in children:
+        assert child.poll() is not None
+        assert child.stdin.closed and child.stdout.closed
+        with pytest.raises(ChildProcessError):
+            os.waitpid(child.pid, os.WNOHANG)
+
+
+def test_success_short_input_and_diagnostic_flood(monkeypatch):
+    children = launch_fake(monkeypatch, '''
+data=sys.stdin.buffer.read()
+for _ in range(64):
+    os.write(1,b'x'*65536)
+    os.write(2,b'y'*65536)
+for piece in [b'O', (4).to_bytes(8,'little'), b'ab', b'cd']:
+    os.write(output,piece)
+''')
+    class Short(io.BytesIO):
+        def read(self, size):
+            assert 0 < size <= cs.IO_BYTES
+            return super().read(min(size, 3))
+    source = Short(header() + b"abcd" + b"next frame")
+    checks = []
+    with decode(source, check=lambda: checks.append(source.tell())) as parts:
+        assert b"".join(parts) == b"abcd"
+    assert source.tell() == 36 and not source.closed
+    assert len(checks) > 20
+    assert_reaped(children)
+
+
+@pytest.mark.parametrize("body,kind", [
+    ("sys.stdin.buffer.read(); os.abort()", "WORKER_FAILED"),
+    ("sys.stdin.buffer.read(); os.write(output,b'O'+(4).to_bytes(8,'little')+b'ab')", "WORKER_FAILED"),
+    ("sys.stdin.buffer.read(); os.write(output,b'O'+(5).to_bytes(8,'little'))", "INVALID"),
+    ("sys.stdin.buffer.read(); os.write(output,b'X'+bytes(8))", "INVALID"),
+    ("os.write(output,b'R'+(4097).to_bytes(8,'little'))", "INVALID"),
+    ("os.write(output,b'R'+(3).to_bytes(8,'little')+b'ram')", "RESOURCE"),
+    ("sys.stdin.buffer.read(); os.write(output,b'O'+(4).to_bytes(8,'little')+b'abcde')", "INVALID"),
+    ("sys.stdin.buffer.read(); os.write(output,b'O'+(4).to_bytes(8,'little')+b'abcd'); sys.exit(2)", "WORKER_FAILED"),
+])
+def test_untrusted_worker_protocol_and_crash(monkeypatch, body, kind):
+    children = launch_fake(monkeypatch, "import resource\nresource.setrlimit(resource.RLIMIT_CORE,(0,0))\n" + body)
+    with pytest.raises(cs.WorkerRefusal) as caught:
+        with decode() as parts:
+            list(parts)
+    assert caught.value.kind == kind
+    assert_reaped(children)
+
+
+@pytest.mark.parametrize("phase", ["input", "compute", "output"])
+def test_cancel_kills_reaps_and_preserves_exception(monkeypatch, phase):
+    body = {
+        "input": "while True: time.sleep(.02)",
+        "compute": "sys.stdin.buffer.read()\nwhile True: time.sleep(.02)",
+        "output": "sys.stdin.buffer.read()\nos.write(output,b'O'+(1<<20).to_bytes(8,'little'))\n"
+                  "while True: os.write(output,b'x'*4096); time.sleep(.02)",
+    }[phase]
+    children = launch_fake(monkeypatch, body)
+    problem = RuntimeError("stop or detached source")
+    start = time.monotonic()
+    checks = 0
+    def check():
+        nonlocal checks
+        checks += 1
+        if time.monotonic() - start > .25:
+            raise problem
+    source = io.BytesIO(header(original=1 << 20, stored=1 << 20) + bytes((1 << 20) - 32))
+    with pytest.raises(RuntimeError) as caught:
+        with decode(source, check=check) as parts:
+            for _ in parts:
+                pass
+    assert caught.value is problem
+    assert time.monotonic() - start < 3
+    assert checks > 4
+    assert not source.closed
+    assert_reaped(children)
+
+
+def test_consumer_enospc_reaps_before_outer_fence_exit(monkeypatch):
+    children = launch_fake(monkeypatch, "sys.stdin.buffer.read()\nos.write(output,b'O'+(1<<20).to_bytes(8,'little'))\n"
+                           "while True: os.write(output,b'x'*65536)")
+    failure = OSError(errno.ENOSPC, "destination full")
+    with pytest.raises(OSError) as caught:
+        try:
+            with decode(io.BytesIO(header(original=1 << 20) + b"abcd")) as parts:
+                assert next(parts)
+                raise failure
+        finally:
+            assert_reaped(children)  # Models source fence release ordering.
+    assert caught.value is failure
+
+
+def test_source_error_identity_and_truncation(monkeypatch):
+    children = launch_fake(monkeypatch, "sys.stdin.buffer.read()")
+    problem = OSError(errno.EIO, "archive read failed")
+    class Broken(io.BytesIO):
+        def read(self, size):
+            if self.tell() >= 32:
+                raise problem
+            return super().read(size)
+    with pytest.raises(OSError) as caught:
+        with decode(Broken(header() + b"abcd")) as parts:
+            list(parts)
+    assert caught.value is problem
+    with pytest.raises(sz.StreamZnnError, match="truncated"):
+        with decode(io.BytesIO(header() + b"ab")) as parts:
+            list(parts)
+    assert_reaped(children)
+
+
+def test_header_and_resource_refusal_precede_spawn_payload(monkeypatch):
+    monkeypatch.setattr(cs, "_launch", lambda *a: pytest.fail("must not spawn"))
+    source = io.BytesIO(header(original=2 << 20) + b"abcd")
+    with pytest.raises(sz.DecodeLimitExceeded):
+        with decode(source):
+            pytest.fail("must not yield")
+    assert source.tell() == 32
+    monkeypatch.setattr(cs, "available_memory", lambda: {"available_bytes": 1})
+    source = io.BytesIO(header() + b"abcd")
+    with pytest.raises(CodecResourceRefusal):
+        with decode(source):
+            pytest.fail("must not yield")
+    assert source.tell() == 32
+
+
+def test_no_authority_fds_inherited(monkeypatch, tmp_path):
+    secret = tmp_path / "archive-fence-catalog-destination"
+    with secret.open("wb") as authority:
+        os.set_inheritable(authority.fileno(), True)
+        children = launch_fake(monkeypatch, f'''
+assert all(os.readlink('/proc/self/fd/'+name) != {str(secret)!r}
+           for name in os.listdir('/proc/self/fd') if os.path.exists('/proc/self/fd/'+name))
+sys.stdin.buffer.read()
+os.write(output,b'O'+(4).to_bytes(8,'little')+b'abcd')
+''')
+        with decode() as parts:
+            assert b"".join(parts) == b"abcd"
+        assert_reaped(children)
+
+
+def test_actual_launch_does_not_inherit_unrelated_fd(monkeypatch, tmp_path):
+    launch = cs._launch
+    processes = []
+    def capture(request, output):
+        proc = launch(request, output)
+        processes.append(proc)
+        return proc
+    monkeypatch.setattr(cs, "_launch", capture)
+    path = tmp_path / "authority"
+    with path.open("wb") as authority:
+        os.set_inheritable(authority.fileno(), True)
+        # Worker waits for stdin. Examine its own FD table after exec, not a fake
+        # launcher. No source bytes are sent until next(parts).
+        with decode():
+            proc = processes[0]
+            deadline = time.monotonic() + 3
+            while True:
+                fdroot = Path(f"/proc/{proc.pid}/fd")
+                links = []
+                for entry in fdroot.iterdir():
+                    try:
+                        links.append(os.readlink(entry))
+                    except FileNotFoundError:
+                        pass
+                assert str(path) not in links
+                if "modelark.codec_worker" in Path(f"/proc/{proc.pid}/cmdline").read_bytes().decode():
+                    break
+                assert time.monotonic() < deadline
+                time.sleep(.01)
+    assert_reaped(processes)
+
+
+def test_real_worker_guard_refuses_before_native_import():
+    with pytest.raises(cs.WorkerRefusal) as caught:
+        with decode(policy=CodecMemoryPolicy(32 << 20, 0)) as parts:
+            list(parts)
+    assert caught.value.kind in {"RESOURCE", "INVALID", "WORKER_FAILED"}
+    # Native dependencies may raise ImportError after guard-denied mappings;
+    # none of these failure paths may retry unguarded or certify success.
+
+
+def test_real_writer_frame_decodes_hash_and_closes_without_source_ownership():
+    zipnn = pytest.importorskip("zipnn")
+    original = b"\x00\x3f\x80\x3f" * (1 << 18)
+    # ZipNN reorders its input in-place, even if handed immutable Python bytes.
+    # Give it an owned copy so the expected original remains an independent oracle.
+    stored = zipnn.ZipNN(input_format="byte", bytearray_dtype="bfloat16", threads=1).compress(bytearray(original))
+    source = io.BytesIO(stored)
+    with decode(source, max_stored_bytes=len(stored), max_decoded_bytes=len(original),
+                remaining_bytes=len(original)) as parts:
+        digest = hashlib.sha256()
+        total = 0
+        for block in parts:
+            assert 0 < len(block) <= cs.IO_BYTES
+            total += len(block)
+            digest.update(block)
+    assert total == len(original)
+    assert digest.digest() == hashlib.sha256(original).digest()
+    assert not source.closed
+
+
+@pytest.mark.parametrize("phase", ["input", "compute", "output"])
+def test_parent_death_kills_worker(phase):
+    # This subprocess becomes a subreaper solely inside the test, allowing it
+    # to reap the orphan itself instead of relying on the host PID 1 behavior.
+    program = r'''
+import ctypes, io, os, signal, subprocess, sys, time
+from modelark import codec_supervisor as cs
+from modelark.codec_resources import CodecMemoryPolicy
+assert ctypes.CDLL(None).prctl(36,1,0,0,0)==0
+r,w=os.pipe()
+parent=os.fork()
+if parent==0:
+    os.close(r)
+    cs.available_memory=lambda: {"available_bytes": 10<<30}
+    real=cs._launch
+    def launch(request,output):
+        phase=sys.argv[1]
+        if phase=='input':
+            proc=real(request,output)
+        else:
+            body="import ctypes,os,sys\nfrom modelark.codec_worker import bind_parent\nbind_parent(int(sys.argv[2]))\nsys.stdin.buffer.read()\n"
+            if phase=='compute':
+                body+="ctypes.CDLL(None).pause()\n"
+            else:
+                body+="os.write(int(sys.argv[1]),b'O'+(1<<20).to_bytes(8,'little'))\nwhile True: os.write(int(sys.argv[1]),b'x'*65536)\n"
+            proc=subprocess.Popen([sys.executable,'-c',body,str(output),str(os.getpid())],
+                stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.STDOUT,
+                close_fds=True,pass_fds=(output,),bufsize=0)
+        os.write(w,str(proc.pid).encode()+b'\n')
+        return proc
+    cs._launch=launch
+    h=bytearray(32); h[:4]=b'ZN\x00\x05'; h[5]=10; h[8]=h[15]=1
+    size=1<<20
+    h[16:24]=size.to_bytes(8,'little'); h[24:32]=(36).to_bytes(8,'little')
+    with cs.guarded_zipnn_frame(io.BytesIO(h+b'abcd'),policy=CodecMemoryPolicy(8<<30,0),
+             max_stored_bytes=36,max_decoded_bytes=size,remaining_bytes=size) as parts:
+        if sys.argv[1]!='input':
+            next(parts)
+        while True: time.sleep(.01)
+os.close(w)
+worker=int(os.read(r,100).strip()); os.close(r)
+time.sleep(.2)
+os.kill(parent,signal.SIGKILL)
+os.waitpid(parent,0)
+pid,status=os.waitpid(worker,0)
+assert pid==worker and os.WIFSIGNALED(status) and os.WTERMSIG(status)==signal.SIGKILL
+print('parent-death-contained')
+'''
+    result = subprocess.run([sys.executable, "-c", program, phase], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "parent-death-contained"
+
+
+def test_launch_failure_closes_pipes(monkeypatch):
+    before = len(os.listdir("/proc/self/fd"))
+    failure = OSError("cannot spawn")
+    def fail(*args):
+        raise failure
+    monkeypatch.setattr(cs, "_launch", fail)
+    with pytest.raises(OSError) as caught:
+        with decode():
+            pass
+    assert caught.value is failure
+    assert len(os.listdir("/proc/self/fd")) == before
+
+
+def test_worker_request_is_closed_world():
+    from modelark.codec_worker import run
+    with pytest.raises(ValueError, match="fields"):
+        run({"version": "modelark.codec-worker.v1", "source_path": "/unauthorized"}, None, None)
+    assert json.loads(json.dumps(POLICY.to_record())) == POLICY.to_record()

--- a/tests/test_codec_supervisor.py
+++ b/tests/test_codec_supervisor.py
@@ -260,6 +260,21 @@ def test_real_writer_frame_decodes_hash_and_closes_without_source_ownership():
     assert not source.closed
 
 
+def test_worker_origin_is_not_resolved_from_untrusted_cwd(monkeypatch, tmp_path):
+    fake = tmp_path / "modelark"
+    fake.mkdir()
+    (fake / "__init__.py").write_text("")
+    (fake / "codec_worker.py").write_text(
+        "import os,sys\nsys.stdin.buffer.read()\n"
+        "os.write(int(sys.argv[1]),b'O'+(4).to_bytes(8,'little')+b'fake')\n")
+    monkeypatch.chdir(tmp_path)
+    # A fake worker certifies malformed data; the package actually imported by
+    # the parent must be launched and refuse it instead, under its real guard.
+    with pytest.raises(cs.WorkerRefusal):
+        with decode() as parts:
+            list(parts)
+
+
 @pytest.mark.parametrize("phase", ["input", "compute", "output"])
 def test_parent_death_kills_worker(phase):
     # This subprocess becomes a subreaper solely inside the test, allowing it
@@ -329,5 +344,32 @@ def test_launch_failure_closes_pipes(monkeypatch):
 def test_worker_request_is_closed_world():
     from modelark.codec_worker import run
     with pytest.raises(ValueError, match="fields"):
-        run({"version": "modelark.codec-worker.v1", "source_path": "/unauthorized"}, None, None)
+        run({"version": "modelark.codec-worker.v1", "source_path": "/unauthorized"}, None)
     assert json.loads(json.dumps(POLICY.to_record())) == POLICY.to_record()
+
+
+@pytest.mark.parametrize("failure", [BrokenPipeError(), MemoryError()])
+def test_worker_never_appends_error_after_success_header(monkeypatch, failure):
+    from modelark import codec_worker as worker
+    monkeypatch.setattr(worker, "bind_parent", lambda pid: None)
+    monkeypatch.setattr(worker, "run", lambda request, source: b"abcd")
+    sent = []
+    def send(fd, data):
+        sent.append(data)
+        if len(sent) >= 2:
+            raise failure
+    monkeypatch.setattr(worker, "_send", send)
+    assert worker.main(["worker", "99", str(os.getpid()), "{}"]) == 1
+    assert sent == [b"O" + (4).to_bytes(8, "little"), b"abcd"]
+
+
+def test_parent_guard_failure_is_not_reported_as_ram(monkeypatch):
+    from modelark import codec_worker as worker
+    def fail(pid):
+        raise worker.WorkerInitializationError("no parent guard")
+    monkeypatch.setattr(worker, "bind_parent", fail)
+    sent = []
+    monkeypatch.setattr(worker, "_send", lambda fd, data: sent.append(data))
+    assert worker.main(["worker", "99", str(os.getpid()), "{}"]) == 1
+    assert len(sent) == 1 and sent[0][:1] == b"I"
+    assert sent[0][9:] == b"codec worker initialization failed"

--- a/tests/test_streamznn_readers.py
+++ b/tests/test_streamznn_readers.py
@@ -1,0 +1,189 @@
+"""Caller-owned StreamZNN primitives preserve standalone wrappers and failures."""
+import hashlib
+import importlib.util
+import io
+import struct
+from array import array
+
+import pytest
+
+from modelark import streamznn as sz
+
+
+class ShortReader:
+    def __init__(self, data, piece=1):
+        self.inner = io.BytesIO(data)
+        self.piece = piece
+        self.requests = []
+
+    def read(self, size):
+        assert 0 < size <= 7
+        self.requests.append(size)
+        return self.inner.read(min(size, self.piece))
+
+
+def fake_container(*frames):
+    return sz.MAGIC + b"".join(struct.pack("<I", len(frame)) + frame for frame in frames)
+
+
+def test_default_iterator_and_all_path_wrappers_share_loop(tmp_path, monkeypatch):
+    blob = fake_container(b"abc", b"def")
+    native_calls = []
+    class Codec:
+        def decompress(self, blob):
+            native_calls.append(blob)
+            return blob.upper()
+    monkeypatch.setattr(sz, "_zipnn", lambda: Codec())
+    source = ShortReader(blob)
+    assert b"".join(sz.iter_decompress(source, read_size=7)) == b"ABCDEF"
+    assert native_calls == [b"abc", b"def"]
+    assert not source.inner.closed
+    # Permissive legacy wrappers must NOT acquire Slice's strict frame parser.
+    monkeypatch.setattr(sz, "read_zipnn_frame", lambda *a, **kw: pytest.fail("narrowed wrapper"))
+    real_iterator = sz.iter_decompress
+    calls = []
+    def iterator(*a, **kw):
+        calls.append(a[0])
+        yield from real_iterator(*a, **kw)
+    monkeypatch.setattr(sz, "iter_decompress", iterator)
+    src, out = tmp_path / "stored", tmp_path / "restored"
+    src.write_bytes(blob)
+    parts = []
+    sz.decompress_to(src, parts.append)
+    assert b"".join(parts) == b"ABCDEF"
+    assert sz.verify_sha256(src, hashlib.sha256(b"ABCDEF").hexdigest())
+    sz.decompress_file(src, out)
+    assert out.read_bytes() == b"ABCDEF"
+    assert len(calls) == 3
+    assert all(stream.closed for stream in calls)
+
+
+def test_iterator_close_does_not_read_next_frame_or_close_input():
+    source = ShortReader(fake_container(b"abc", b"def"))
+    seen = []
+    def reader(stream, length, remaining):
+        seen.append((length, remaining))
+        return sz._read_exact(stream, length, read_size=7)
+    iterator = sz.iter_decompress(source, max_total_bytes=6, read_size=7, frame_reader=reader)
+    assert next(iterator) == b"abc"
+    consumed = source.inner.tell()
+    iterator.close()
+    assert source.inner.tell() == consumed
+    assert seen == [(3, 6)]
+    assert not source.inner.closed
+
+
+@pytest.mark.parametrize("bound", [{"max_stored_frame_bytes": 2},
+                                  {"max_decoded_frame_bytes": 2}, {"max_total_bytes": 2}])
+def test_explicit_iterator_bounds(bound):
+    source = ShortReader(fake_container(b"abc"))
+    def reader(stream, length, remaining):
+        return sz._read_exact(stream, length, read_size=7)
+    with pytest.raises(sz.DecodeLimitExceeded):
+        list(sz.iter_decompress(source, read_size=7, frame_reader=reader, **bound))
+    assert not source.inner.closed
+
+
+@pytest.mark.parametrize("data", [b"", b"S", b"XXXXX", sz.MAGIC + b"\0",
+                                 sz.MAGIC + bytes(4), fake_container(b"abc")[:-1]])
+def test_short_or_invalid_container(data, monkeypatch):
+    monkeypatch.setattr(sz, "_zipnn", lambda: pytest.fail("truncation reached native"))
+    with pytest.raises(sz.StreamZnnError):
+        list(sz.iter_decompress(ShortReader(data), read_size=7))
+
+
+@pytest.mark.parametrize("value", [False, -1, 0, 1.5, "7"])
+def test_input_read_bound_is_strict(value):
+    with pytest.raises(ValueError):
+        list(sz.iter_decompress(io.BytesIO(sz.MAGIC), read_size=value))
+
+
+def test_callback_and_source_failures_keep_identity(tmp_path, monkeypatch):
+    problem = RuntimeError("codec callback failed")
+    def fail(*args):
+        raise problem
+    source = ShortReader(fake_container(b"abc"))
+    with pytest.raises(RuntimeError) as caught:
+        list(sz.iter_decompress(source, read_size=7, frame_reader=fail))
+    assert caught.value is problem
+    assert not source.inner.closed
+    class Broken:
+        def read(self, size):
+            raise problem
+    with pytest.raises(RuntimeError) as caught:
+        list(sz.iter_decompress(Broken()))
+    assert caught.value is problem
+    class Codec:
+        decompress = staticmethod(fail)
+    monkeypatch.setattr(sz, "_zipnn", lambda: Codec())
+    src, dst = tmp_path / "stored", tmp_path / "out"
+    src.write_bytes(fake_container(b"abc"))
+    dst.write_bytes(b"keep")
+    with pytest.raises(RuntimeError) as caught:
+        sz.decompress_file(src, dst)
+    assert caught.value is problem
+    assert dst.read_bytes() == b"keep"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["out", "stored"]
+
+
+def test_sink_failure_closes_owned_path_handle(tmp_path, monkeypatch):
+    src = tmp_path / "stored"
+    src.write_bytes(sz.MAGIC)
+    opened = []
+    real_open = open
+    def tracked_open(*a, **kw):
+        stream = real_open(*a, **kw)
+        opened.append(stream)
+        return stream
+    monkeypatch.setattr(sz, "open", tracked_open, raising=False)
+    monkeypatch.setattr(sz, "iter_decompress", lambda stream: iter([b"data"]))
+    problem = OSError("destination full")
+    def sink(data):
+        raise problem
+    with pytest.raises(OSError) as caught:
+        sz.decompress_to(src, sink)
+    assert caught.value is problem
+    assert opened[0].closed
+
+
+def header(original=4, stored=36):
+    value = bytearray(32)
+    value[:4] = b"ZN\x00\x05"
+    value[5], value[8], value[15] = 10, 1, 1
+    value[16:24] = original.to_bytes(8, "little")
+    value[24:32] = stored.to_bytes(8, "little")
+    return bytes(value)
+
+
+@pytest.mark.parametrize("dtype", [1, 2, 4, 5, 6])
+def test_validated_frame_supported_byte_dtype_headers(dtype):
+    data = bytearray(header() + b"abcd")
+    data[15] = dtype
+    source = ShortReader(data)
+    assert sz.read_zipnn_frame(source, max_stored_bytes=36, max_decoded_bytes=4,
+                               remaining_bytes=4, read_size=7,
+                               decode_frame=lambda blob: blob[-4:]) == b"abcd"
+    assert not source.inner.closed
+
+
+def test_validated_frame_injection_and_actual_byte_count():
+    # A typed memoryview's len counts elements, not bytes.
+    data = header(original=1, stored=33) + b"a"
+    with pytest.raises(sz.StreamZnnError, match="decoded size"):
+        sz.read_zipnn_frame(io.BytesIO(data), max_stored_bytes=33, max_decoded_bytes=1,
+                            remaining_bytes=1, decode_frame=lambda b: memoryview(array("I", [1])))
+    problem = RuntimeError("cancel decoder")
+    def fail(blob):
+        raise problem
+    with pytest.raises(RuntimeError) as caught:
+        sz.read_zipnn_frame(io.BytesIO(data), max_stored_bytes=33, max_decoded_bytes=1,
+                            remaining_bytes=1, decode_frame=fail)
+    assert caught.value is problem
+
+
+def test_standalone_import_by_file_without_modelark_package():
+    spec = importlib.util.spec_from_file_location("standalone_streamznn", sz.__file__)
+    standalone = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(standalone)
+    assert list(standalone.iter_decompress(ShortReader(sz.MAGIC), read_size=7)) == []
+    assert standalone.MAGIC == sz.MAGIC


### PR DESCRIPTION
## What and why

Stage C1 of DEC-139: qualify a guarded single-frame decoder **without enabling larger Slice deliveries yet**. C2 still owns bounded StreamZNN integration, versioned direct/native/FAT approvals, early candidate admission and the zstd units correction.

Dependency #75 was merged by the operator as `37f0e1d`. C1's own changes begin after Stage B head `204c487`. This PR targets `main`; no automatic merge or deployment is authorized.

- Share the standalone MIT ZipNN header parser between existing readers and the guarded worker; preserve existing container bytes and reader behavior.
- Reuse the same host/visible-cgroup sampling and explicit AS memory policy as compression/canary/restore qualification.
- Transfer one frame through bounded parent pipes; only the guarded child holds the indivisible native frame. Protocol is separate from drained stdout/stderr diagnostics. No source path, catalog/archive/destination handle or drive fence is inherited.
- Check exact protocol sizes, EOF and child exit; preserve caller failures and kill/reap before returning control to source-fence ownership. Qualify cancellation, blocked pipes, crashes and parent death.
- Pin isolated no-site child startup to the package the parent imported. No cwd package substitution; shared startup installs lifetime/memory guards before dependency site hooks, for decoder and compression/canary/restore qualification workers alike.
- Normalize the protocol writer above fd 2 so closed stdio cannot capture the result stream. Protocol v2 validates a bounded actual-child runtime record separately from original bytes; only completed output and zero exit publish that record with the exact parent admission sample.
- Separate initialization, decoding and response emission: failure after output begins cannot append an error response into file bytes, and parent-guard failures are not labelled RAM failures.

No live service, catalog, archive, USB, host policy, tensor/GPU workflow, old seal, Slice limit, compression/restore policy or zstd behavior was changed. Descriptor confinement is not an OS filesystem sandbox; sampled headroom is not a memory reservation. C1 does not establish complete Stage C, production writer/reader parity or physical Slice acceptance.

## Validation

- [x] Zstd-enabled focused suite **208 passed**; malformed/missing/duplicate metadata, evidence completion phases, all eight closed-stdio combinations, real guarded `.pth` hooks, parent death/cancellation during startup, and prior worker transport regressions.
- [x] Four startup tests also passed on Python **3.12.12**; primary suite uses **3.10.12**.
- [x] Fresh complete Slice suite on `63089b3`: **1346 passed, 5 optional skips**, completed in 569.07 seconds (two dependency deprecation warnings).
- [x] Rebuilt installed wheel outside the checkout: **196 passed**, including the actual isolated worker bootstrap.
- [x] `ruff check modelark scripts tests` and `git diff --check` passed.
- [x] Real installed-dependency qualification: **22 checks passed** on Python 3.10.12 / ZipNN 0.5.4 / Torch 2.14.0. Whole and StreamZNN compression/canary/restore at 64 MiB, 99,630,640 and 409,993,344 original bytes, deliberate guard-denied allocation, plus the actual bounded parent/worker path for each whole frame. Original hashes matched under the same 8 GiB AS + 2 GiB sampled-headroom policy; output pieces never exceeded 64 KiB. Final report fingerprints the implementation. These are qualification parameters, not newly enabled production defaults.
- [x] Docs and append-only HYP-002 evidence updated; no runtime catalog data or model bytes committed.
- [x] All operations used fixtures/disposable data; portal behavior unchanged. Browser E2E is left to CI.

Current local report: `/tmp/modelark-codec-qualification-lg9hbfo8/result.json` (operator-local, not a committed artifact). Guarded results now include their own admission sample and actual interpreter/venv, loaded module paths, installed distribution versions and observed guards. This is process evidence, not binary attestation. Boundary and remaining gates: `docs/guarded-codec-worker.md`.

## Review and architectural assessment

Local Grok CLI round 1 accepted its inspected boundary with two low-severity reporting observations. Round 2 accepted `6d5376d`. Codex then exposed three additional startup/evidence gaps sharing an implicit launch/session contract. DEC-142 records the operator-approved bounded architectural correction: shared guarded startup, stdio-safe protocol ownership and actual-child evidence. **Local Grok round 3 of 3 ACCEPTED exact head `63089b37cbce33f4deff4eb76686d993de453538`, with no findings.** Its CLI required same-session conclusion retrieval after a memory flush; that was not a fourth review pass. Grok inspected the code, docs, tests and report; the primary agent independently verified all seven report fingerprints. No broader Slice redesign or production rollout is inferred.

Remote round 1 at `6d5376d` had all CI passing and Codex findings 3984989491 (P1), 3984989497 (P2), and 3984989506 (P2), all independently validated. The approved architecture correction in `63089b3` addresses all three. **Remote Stage C round 2 of at most 3:** Codex reviewed exact head `63089b37cbce33f4deff4eb76686d993de453538` and reported no major issues in https://github.com/Auspex-Aerie/modelark/pull/76#issuecomment-5628059480. All current-head CI jobs passed in workflow https://github.com/Auspex-Aerie/modelark/actions/runs/34550750572 (Python 3.10, Python 3.12 and browser E2E). Greptile remains pending; prior-head evidence is not being substituted for its review.

Greptile reported its 100 free open-source review credits exhausted until September 14 (review 5173868550); that is a quota refusal, not a completed review or code finding. Its earlier pending head is superseded by this correction, not counted as accepted. Both reviewers were requested in https://github.com/Auspex-Aerie/modelark/pull/76#issuecomment-5628010657 before the operator explicitly clarified: **do not tag Greptile while credits are exhausted, including after another push**. Greptile remains pending until credit restoration/reset; Codex and CI monitoring continue. No paid-usage change is authorized. This PR is **not merge-ready**. Keep the Stage C counters across incremental pushes/subdivisions; do not restart the three-round cap per push. Operator retains merge control and must receive a bold explicit prompt once all merge gates pass.
