### PR TITLE
feat(slice): seal guarded decoding and preflight source frames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,14 @@ push an unreviewed final fix or silently reset the counter. A user-authorized
 exception applies only to its explicitly named scope; PR #73's one-time
 no-review-wait merge authorization does not carry forward to other PRs.
 
+Quota exception (2026-09-10): when a reviewer explicitly reports exhausted
+credits, do not keep tagging it, including after new pushes. Record its review
+as pending and continue available reviewers/CI. Resume its canonical trigger
+only after credits are restored or its announced reset time arrives; if that
+single retry is still quota-blocked, stop retrying and tell the operator.
+Quota refusal is neither acceptance nor a completed review, and does not reset
+the stage's counters. Never enable paid usage without explicit authorization.
+
 ## Operator approval continuity (2026-09-10)
 
 When the operator replies "ok", "begin", "go", "continue", or equivalent to an

--- a/docs/codec-resource-qualification.md
+++ b/docs/codec-resource-qualification.md
@@ -7,6 +7,13 @@ claim that Slice's 64 MiB incompatibility is fixed.
 
 ## What the policy means
 
+DEC-144 also makes platform/inherited-limit compatibility part of shared
+read-only admission. The current Linux process's soft and hard AS ceilings must
+both permit the requested envelope; no existing lower ceiling is relaxed.
+The same checker runs again before worker installation. Admission never calls
+`setrlimit` in the parent, and does not guarantee that a later child can install
+its guard: installation and verification still fail closed in the child.
+
 The same versioned record controls all three qualification operations. It has an
 explicit address-space ceiling and a headroom reserve; no separate compression
 multiplier, decoder cap, implicit environment variable or Slice default.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3061,3 +3061,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: C1 worker protocol moves to internal v2; no archive-format, live data, old-seal, production Slice or compression rollout changes. The approved fix may proceed locally despite the partial first remote round; both reviewers remain required, cumulative review caps remain unchanged and the operator retains merge authority.
 - `docs_updated`: docs/decision_log.md, docs/guarded-codec-worker.md, docs/plans/slice-representation-architecture.md
 - `related`: DEC-138, DEC-139, DEC-140, DEC-141, HYP-002
+
+### DEC-143: Suspend reviewer triggers while its credits are exhausted
+- `id`: DEC-143
+- `date`: 2026-09-10
+- `status`: accepted
+- `triggered_by`: Operator corrected the PR #76 workflow after a new-head Greptile tag was posted despite its known exhausted-credit state.
+- `decision`: The every-push review requirement does not mean repeatedly tagging an unavailable reviewer. While credits are exhausted, leave that review pending and continue available reviewers and CI. Resume the canonical trigger only after restored credits or the announced reset; stop and report if a single post-reset retry still refuses. Do not enable paid usage without explicit authorization.
+- `rationale`: A known quota failure cannot produce a review; another push does not restore credits. Preserve the review gate without generating ineffective requests.
+- `impact`: Clarifies DEC-140 with a quota-aware trigger exception, not an acceptance waiver or counter reset. AGENTS.md and the active review watcher carry the same rule. The already-posted round-2 request is historical; no further exhausted-quota tags are authorized.
+- `docs_updated`: AGENTS.md, docs/decision_log.md
+- `related`: DEC-140, DEC-141, DEC-142

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3072,3 +3072,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Clarifies DEC-140 with a quota-aware trigger exception, not an acceptance waiver or counter reset. AGENTS.md and the active review watcher carry the same rule. The already-posted round-2 request is historical; no further exhausted-quota tags are authorized.
 - `docs_updated`: AGENTS.md, docs/decision_log.md
 - `related`: DEC-140, DEC-141, DEC-142
+
+### DEC-144: Own preclaim outcomes and share codec environment admission
+- `id`: DEC-144
+- `date`: 2026-09-10
+- `status`: accepted
+- `triggered_by`: Operator approved the bounded follow-up after PR #77 Codex findings 3985723013, 3985723019 and 3985723021; disposable probes reproduced interrupted FAT preflight, acknowledged-resume outcome masking and inherited-AS admission gaps.
+- `decision`: Interpret reservation/Stop serials through one predicate shared by preflight guards, refusal publication and claim. Acknowledge preflight interruption atomically under retained destination exclusion and carry that outcome to public adapters without another claim. Consume only the exact acknowledged Stop authorized by the reservation; any newer Stop wins. Share read-only platform/inherited-AS compatibility checks between codec admission and worker guard installation, retaining installation and verification in the fresh child.
+- `rationale`: Moving work before claim exposed execution-only assumptions. Give preclaim lifecycle and deterministic worker prerequisites explicit owners rather than adding destination-specific stop workarounds or a second RAM formula.
+- `impact`: Shared Slice private-state/authority and public interrupt plumbing, plus operation-neutral codec policy admission. No new schema, changed sealed policy values, archive format, live-instance change, parent resource-limit mutation or production writer rollout. Regression and qualification work stays in the C2 tracker.
+- `docs_updated`: docs/decision_log.md, docs/plans/slice-c2-progress.md, docs/codec-resource-qualification.md
+- `related`: DEC-138, DEC-139, DEC-142, HYP-002

--- a/docs/plans/slice-c2-progress.md
+++ b/docs/plans/slice-c2-progress.md
@@ -1,0 +1,92 @@
+# C2 — guarded Slice decoding
+
+Approved scope: integrate the qualified C1 worker with Slice original delivery,
+version all three approval bindings, inspect attached candidates before output
+mutation/FAT attempt consumption, and preserve old approvals and native resume.
+No live deployment, catalog/archive changes, physical USB operations, stored
+export, or production compression/canary/restore adoption (Stage D).
+
+Review instructions for this stage: up to three local Grok CLI passes, then a
+new PR with up to three Codex review/fix rounds. **No Greptile requests.** These
+are stage-wide counters, not fresh allowances per push. The operator merges;
+hand off readiness explicitly in bold after current-head review and CI pass.
+This review exception is recorded here, not in the decision ledger, as requested.
+
+## Local implementation checkpoint before PR review
+
+- Branch: `codex/slice-guarded-decoding`, based on merged PR #76 (`5799635`).
+- Initial implementation complete; final full regression in progress.
+- Local Grok: rounds 1 and 2 accepted their inspected versions; round 2 covers
+  the self-review corrections (session `2f39485c-a247-4937-9d89-dff3da0a7450`).
+- Codex PR: 0/3 at this checkpoint; first request accompanies publication.
+- Pending DEC-143/AGENTS quota policy from the preceding stage is preserved.
+
+## Compatibility contract
+
+New public previews carry `modelark.original-decode.v1`: stored and decoded
+frame ceilings derived from the shared AS envelope, 1 MiB caller reads, a 64 MiB zstd window, and C1's
+8 GiB virtual-address-space ceiling plus 2 GiB sampled headroom for ZipNN.
+These are upper bounds, not a guarantee that every permitted frame succeeds.
+There is no independent fixed Slice ZipNN frame cap: each single buffer must
+fit within the same worker AS envelope; runtime mappings and concurrent buffers
+can still cause a contained resource refusal for a smaller frame.
+ZipNN always uses the guarded helper under this policy. zstd remains bounded
+streaming in the parent; its native window setting is explicitly bytes.
+That setting is qualified for zstandard 0.25.0's C extension; other versions or
+backends refuse under v1 of the new policy. Existing legacy approvals retain
+their previous backend behavior. No unsupported backend is silently treated as
+having the same units.
+
+Direct admission v2 hashes the complete policy into its binding. Native and
+FAT32 transaction v2 include it in both their canonical plan and admission hash.
+Their v1 forms preserve the exact old serialized bytes and limits; old public
+readers reject v2. No live catalog or private-state schema migration is needed.
+A private store containing v2 plans requires the upgraded reader, including
+when checking overlapping ownership; downgrading is not supported for those
+records. Existing v1 records remain readable without reinterpretation.
+
+Before the first destination mutation, source preflight runs under destination
+exclusion and per-candidate archive read fences, but before an attempt is claimed.
+It inspects every attached alternative and every StreamZNN frame header using
+bounded reads. One usable attached alternative is enough; offline alternatives
+remain unchecked. If none is usable, absence yields a wait rather than destroying
+the approved alternatives. This is not full decode/digest verification.
+
+Native partial recovery authenticates existing output without requiring completed
+files' sources online. All actual reads still recheck source evidence, headers,
+resource admission, and original length/hash. During decoding, stop/destination
+and source checks reach the worker supervisor; helper cleanup completes before
+source descriptors and archive fences release. Worker success alone never
+publishes a receipt.
+
+## Validation / review notes
+
+- Initial full Slice suite: 1,373 passed, 16 optional-codec skips. Current
+  focused optional-zstd/codec suite: 186 passed. Disposable installed wheel:
+  42 C2 tests passed. These runs predate the three corrections below; final
+  regression and qualification runs are in progress.
+- `/tmp/modelark-codec-qualification-pyfaco3s/result.json`: 25 checks passed,
+  all 11 fingerprints matched, both formats decoded at 67,108,864 / 99,630,640 /
+  409,993,344 original bytes, with at most 65,536 output bytes per piece.
+  This precedes the frame-bound correction below; it is historical evidence.
+- Actual installed C1 wheel readers were exercised: native/FAT v1 canonical
+  bytes and direct v1 admission remain valid; all three old readers reject v2.
+- Round 1 Grok accepted, without executing tests. Main-agent probes additionally
+  found: a separate draft 512 MiB frame ceiling; fresh copy evidence checked only
+  after inspection reads; and a stop between preflight/claim spending FAT's
+  attempt without output. Corrections derive frame ceilings from the shared AS
+  envelope, validate fresh candidates before reading, and acknowledge Stop before
+  consuming the one-shot attempt. Regression tests accompany all three.
+- No exception entry was added to the decision ledger. D/E and physical tests
+  remain separate; none of these results claims production writer parity.
+- Final corrected-code qualification: 25 checks passed in
+  `/tmp/modelark-codec-qualification-tn1wzy18/result.json`, all fingerprints
+  matched. Six whole/StreamZNN Slice round trips retain the original hashes and
+  65,536-byte output ceiling under the same AS/headroom envelope.
+- Final focused optional-zstd/codec tests: 193 passed. Final installed wheel:
+  49 C2 tests passed from `/tmp/modelark-c2-final-wheel.ekVCUM/installed`.
+  Standalone writer/canary wrapper and process-guard regressions: 46 passed.
+- Four actual FencedSources + LocalArchiveReader + child-process tests prove
+  reaping occurs while the real archive fence is still held, on success, Stop,
+  simulated source loss and destination failure. The original sealed hash is
+  checked on success; consumer exceptions retain identity.

--- a/docs/plans/slice-c2-progress.md
+++ b/docs/plans/slice-c2-progress.md
@@ -12,6 +12,32 @@ are stage-wide counters, not fresh allowances per push. The operator merges;
 hand off readiness explicitly in bold after current-head review and CI pass.
 This review exception is recorded here, not in the decision ledger, as requested.
 
+## Approved preclaim follow-up (DEC-144)
+
+After the original CI fix (`49e2a3c`), all CI checks passed (3,487 tests on both
+Python versions), but Codex round 2 found three confirmed preclaim gaps: Ctrl+C
+before FAT claim was unacknowledged, an old acknowledged Stop hid a resumed
+source wait/block, and an inherited AS limit was not checked until the child.
+The operator approved a bounded shared-lifecycle/resource-admission correction
+and an additional local review budget. Original local Grok 3/3 remains recorded;
+this follow-up permits up to three additional local passes. Codex remains 2/3,
+with one remote round left. No Greptile and no merge authority are added.
+
+The implementation shares the exact acknowledged-resume predicate across
+preflight and claim. Preflight refusal/interrupt publishes under retained
+exclusion, never consumes FAT's attempt, and returns the committed outcome.
+An interrupted preflight carries that already-acknowledged outcome to the
+public adapters, avoiding a second Stop/claim. A resumed source wait consumes
+only the reservation-authorized old Stop; new Stop serials always take priority.
+
+Codec admission now shares a read-only environment check with child guard
+installation: qualified Linux and inherited soft/hard AS ceilings compatible
+with the sealed policy. All existing admission callers (Slice preflight,
+guarded frame decode and writer qualification) get the same check. No parent
+limits are changed; the child still installs and verifies its guard. This
+detects known incompatibilities, not every possible launch failure or later
+resource race. Legacy approvals, policy bytes and private schema are unchanged.
+
 ## Local implementation checkpoint before PR review
 
 - Branch: `codex/slice-guarded-decoding`, based on merged PR #76 (`5799635`).

--- a/docs/plans/slice-c2-progress.md
+++ b/docs/plans/slice-c2-progress.md
@@ -90,3 +90,12 @@ publishes a receipt.
   reaping occurs while the real archive fence is still held, on success, Stop,
   simulated source loss and destination failure. The original sealed hash is
   checked on success; consumer exceptions retain identity.
+- PR #77's first CI run exposed one regression on both Python versions: the
+  public serial-repair integration test is outside the `test_slice*` selection.
+  Source preflight correctly blocked the obsolete identity, but its exception
+  bypassed the usual public blocked-source result. The shared delivery authority
+  now returns the recorded source wait/block status before releasing exclusion;
+  unrelated failures retain their exception behavior. FAT reports its attempt
+  as unspent. Tests cover all three public destination paths, retry, a racing
+  Stop, and unchanged old receipts/output. The full CI-equivalent suite is part
+  of follow-up validation, not just the Slice filename subset.

--- a/docs/plans/slice-representation-architecture.md
+++ b/docs/plans/slice-representation-architecture.md
@@ -379,3 +379,12 @@ archive formats nor old Slice approvals; C2 and production writer adoption remai
 separate gates. The operator approved implementing this correction while the
 first remote pass remains partial due to Greptile quota; that does not waive
 either reviewer, grant merge authority or reset the stage's counters.
+
+C1 subsequently merged as PR #76 (`5799635`), after Grok round 3 and Codex
+round 2 accepted final head `63089b3` and CI passed. Greptile remained quota-
+blocked, not accepted. The operator authorized a new scoped C2 cycle after that
+merge: local Grok, then Codex on a new PR, no Greptile. This is explicit new
+authorization, not an automatic counter reset. See [C2 work and review tracker](slice-c2-progress.md)
+for implementation, compatibility and current validation state. Production
+writer/canary/restore adoption and the full public CLI qualification remain
+separate D/E gates; no physical acceptance is implied.

--- a/docs/usable-slice-direct.md
+++ b/docs/usable-slice-direct.md
@@ -111,9 +111,13 @@ adversarial same-account namespace isolation. Ordinary collisions still refuse.
 Source reads retain the shared archive fence, refresh the explicit read-only catalog and validate
 filesystem/serial/annex identity. Stored paths are repository-relative. Only a final annex link to the
 sealed key beneath the pinned object store is permitted. No annex command or retrieval runs. Raw,
-bounded ZipNN 0.5 byte-format, StreamZNN and optional zstd streams yield original bytes. The default
-64-MiB limit bounds individual frames/windows, not the native codec's entire working set; oversized
-legacy whole-ZipNN blobs and unsupported modes refuse. Consumer errors are not relabeled as source IO.
+bounded ZipNN 0.5 byte-format, StreamZNN and optional zstd streams yield original bytes. Old direct-v1
+approvals retain their 64-MiB frame/window bounds and legacy zstd behavior; these bounds alone are
+not a native working-memory guard. Fresh direct-v2 previews seal the versioned decode policy:
+ZipNN uses the qualified child AS/headroom guard, with bounded output into the parent, and zstd
+uses a qualified byte-valued window setting. No Start flag or current configuration widens an
+old approval. See [C2 policy and qualification limits](plans/slice-c2-progress.md).
+Unsupported modes refuse. Consumer errors are not relabeled as source IO.
 Source and destination attachments share lexical absolute-path normalization, expanding `~` and
 collapsing `..` without following symlinks. Operator preview/Start, observation and cached-loss
 recovery, descriptor binding and source reads use the same spelling. Descriptor opening still

--- a/docs/usable-slice-folders.md
+++ b/docs/usable-slice-folders.md
@@ -76,7 +76,8 @@ code running as that same UID or root.
 `FolderTarget` seals the canonical filesystem scope, existing parent identity and intended child.
 It excludes free-space observations and the not-yet-created root identity. `NativePlan` adds the
 approved closure, backing/admission evidence, catalog, advisory snapshot and metadata allowance
-under `modelark.slice.native-transaction.v1`. `FolderReview` remains non-executable; parsing it
+under `modelark.slice.native-transaction.v1` for legacy approvals. Fresh previews use v2 and
+also bind the explicit decode/resource policy. `FolderReview` remains non-executable; parsing it
 cannot produce source approval, ownership or execution authority.
 
 Durable claims compare canonical same-filesystem paths: exact and ancestor/descendant roots
@@ -122,6 +123,26 @@ not a catalog schema migration. Legacy
 golden tests pin their seal hashes against reviewed commit `6fd87c3`. Unknown/mixed envelopes
 refuse before destination observation or writer authority. No public flag weakens an old seal.
 
+Fresh direct/native/FAT approval envelopes now carry a versioned original-byte decoding policy.
+ZipNN frames run in the C1-qualified child: 8 GiB AS ceiling plus 2 GiB sampled headroom, with
+individual buffer ceilings derived from that same envelope and at most 64 KiB output pieces.
+This is not an RSS reservation or a guarantee every smaller frame fits; unknown headroom and
+child allocation failures refuse. zstd stays bounded streaming with a 64 MiB byte-valued window;
+this policy currently qualifies only zstandard 0.25.0's C extension. Old approvals retain their
+old limits and conversion. Fresh preview and approval are necessary to use the new behavior.
+
+Before first output mutation, preflight checks fresh sealed source candidates under their read
+fences, including every StreamZNN header. It reads/discards payload in bounded pieces, so a large
+archive may take time to inspect. It is not a full decode/hash verification. A usable attached
+alternative can proceed; absent alternatives remain unchecked, and absent required sources wait.
+Actual decoding repeats header/resource checks and still verifies the sealed original hash.
+Native partial resume authenticates completed output without requiring its sources online.
+
+No private schema migration is added by these v2 envelopes. An older binary rejects them, including
+while checking overlapping ownership; stores with v2 records require the upgraded reader. The
+[C2 tracker](plans/slice-c2-progress.md) separates synthetic implementation qualification from
+the still-required public CLI, live deployment and physical compressed-source acceptance gates.
+
 ## FAT32 session workflow
 
 The same Preview → Approve → Start commands select the FAT32 adapter for a vfat parent;
@@ -138,7 +159,8 @@ Protected paths still include all of `/run`, so `/run/media/...` is currently re
 
 FAT32 has **one attempt, no resume**. Once the host claim is consumed, Stop, Ctrl+C, source or
 capacity waits and failures require a new intent and different output folder. Residue remains
-untouched. A known capacity shortfall before claim consumption is retryable. The media report
+untouched. Known capacity/source/header/resource refusals before claim consumption are retryable;
+so is a Stop acknowledged before the one-shot attempt is consumed. The media report
 says export verified, not host transaction committed; committed host status supplies that evidence.
 
 ## Completed qualification gates and evidence limits

--- a/modelark/artifact_io.py
+++ b/modelark/artifact_io.py
@@ -2,13 +2,16 @@
 
 The bound limits individual stored/decoded ZipNN frames and zstd windows, not
 the native codecs' total working set. No tensor input, whole-file scratch, or
-unbounded ``read()`` is accepted. Large legacy whole-ZipNN files fail closed.
+unbounded ``read()`` is accepted. Without an explicit policy, large legacy
+whole-ZipNN files fail closed. A policy opts into isolated bounded frame output.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 
 from . import streamznn
+from .codec_resources import CodecResourceRefusal
+from .codec_supervisor import WorkerRefusal
 
 
 class DecodeError(Exception):
@@ -59,18 +62,47 @@ def _prefix(stream, size):
     return data
 
 
-def _chunks(stream, compressed, expected, limits):
+def _zstd_header(stream, prefix, expected, limits, *, qualified=False):
     try:
-        yield from _decoded_chunks(stream, compressed, expected, limits)
+        import zstandard as zstd
+    except ImportError as exc:
+        raise DecodeError("UNSUPPORTED", "zstandard is not installed") from exc
+    if qualified and (getattr(zstd, "__version__", None), getattr(zstd, "backend", None)) != ("0.25.0", "cext"):
+        _refuse("UNSUPPORTED", "byte-window policy is qualified for zstandard 0.25.0 cext only")
+    if limits.decoded_frame_bytes < 128 << 10:
+        _refuse("LIMIT", "zstd requires a 128 KiB decoding bound")
+    header = prefix
+    while True:
+        try:
+            params = zstd.get_frame_parameters(header)
+            break
+        except zstd.ZstdError:
+            if len(header) >= 18:
+                _refuse(detail="invalid zstd header")
+            header += _exact(stream, 1)
+    if (params.window_size > limits.zstd_window_bytes
+            or params.content_size not in (zstd.CONTENTSIZE_UNKNOWN, zstd.CONTENTSIZE_ERROR)
+            and (params.content_size > expected or qualified and params.content_size != expected)):
+        _refuse("LIMIT", "zstd window/content exceeds bound")
+    return zstd, header
+
+
+def _chunks(stream, compressed, expected, limits, policy, check, on_frame_complete):
+    try:
+        yield from _decoded_chunks(stream, compressed, expected, limits, policy, check, on_frame_complete)
     except streamznn.DecodeLimitExceeded as exc:
         raise DecodeError("LIMIT", str(exc)) from exc
     except streamznn.UnsupportedFrame as exc:
         raise DecodeError("UNSUPPORTED", str(exc)) from exc
     except streamznn.StreamZnnError as exc:
         raise DecodeError("INVALID", str(exc)) from exc
+    except WorkerRefusal as exc:
+        raise DecodeError(exc.kind, exc.detail) from exc
+    except CodecResourceRefusal as exc:
+        raise DecodeError("RESOURCE", str(exc)) from exc
 
 
-def _decoded_chunks(stream, compressed, expected, limits):
+def _decoded_chunks(stream, compressed, expected, limits, policy, check, on_frame_complete):
     if not compressed:
         while chunk := stream.read(min(limits.read_bytes, 1 << 20)):
             yield chunk
@@ -84,48 +116,45 @@ def _decoded_chunks(stream, compressed, expected, limits):
             stored_length=stored_length, prefix=prefix,
             read_size=min(limits.read_bytes, 1 << 20))
 
+    def guarded(source, stored_length, remaining, prefix=b""):
+        from .codec_supervisor import guarded_zipnn_frame
+        return guarded_zipnn_frame(
+            source, policy=policy.memory, max_stored_bytes=limits.stored_frame_bytes,
+            max_decoded_bytes=limits.decoded_frame_bytes, remaining_bytes=remaining,
+            stored_length=stored_length, prefix=prefix, check=check, on_complete=on_frame_complete)
+
     if prefix == streamznn.MAGIC:
         yield from streamznn.iter_decompress(
             stream, prefix=prefix, max_stored_frame_bytes=limits.stored_frame_bytes,
             max_decoded_frame_bytes=limits.decoded_frame_bytes, max_total_bytes=expected,
-            read_size=min(limits.read_bytes, 1 << 20), frame_reader=frame)
+            read_size=min(limits.read_bytes, 1 << 20),
+            **({"frame_stream": guarded} if policy is not None else {"frame_reader": frame}))
     elif prefix.startswith(b"ZN"):
-        yield frame(stream, None, expected, prefix)
+        if policy is None:
+            yield frame(stream, None, expected, prefix)
+        else:
+            with guarded(stream, None, expected, prefix) as chunks:
+                yield from chunks
         if stream.read(1):
             _refuse(detail="trailing whole-ZipNN data")
     elif prefix.startswith(b"\x28\xb5\x2f\xfd"):
-        try:
-            import zstandard as zstd
-        except ImportError as exc:
-            raise DecodeError("UNSUPPORTED", "zstandard is not installed") from exc
         # zstd's maximum regenerated block is 128 KiB. Feeding no more
         # than limit/128KiB input bytes bounds even maximally dense RLE output
         # before Python gets the opportunity to check its length.
-        if limits.decoded_frame_bytes < 128 << 10:
-            _refuse("LIMIT", "zstd requires a 128 KiB decoding bound")
-        header = prefix
-        while True:
-            try:
-                params = zstd.get_frame_parameters(header)
-                break
-            except zstd.ZstdError:
-                if len(header) >= 18:
-                    _refuse(detail="invalid zstd header")
-                header += _exact(stream, 1)
-        if (params.window_size > limits.zstd_window_bytes
-                or params.content_size not in (zstd.CONTENTSIZE_UNKNOWN, zstd.CONTENTSIZE_ERROR)
-                and params.content_size > expected):
-            _refuse("LIMIT", "zstd window/content exceeds bound")
+        zstd, header = _zstd_header(stream, prefix, expected, limits, qualified=policy is not None)
         # Preserve legacy Slice's native setting in this no-widening extraction.
         # zstandard 0.25.0 actually treats this setting as bytes, despite its
         # documentation's KiB wording. Stage C must qualify the units correction;
         # this conversion currently refuses some frames below our header ceiling.
-        decoder = zstd.ZstdDecompressor(max_window_size=max(1, limits.zstd_window_bytes // 1024)).decompressobj()
+        window = (limits.zstd_window_bytes if policy is not None
+                  else max(1, limits.zstd_window_bytes // 1024))
+        decoder = zstd.ZstdDecompressor(max_window_size=window).decompressobj()
+        output_bound = min(limits.decoded_frame_bytes, 1 << 20) if policy else limits.decoded_frame_bytes
         pending = header
         try:
             while pending:
                 data = decoder.decompress(pending)
-                if len(data) > limits.decoded_frame_bytes:
+                if len(data) > output_bound:
                     _refuse("LIMIT", "zstd output block exceeds bound")
                 if data:
                     yield data
@@ -133,7 +162,7 @@ def _decoded_chunks(stream, compressed, expected, limits):
                     if decoder.unused_data or stream.read(1):
                         _refuse(detail="trailing/concatenated zstd data")
                     break
-                pending = stream.read(max(1, limits.decoded_frame_bytes // (128 << 10)))
+                pending = stream.read(max(1, output_bound // (128 << 10)))
             if not decoder.eof:
                 _refuse(detail="truncated zstd frame")
         except zstd.ZstdError as exc:
@@ -159,14 +188,19 @@ class _CheckedInput:
 
 
 class _OriginalStream:
-    def __init__(self, stream, compressed, expected, limits, check):
+    def __init__(self, stream, compressed, expected, limits, check, policy, on_frame_complete):
         self._chunks = iter(_chunks(_CheckedInput(stream, limits.read_bytes, check),
-                                    compressed, expected, limits))
+                                    compressed, expected, limits, policy, check, on_frame_complete))
         self._pending = b""
         self._offset = 0
         self._total = 0
         self._expected, self._limit, self._check = expected, limits.read_bytes, check
         self._done = False
+
+    def close(self):
+        self._done = True
+        self._pending = b""
+        self._chunks.close()
 
     def read(self, size=-1):
         if type(size) is not int or size < 0 or size > self._limit:
@@ -194,14 +228,21 @@ class _OriginalStream:
 
 
 def original_stream(stream, *, compressed, expected_bytes, limits: DecodeLimits,
-                    check=lambda: None):
+                    check=lambda: None, policy=None, on_frame_complete=lambda evidence: None):
     """Decode caller-owned bytes; no paths, source authority or output publication.
 
     Original length is enforced here; the caller must verify the original digest.
-    Resource isolation/admission is not added by these explicit buffer limits.
+    Buffer limits alone do not add resource isolation. An explicit DecodePolicy
+    selects the guarded ZipNN helper and qualified byte-valued zstd window.
+    Close this reader on early termination before releasing source ownership.
+    on_frame_complete is per-child evidence, not artifact/destination success.
     """
     if type(expected_bytes) is not int or expected_bytes < 0:
         raise ValueError("nonnegative original size required")
     if not isinstance(limits, DecodeLimits):
         raise ValueError("explicit DecodeLimits required")
-    return _OriginalStream(stream, compressed, expected_bytes, limits, check)
+    if policy is not None:
+        from .artifact_policy import DecodePolicy
+        if not isinstance(policy, DecodePolicy) or policy.limits != limits:
+            raise ValueError("decode policy differs from supplied limits")
+    return _OriginalStream(stream, compressed, expected_bytes, limits, check, policy, on_frame_complete)

--- a/modelark/artifact_policy.py
+++ b/modelark/artifact_policy.py
@@ -1,0 +1,54 @@
+"""Versioned original-byte decoding policy, independent of storage authority."""
+from dataclasses import asdict, dataclass
+
+from .artifact_io import DecodeLimits
+from .codec_resources import CodecMemoryPolicy
+
+
+@dataclass(frozen=True)
+class DecodePolicy:
+    """Explicit approved bounds; the memory envelope is not a reservation.
+
+    The initial profile uses C1's qualified 8 GiB AS / 2 GiB headroom envelope.
+    Individual frame buffers cannot exceed that same AS envelope; there is no
+    independent Slice-sized ceiling. Native mappings and simultaneous buffers
+    can still make a smaller frame fail inside the enforced child guard.
+    """
+
+    limits: DecodeLimits
+    memory: CodecMemoryPolicy
+    version: str = "modelark.original-decode.v1"
+    zstd_window_unit: str = "bytes"
+
+    def __post_init__(self):
+        if (self.version != "modelark.original-decode.v1" or self.zstd_window_unit != "bytes"
+                or not isinstance(self.limits, DecodeLimits)
+                or not isinstance(self.memory, CodecMemoryPolicy)):
+            raise ValueError("unsupported original decode policy")
+        # Keep parent streaming/window bounds fixed for this qualified version.
+        if (self.limits.read_bytes > 1 << 20
+                or self.limits.decoded_frame_bytes > self.memory.address_space_bytes
+                or self.limits.stored_frame_bytes > self.memory.address_space_bytes
+                or self.limits.zstd_window_bytes > 64 << 20):
+            raise ValueError("decode bounds exceed qualified policy version")
+
+    def to_record(self):
+        return asdict(self)
+
+    @classmethod
+    def from_record(cls, record):
+        if type(record) is not dict or set(record) != {
+                "version", "limits", "memory", "zstd_window_unit"}:
+            raise ValueError("invalid decode policy fields")
+        limits = record["limits"]
+        if type(limits) is not dict or set(limits) != {
+                "stored_frame_bytes", "decoded_frame_bytes", "read_bytes", "zstd_window_bytes"}:
+            raise ValueError("invalid decode limit fields")
+        return cls(DecodeLimits(**limits), CodecMemoryPolicy.from_record(record["memory"]),
+                   record["version"], record["zstd_window_unit"])
+
+
+def qualified_policy():
+    memory = CodecMemoryPolicy(8 << 30, 2 << 30)
+    return DecodePolicy(DecodeLimits(memory.address_space_bytes, memory.address_space_bytes,
+                                     1 << 20, 64 << 20), memory)

--- a/modelark/artifact_preflight.py
+++ b/modelark/artifact_preflight.py
@@ -1,0 +1,62 @@
+"""Read-only header/resource checks; not full decode or digest verification."""
+from . import artifact_io as io, streamznn
+from .codec_resources import available_memory
+
+
+def inspect_original(stream, *, compressed, expected_bytes, stored_bytes, policy, check=lambda: None):
+    """Inspect every framed header with bounded checked reads, without native ZipNN.
+
+    No paths, retrieval or destination authority. Consumes the caller-owned stream;
+    payload bytes are discarded, never buffered as a frame or interpreted as proof
+    of integrity. Actual use must check again and verify original length/hash.
+    """
+    source = io._CheckedInput(stream, policy.limits.read_bytes, check)
+    limits = policy.limits
+    if not compressed:
+        if expected_bytes != stored_bytes:
+            raise io.DecodeError("INVALID", "raw stored/original sizes differ")
+        check()
+        return
+    prefix = io._prefix(source, 5)
+
+    def frame(length=None, prefix=b"", remaining=expected_bytes):
+        header = streamznn.read_zipnn_header(
+            source, max_stored_bytes=limits.stored_frame_bytes,
+            max_decoded_bytes=limits.decoded_frame_bytes, remaining_bytes=remaining,
+            stored_length=length, prefix=prefix, read_size=limits.read_bytes)
+        original = int.from_bytes(header[16:24], "little")
+        stored = int.from_bytes(header[24:32], "little")
+        pending = stored - 32
+        while pending:
+            piece = source.read(min(pending, 64 << 10))
+            if not piece:
+                raise io.DecodeError("INVALID", "truncated ZipNN payload")
+            pending -= len(piece)
+        return original
+
+    try:
+        if prefix == streamznn.MAGIC:
+            total = 0
+            for length in streamznn.iter_frame_lengths(
+                    source, prefix=prefix, max_stored_frame_bytes=limits.stored_frame_bytes,
+                    read_size=limits.read_bytes):
+                total += frame(length, remaining=expected_bytes - total)
+            if total != expected_bytes:
+                raise io.DecodeError("INVALID", "framed total differs from original size")
+        elif prefix.startswith(b"ZN"):
+            if frame(prefix=prefix) != expected_bytes or source.read(1):
+                raise io.DecodeError("INVALID", "whole frame differs from original size or has trailing bytes")
+        elif prefix.startswith(b"\x28\xb5\x2f\xfd"):
+            io._zstd_header(source, prefix, expected_bytes, limits, qualified=True)
+            return  # streaming window guard, not the ZipNN whole-frame helper
+        else:
+            raise io.DecodeError("UNSUPPORTED", "unknown compressed container")
+    except streamznn.DecodeLimitExceeded as exc:
+        raise io.DecodeError("LIMIT", str(exc)) from exc
+    except streamznn.UnsupportedFrame as exc:
+        raise io.DecodeError("UNSUPPORTED", str(exc)) from exc
+    except streamznn.StreamZnnError as exc:
+        raise io.DecodeError("INVALID", str(exc)) from exc
+    check()
+    policy.memory.admit(available_memory()["available_bytes"])
+    check()

--- a/modelark/codec_resources.py
+++ b/modelark/codec_resources.py
@@ -114,6 +114,25 @@ class CodecMemoryPolicy:
         if available_bytes < required:
             raise CodecResourceRefusal(
                 f"headroom {available_bytes} is below policy requirement {required}")
+        self.check_worker_environment()
+
+    def check_worker_environment(self) -> None:
+        """Read-only prerequisites shared by admission and actual guard install.
+
+        Inherited soft AND hard ceilings must permit this exact policy. This is
+        not proof of later setrlimit success; the fresh child still installs and
+        verifies its guard. Never lower or relax the caller's process limits.
+        """
+        if sys.platform != "linux":
+            raise CodecResourceRefusal("codec AS guard is only qualified on Linux")
+        try:
+            import resource
+            inherited = resource.getrlimit(resource.RLIMIT_AS)
+        except (ImportError, OSError, ValueError, OverflowError) as exc:
+            raise CodecResourceRefusal("could not inspect inherited codec memory guard") from exc
+        if any(limit != resource.RLIM_INFINITY and limit < self.address_space_bytes
+               for limit in inherited):
+            raise CodecResourceRefusal("inherited AS ceiling is below requested policy")
 
     def install_in_worker(self) -> None:
         """Irreversibly constrain THIS process; call only in a fresh child.
@@ -123,15 +142,10 @@ class CodecMemoryPolicy:
         do not fall back to an unguarded decode. Set the core-file limit to zero;
         this does not change the host's separate crash-reporting policy.
         """
-        if sys.platform != "linux":
-            raise CodecResourceRefusal("codec AS guard is only qualified on Linux")
+        self.check_worker_environment()
         import resource
 
         try:
-            inherited = resource.getrlimit(resource.RLIMIT_AS)
-            if any(limit != resource.RLIM_INFINITY and limit < self.address_space_bytes
-                   for limit in inherited):
-                raise CodecResourceRefusal("inherited AS ceiling is below requested policy")
             resource.setrlimit(resource.RLIMIT_AS,
                                (self.address_space_bytes, self.address_space_bytes))
             resource.setrlimit(resource.RLIMIT_CORE, (0, 0))

--- a/modelark/slice/authority.py
+++ b/modelark/slice/authority.py
@@ -121,6 +121,13 @@ class DeliveryAuthority:
                 except TransferRefusal as exc:
                     lease.check()
                     store.refuse_preclaim(tx, device, exc)
+                    if exc.code in {"SOURCE_BLOCKED", "WAITING_SOURCE"}:
+                        # Moving source admission before claim must preserve the
+                        # normal attended-wait result for every destination kind.
+                        # Read under exclusion: a concurrent Stop may have won.
+                        outcome = store.status(tx)
+                        lease.close()
+                        return outcome
                     raise
             outcome = store.claim(tx, device, lease.attempt, reservation)
             if outcome.state in {"complete", "stopped"}:

--- a/modelark/slice/authority.py
+++ b/modelark/slice/authority.py
@@ -91,7 +91,7 @@ class DeliveryAuthority:
         self.attempt = lease.attempt
 
     @classmethod
-    def acquire(cls, store, tx, device, reservation):
+    def acquire(cls, store, tx, device, reservation, *, preflight=None):
         from .transaction import TransferRefusal
         try:
             lease = Lease(device, tx)
@@ -110,6 +110,18 @@ class DeliveryAuthority:
             if current.state == "complete":
                 lease.close()
                 return current
+            if preflight is not None:
+                def check():
+                    lease.check()
+                    store.guard_preclaim(tx, device, reservation)
+                try:
+                    check()
+                    preflight(check)
+                    check()
+                except TransferRefusal as exc:
+                    lease.check()
+                    store.refuse_preclaim(tx, device, exc)
+                    raise
             outcome = store.claim(tx, device, lease.attempt, reservation)
             if outcome.state in {"complete", "stopped"}:
                 lease.close()

--- a/modelark/slice/authority.py
+++ b/modelark/slice/authority.py
@@ -84,6 +84,13 @@ class Lease:
             raise TransferRefusal("EXECUTION_FENCE_LOST")
 
 
+class PreclaimInterrupted(KeyboardInterrupt):
+    """Stop already acknowledged under exclusion; adapters must not re-claim."""
+    def __init__(self, outcome):
+        super().__init__("source preflight interrupted")
+        self.outcome = outcome
+
+
 class DeliveryAuthority:
     """The sole execution facade for activation, boundaries, outcomes and release."""
     def __init__(self, store, tx, device, lease):
@@ -118,14 +125,18 @@ class DeliveryAuthority:
                     check()
                     preflight(check)
                     check()
+                except KeyboardInterrupt as exc:
+                    lease.check()
+                    outcome = store.refuse_preclaim(
+                        tx, device, reservation, TransferRefusal("STOPPED"), interrupted=True)
+                    raise PreclaimInterrupted(outcome) from exc
                 except TransferRefusal as exc:
                     lease.check()
-                    store.refuse_preclaim(tx, device, exc)
+                    outcome = store.refuse_preclaim(tx, device, reservation, exc)
                     if exc.code in {"SOURCE_BLOCKED", "WAITING_SOURCE"}:
                         # Moving source admission before claim must preserve the
                         # normal attended-wait result for every destination kind.
                         # Read under exclusion: a concurrent Stop may have won.
-                        outcome = store.status(tx)
                         lease.close()
                         return outcome
                     raise

--- a/modelark/slice/decoding.py
+++ b/modelark/slice/decoding.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from modelark import artifact_io
+from modelark.codec_resources import CodecResourceRefusal
+from modelark.codec_supervisor import WorkerRefusal
 
 from .transaction import TransferRefusal
 
@@ -15,16 +17,23 @@ class _SliceOriginalStream:
             return self._reader.read(size)
         except artifact_io.DecodeError as exc:
             raise TransferRefusal(f"SOURCE_DECODE_{exc.kind}", exc.detail) from exc
+        except WorkerRefusal as exc:
+            raise TransferRefusal(f"SOURCE_DECODE_{exc.kind}", exc.detail) from exc
+        except CodecResourceRefusal as exc:
+            raise TransferRefusal("SOURCE_DECODE_RESOURCE", str(exc)) from exc
+
+    def close(self):
+        self._reader.close()
 
 
 def original_stream(stream, *, compressed, expected_bytes, max_decode_bytes=64 << 20,
-                    check=lambda: None):
-    """Preserve legacy Slice limits; caller retains source descriptor ownership.
+                    check=lambda: None, policy=None, on_frame_complete=lambda evidence: None):
+    """Use sealed policy when provided; otherwise preserve legacy Slice limits.
 
-    No new seal/resource policy or large-frame admission is enabled in Stage B.
+    Caller owns the source and closes this reader before releasing its fences.
     """
-    limits = artifact_io.DecodeLimits(max_decode_bytes, max_decode_bytes,
-                                      max_decode_bytes, max_decode_bytes)
+    limits = (policy.limits if policy is not None else artifact_io.DecodeLimits(
+        max_decode_bytes, max_decode_bytes, max_decode_bytes, max_decode_bytes))
     return _SliceOriginalStream(artifact_io.original_stream(
         stream, compressed=compressed, expected_bytes=expected_bytes,
-        limits=limits, check=check))
+        limits=limits, check=check, policy=policy, on_frame_complete=on_frame_complete))

--- a/modelark/slice/fat32_operator.py
+++ b/modelark/slice/fat32_operator.py
@@ -113,7 +113,8 @@ def start(store, tx, plan, destination_path, attachments):
                     raise
                 return {**_result(store.status(tx)), "new_root_required": store.attempt_consumed(tx)}
             if isinstance(session, t.Status):
-                return _result(session)
+                return {**_result(session), "new_root_required":
+                        session.state != "complete" and store.attempt_consumed(tx)}
             with session:
                 try:
                     result = session.run()

--- a/modelark/slice/fat32_operator.py
+++ b/modelark/slice/fat32_operator.py
@@ -19,6 +19,8 @@ from .io_errors import io_boundary
 from .local_source import LocalArchiveReader
 from .paths import canonical_attachment
 from .sources import FencedSources
+from modelark.artifact_policy import qualified_policy
+from .fat32_plan import POLICY_VERSION
 
 
 def _intent(evidence):
@@ -47,11 +49,12 @@ def preview(catalog_path, destination_path, repo_ids):
     evidence = observer.observe(destination, archives=_archives(catalog), protected_paths=_protected(catalog))
     target = _intent(evidence)
     proposal = d.preview(replace(spec, destination_id=target.target_id), snapshot)
-    binding = binding_for(target, catalog, evidence.parent_path, evidence.backing_ids)
+    policy = qualified_policy()
+    binding = binding_for(target, catalog, evidence.parent_path, evidence.backing_ids, policy)
     reserve = estimate_metadata(proposal, binding, catalog, evidence.parent_path, evidence.backing_ids,
-                                evidence.capacity, private_state.HOST_STATE_DIR)
+                                evidence.capacity, private_state.HOST_STATE_DIR, policy)
     plan = Fat32Plan(proposal, binding, catalog, evidence.parent_path, evidence.backing_ids,
-                     evidence.capacity, reserve)
+                     evidence.capacity, reserve, POLICY_VERSION, policy)
     with io_boundary(None, "DESTINATION_UNPROVEN", "FAT32 preview setup/teardown failed"), \
             Fat32Tree(evidence.parent_path, writable=True) as tree:
         fresh = observer.recheck(tree, evidence, archives=_archives(catalog))
@@ -95,7 +98,8 @@ def start(store, tx, plan, destination_path, attachments):
         if fresh.capacity.available_bytes < plan.required_bytes(store.root):
             raise t.TransferRefusal("DESTINATION_CAPACITY_WAIT", "shared capacity insufficient before claim")
         with Fat32Destination(tree, plan.destination, store, tx, recheck=recheck) as destination:
-            sources = FencedSources(plan.catalog, LocalArchiveReader(attachments, observer=LinuxObserver()))
+            options = {"policy": plan.decode_policy} if plan.decode_policy is not None else {}
+            sources = FencedSources(plan.catalog, LocalArchiveReader(attachments, observer=LinuxObserver(), **options))
             try:
                 session = t.start(store, tx, destination, sources)
             except KeyboardInterrupt:

--- a/modelark/slice/fat32_operator.py
+++ b/modelark/slice/fat32_operator.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 
 from . import domain as d, state as private_state, transaction as t
+from .authority import PreclaimInterrupted
 from .catalog import read_catalog
 from .fat32_destination import Fat32Destination
 from .fat32_observation import Fat32FolderObserver, Fat32Tree
@@ -102,6 +103,9 @@ def start(store, tx, plan, destination_path, attachments):
             sources = FencedSources(plan.catalog, LocalArchiveReader(attachments, observer=LinuxObserver(), **options))
             try:
                 session = t.start(store, tx, destination, sources)
+            except PreclaimInterrupted as exc:
+                return {**_result(exc.outcome, stop_requested=True), "ok": False,
+                        "new_root_required": False}
             except KeyboardInterrupt:
                 _request_stop_once(store, tx)
                 # Never use native's fresh-Start interrupt acknowledgment path:

--- a/modelark/slice/fat32_plan.py
+++ b/modelark/slice/fat32_plan.py
@@ -15,9 +15,11 @@ from . import fat32_layout as layout
 from .folder_contract import CapacityObservation, FolderProfile, _decode, _fields, _text
 from .folder_plan import _absolute, _backing, _proposal_record
 from .transaction import TransferRefusal
+from modelark.artifact_policy import DecodePolicy
 
 
 VERSION = "modelark.slice.fat32-transaction.v1"
+POLICY_VERSION = "modelark.slice.fat32-transaction.v2"
 _INTENT_VERSION = "modelark.slice.fat32-intent.v1"
 _ADMISSION_PREFIX = "fat32-folder-v1:"
 _SHA = re.compile(r"[0-9a-f]{64}\Z")
@@ -75,8 +77,9 @@ class Fat32Binding:
 
     def __post_init__(self):
         if (not isinstance(self.target, Fat32Intent) or not isinstance(self.admission_id, str)
-                or not self.admission_id.startswith(_ADMISSION_PREFIX)
-                or not _SHA.fullmatch(self.admission_id[len(_ADMISSION_PREFIX):])):
+                or self.admission_id.split(":", 1)[0] not in
+                {"fat32-folder-v1", "fat32-folder-v2"}
+                or not _SHA.fullmatch(self.admission_id.split(":", 1)[-1])):
             raise TransferRefusal("FAT32_PLAN_INVALID", "FAT32 intent binding required")
 
     @property
@@ -92,14 +95,20 @@ class Fat32Binding:
         return self.admission_id
 
 
-def binding_for(target, catalog, parent_path, backing_ids):
+def binding_for(target, catalog, parent_path, backing_ids, decode_policy=None):
     """Seal stable path/backing policy, never a live descriptor or capacity claim."""
     if not isinstance(target, Fat32Intent):
         raise TransferRefusal("FAT32_PLAN_INVALID", "FAT32 intent required")
-    payload = {"version": VERSION, "target": json.loads(target.to_json()),
+    payload = {"version": POLICY_VERSION if decode_policy is not None else VERSION,
+               "target": json.loads(target.to_json()),
                "catalog": _absolute(catalog), "parent_path": _absolute(parent_path),
                "backing_ids": _backing(backing_ids)}
-    return Fat32Binding(target, _ADMISSION_PREFIX + hashlib.sha256(d._json(payload)).hexdigest())
+    if decode_policy is not None:
+        if not isinstance(decode_policy, DecodePolicy):
+            raise TransferRefusal("ADMISSION_CORRUPT", "typed decode policy required")
+        payload["decode_policy"] = decode_policy.to_record()
+    prefix = "fat32-folder-v2:" if decode_policy is not None else _ADMISSION_PREFIX
+    return Fat32Binding(target, prefix + hashlib.sha256(d._json(payload)).hexdigest())
 
 
 @dataclass(frozen=True)
@@ -112,9 +121,12 @@ class Fat32Plan:
     capacity: CapacityObservation
     metadata_reserve_bytes: int
     version: str = VERSION
+    decode_policy: DecodePolicy | None = None
 
     def __post_init__(self):
-        if (self.version != VERSION or not isinstance(self.proposal, d.SlicePreview)
+        if (self.version != (POLICY_VERSION if self.decode_policy is not None else VERSION)
+                or self.decode_policy is not None and not isinstance(self.decode_policy, DecodePolicy)
+                or not isinstance(self.proposal, d.SlicePreview)
                 or not isinstance(self.destination, Fat32Binding)
                 or not isinstance(self.capacity, CapacityObservation)
                 or not d._integer(self.metadata_reserve_bytes)):
@@ -123,7 +135,8 @@ class Fat32Plan:
         if not self.proposal.source_ready:
             raise TransferRefusal("PREVIEW_BLOCKED")
         object.__setattr__(self, "backing_ids", _backing(self.backing_ids))
-        expected = binding_for(self.destination.target, self.catalog, self.parent_path, self.backing_ids)
+        expected = binding_for(self.destination.target, self.catalog, self.parent_path,
+                               self.backing_ids, self.decode_policy)
         if self.destination != expected:
             raise TransferRefusal("ADMISSION_CORRUPT", "FAT32 admission differs from binding")
         if (self.proposal.spec.destination_id != expected.device_id
@@ -144,7 +157,10 @@ class Fat32Plan:
         return self.destination.target.child_name + "/.modelark-slice-owner"
 
     def to_json(self):
-        return d._json(asdict(self)).decode()
+        record = asdict(self)
+        if self.decode_policy is None:
+            record.pop("decode_policy")  # preserve every legacy canonical byte/seal
+        return d._json(record).decode()
 
     @property
     def seal(self):
@@ -189,9 +205,14 @@ class Fat32Plan:
         from .transaction import decode_proposal
         try:
             obj = _decode(payload)
-            _fields(obj, {"proposal", "destination", "catalog", "parent_path", "backing_ids",
-                          "capacity", "metadata_reserve_bytes", "version"})
-            if obj["version"] != VERSION:
+            if type(obj) is not dict:
+                raise ValueError("plan envelope required")
+            keys = {"proposal", "destination", "catalog", "parent_path", "backing_ids",
+                    "capacity", "metadata_reserve_bytes", "version"}
+            if obj.get("version") == POLICY_VERSION:
+                keys.add("decode_policy")
+            _fields(obj, keys)
+            if obj["version"] not in {VERSION, POLICY_VERSION}:
                 raise ValueError("unsupported FAT32 transaction version")
             _fields(obj["destination"], {"target", "admission_id"})
             _fields(obj["destination"]["target"], {"profile", "filesystem_scope", "parent_parts", "child_name"})
@@ -199,12 +220,14 @@ class Fat32Plan:
             return cls(decode_proposal(_proposal_record(obj["proposal"])),
                        Fat32Binding(Fat32Intent(**obj["destination"]["target"]), obj["destination"]["admission_id"]),
                        obj["catalog"], obj["parent_path"], obj["backing_ids"],
-                       CapacityObservation(**obj["capacity"]), obj["metadata_reserve_bytes"], obj["version"])
+                       CapacityObservation(**obj["capacity"]), obj["metadata_reserve_bytes"], obj["version"],
+                       DecodePolicy.from_record(obj["decode_policy"]) if obj["version"] == POLICY_VERSION else None)
         except (KeyError, TypeError, ValueError, RecursionError) as exc:
             raise TransferRefusal("STATE_CORRUPT", "invalid FAT32 plan: " + str(exc)) from exc
 
 
-def estimate_metadata(proposal, binding, catalog, parent_path, backing_ids, capacity, store_root):
+def estimate_metadata(proposal, binding, catalog, parent_path, backing_ids, capacity, store_root,
+                      decode_policy=None):
     """Conservative shared-space estimate; the live adapter still checks capacity."""
     root = PurePosixPath(proposal.spec.destination_root)
     directories = {str(parent) for artifact in proposal.closure
@@ -216,7 +239,8 @@ def estimate_metadata(proposal, binding, catalog, parent_path, backing_ids, capa
               "store": str(store_root)}
     allowance = 256 * 1024 + objects * 128 * 1024
     reserve = allowance + 3 * len(d._json(record))
-    plan = Fat32Plan(proposal, binding, catalog, parent_path, backing_ids, capacity, reserve)
+    plan = Fat32Plan(proposal, binding, catalog, parent_path, backing_ids, capacity, reserve,
+                     POLICY_VERSION if decode_policy is not None else VERSION, decode_policy)
     reserve = max(reserve, sum(plan._metadata_sizes(store_root)) + allowance)
     plan.required_bytes(store_root)
     return reserve

--- a/modelark/slice/folder_operator.py
+++ b/modelark/slice/folder_operator.py
@@ -18,6 +18,8 @@ from .linux import BoundTree
 from .local_source import LocalArchiveReader
 from .paths import canonical_attachment, utf8_size
 from .sources import FencedSources
+from modelark.artifact_policy import qualified_policy
+from .folder_plan import POLICY_VERSION
 
 
 def _protected(catalog):
@@ -81,11 +83,12 @@ def preview(catalog_path, destination_path, repo_ids):
     evidence = observer.observe(destination, archives=archives, protected_paths=_protected(catalog))
     proposal = d.preview(replace(spec, destination_id=evidence.target.target_id), snapshot)
     _layout(proposal, evidence)
-    binding = binding_for(evidence.target, catalog, evidence.parent_path, evidence.backing_ids)
+    policy = qualified_policy()
+    binding = binding_for(evidence.target, catalog, evidence.parent_path, evidence.backing_ids, policy)
     reserve = estimate_metadata(proposal, binding, catalog, evidence.parent_path, evidence.backing_ids,
-                                evidence.capacity, private_state.HOST_STATE_DIR)
+                                evidence.capacity, private_state.HOST_STATE_DIR, policy)
     plan = NativePlan(proposal, binding, catalog, evidence.parent_path, evidence.backing_ids,
-                      evidence.capacity, reserve)
+                      evidence.capacity, reserve, POLICY_VERSION, policy)
     with io_boundary(None, "DESTINATION_UNPROVEN", "native folder preview setup/teardown failed"), \
             BoundTree(evidence.parent_path, writable=True) as tree:
         fresh = observer.recheck(tree, evidence, archives=_archives(catalog))
@@ -133,7 +136,8 @@ def start(store, tx, plan, destination_path, attachments):
             recheck(tree)
             destination = NativeFolderDestination(tree, plan.destination, store, tx, recheck=recheck)
             # Destination folder eligibility does not replace archive source proof.
-            sources = FencedSources(plan.catalog, LocalArchiveReader(attachments, observer=LinuxObserver()))
+            options = {"policy": plan.decode_policy} if plan.decode_policy is not None else {}
+            sources = FencedSources(plan.catalog, LocalArchiveReader(attachments, observer=LinuxObserver(), **options))
             try:
                 session = t.start(store, tx, destination, sources)
             except KeyboardInterrupt:

--- a/modelark/slice/folder_operator.py
+++ b/modelark/slice/folder_operator.py
@@ -140,8 +140,8 @@ def start(store, tx, plan, destination_path, attachments):
             sources = FencedSources(plan.catalog, LocalArchiveReader(attachments, observer=LinuxObserver(), **options))
             try:
                 session = t.start(store, tx, destination, sources)
-            except KeyboardInterrupt:
-                return _result(_acknowledge_interrupt(store, tx, destination, sources),
+            except KeyboardInterrupt as exc:
+                return _result(_acknowledge_interrupt(store, tx, destination, sources, error=exc),
                                stop_requested=True)
             except t.TransferRefusal as exc:
                 if exc.code == "DESTINATION_CAPACITY_WAIT":

--- a/modelark/slice/folder_plan.py
+++ b/modelark/slice/folder_plan.py
@@ -13,9 +13,11 @@ import re
 from . import domain as d
 from .folder_contract import CapacityObservation, FolderProfile, FolderTarget, _decode, _fields
 from .transaction import TransferRefusal
+from modelark.artifact_policy import DecodePolicy
 
 
 VERSION = "modelark.slice.native-transaction.v1"
+POLICY_VERSION = "modelark.slice.native-transaction.v2"
 _ADMISSION_PREFIX = "native-folder-v1:"
 _SHA = re.compile(r"[0-9a-f]{64}\Z")
 
@@ -66,8 +68,9 @@ class NativeBinding:
         if (not isinstance(self.target, FolderTarget)
                 or self.target.profile is not FolderProfile.NATIVE_EXT4
                 or not isinstance(self.admission_id, str)
-                or not self.admission_id.startswith(_ADMISSION_PREFIX)
-                or not _SHA.fullmatch(self.admission_id[len(_ADMISSION_PREFIX):])):
+                or self.admission_id.split(":", 1)[0] not in
+                {"native-folder-v1", "native-folder-v2"}
+                or not _SHA.fullmatch(self.admission_id.split(":", 1)[-1])):
             raise TransferRefusal("FOLDER_PLAN_INVALID", "native binding required")
 
     @property
@@ -83,14 +86,20 @@ class NativeBinding:
         return self.admission_id
 
 
-def binding_for(target, catalog, parent_path, backing_ids):
+def binding_for(target, catalog, parent_path, backing_ids, decode_policy=None):
     """Bind stable admission policy, excluding mutable free-space observations."""
     if not isinstance(target, FolderTarget) or target.profile is not FolderProfile.NATIVE_EXT4:
         raise TransferRefusal("FOLDER_PLAN_INVALID", "native target required")
-    payload = {"version": VERSION, "target": json.loads(target.to_json()),
+    payload = {"version": POLICY_VERSION if decode_policy is not None else VERSION,
+               "target": json.loads(target.to_json()),
                "catalog": _absolute(catalog), "parent_path": _absolute(parent_path),
                "backing_ids": _backing(backing_ids)}
-    return NativeBinding(target, _ADMISSION_PREFIX + hashlib.sha256(d._json(payload)).hexdigest())
+    if decode_policy is not None:
+        if not isinstance(decode_policy, DecodePolicy):
+            raise TransferRefusal("ADMISSION_CORRUPT", "typed decode policy required")
+        payload["decode_policy"] = decode_policy.to_record()
+    prefix = "native-folder-v2:" if decode_policy is not None else _ADMISSION_PREFIX
+    return NativeBinding(target, prefix + hashlib.sha256(d._json(payload)).hexdigest())
 
 
 @dataclass(frozen=True)
@@ -103,9 +112,12 @@ class NativePlan:
     capacity: CapacityObservation
     metadata_reserve_bytes: int
     version: str = VERSION
+    decode_policy: DecodePolicy | None = None
 
     def __post_init__(self):
-        if (self.version != VERSION or not isinstance(self.proposal, d.SlicePreview)
+        if (self.version != (POLICY_VERSION if self.decode_policy is not None else VERSION)
+                or self.decode_policy is not None and not isinstance(self.decode_policy, DecodePolicy)
+                or not isinstance(self.proposal, d.SlicePreview)
                 or not isinstance(self.destination, NativeBinding)
                 or not isinstance(self.capacity, CapacityObservation)
                 or not d._integer(self.metadata_reserve_bytes)):
@@ -114,7 +126,8 @@ class NativePlan:
         if not self.proposal.source_ready:
             raise TransferRefusal("PREVIEW_BLOCKED")
         object.__setattr__(self, "backing_ids", _backing(self.backing_ids))
-        expected = binding_for(self.destination.target, self.catalog, self.parent_path, self.backing_ids)
+        expected = binding_for(self.destination.target, self.catalog, self.parent_path,
+                               self.backing_ids, self.decode_policy)
         if self.destination != expected:
             raise TransferRefusal("ADMISSION_CORRUPT", "native admission differs from binding")
         if (self.proposal.spec.destination_id != expected.device_id
@@ -140,7 +153,10 @@ class NativePlan:
         return len(directories) + len(self.proposal.closure) + 2  # control + receipt
 
     def to_json(self):
-        return d._json(asdict(self)).decode()
+        record = asdict(self)
+        if self.decode_policy is None:
+            record.pop("decode_policy")  # preserve every legacy canonical byte/seal
+        return d._json(record).decode()
 
     @property
     def seal(self):
@@ -177,9 +193,14 @@ class NativePlan:
         from .transaction import decode_proposal
         try:
             obj = _decode(payload)
-            _fields(obj, {"proposal", "destination", "catalog", "parent_path", "backing_ids",
-                          "capacity", "metadata_reserve_bytes", "version"})
-            if obj["version"] != VERSION:
+            if type(obj) is not dict:
+                raise ValueError("plan envelope required")
+            keys = {"proposal", "destination", "catalog", "parent_path", "backing_ids",
+                    "capacity", "metadata_reserve_bytes", "version"}
+            if obj.get("version") == POLICY_VERSION:
+                keys.add("decode_policy")
+            _fields(obj, keys)
+            if obj["version"] not in {VERSION, POLICY_VERSION}:
                 raise ValueError("unsupported native transaction version")
             _fields(obj["destination"], {"target", "admission_id"})
             target = obj["destination"]["target"]
@@ -188,12 +209,14 @@ class NativePlan:
             return cls(decode_proposal(_proposal_record(obj["proposal"])),
                        NativeBinding(FolderTarget(**target), obj["destination"]["admission_id"]),
                        obj["catalog"], obj["parent_path"], obj["backing_ids"],
-                       CapacityObservation(**obj["capacity"]), obj["metadata_reserve_bytes"], obj["version"])
+                       CapacityObservation(**obj["capacity"]), obj["metadata_reserve_bytes"], obj["version"],
+                       DecodePolicy.from_record(obj["decode_policy"]) if obj["version"] == POLICY_VERSION else None)
         except (KeyError, TypeError, ValueError, RecursionError) as exc:
             raise TransferRefusal("STATE_CORRUPT", "invalid native plan: " + str(exc)) from exc
 
 
-def estimate_metadata(proposal, binding, catalog, parent_path, backing_ids, capacity, store_root):
+def estimate_metadata(proposal, binding, catalog, parent_path, backing_ids, capacity, store_root,
+                      decode_policy=None):
     """Conservative advisory metadata budget, not proof of filesystem allocation.
 
     Include serialized evidence and per-inode/directory overhead. Runtime space and
@@ -209,6 +232,7 @@ def estimate_metadata(proposal, binding, catalog, parent_path, backing_ids, capa
               "store": str(store_root)}
     allowance = 256 * 1024 + objects * 16 * 1024
     reserve = allowance + 3 * len(d._json(record))
-    plan = NativePlan(proposal, binding, catalog, parent_path, backing_ids, capacity, reserve)
+    plan = NativePlan(proposal, binding, catalog, parent_path, backing_ids, capacity, reserve,
+                     POLICY_VERSION if decode_policy is not None else VERSION, decode_policy)
     reserve = max(reserve, plan._metadata_minimum(store_root) + allowance)
     return reserve

--- a/modelark/slice/local_source.py
+++ b/modelark/slice/local_source.py
@@ -145,14 +145,15 @@ def _open_content(tree, candidate):
 class LocalArchiveReader:
     """Internal reader with full per-artifact and lightweight per-read attachment proofs."""
 
-    def __init__(self, attachments, *, observer, max_decode_bytes=64 << 20):
+    def __init__(self, attachments, *, observer, max_decode_bytes=64 << 20, policy=None):
         self.attachments = {label: canonical_attachment(path)
                             for label, path in attachments.items()}
         self.observer = observer
         self.max_decode_bytes = max_decode_bytes
+        self.policy = policy
 
     @contextmanager
-    def open(self, candidate):
+    def _stored(self, candidate, boundary):
         from .linux import BoundTree
         label = candidate.drive.drive_label
         if label not in self.attachments:
@@ -198,12 +199,16 @@ class LocalArchiveReader:
                     # annex identity are checked at artifact-open boundaries;
                     # each read retains kernel attachment/backing-device proof
                     # without spawning a complete inventory for every chunk.
-                    self.observer.check_attachment(tree, confirmed)
+                    boundary()
+                    try:
+                        self.observer.check_attachment(tree, confirmed)
+                    except TransferRefusal as exc:
+                        raise _translate_confinement(exc) from exc
+                    except OSError as exc:
+                        raise _translate_confinement(classify_io(
+                            exc, recheck, _translate_io(exc, label))) from exc
+                    boundary()
 
-                check()
-                decoded = original_stream(stream, compressed=candidate.copy.compressed,
-                                          expected_bytes=candidate.copy.orig_bytes,
-                                          max_decode_bytes=self.max_decode_bytes, check=check)
             except OSError as exc:
                 raise _translate_confinement(classify_io(exc, recheck, _translate_io(exc, label))) from exc
             except TransferRefusal as exc:
@@ -213,4 +218,36 @@ class LocalArchiveReader:
                 raise translated from exc
             # Consumer exceptions (particularly destination ENOSPC/EIO) must
             # never be attributed to the source by this context manager.
-            yield _SourceErrors(decoded, label, recheck)
+            check()
+            yield _SourceErrors(stream, label, recheck), check
+
+    @contextmanager
+    def open(self, candidate, *, check=lambda: None):
+        with self._stored(candidate, check) as (stream, attachment_check):
+            decoded = original_stream(stream, compressed=candidate.copy.compressed,
+                                      expected_bytes=candidate.copy.orig_bytes,
+                                      max_decode_bytes=self.max_decode_bytes,
+                                      check=attachment_check, policy=self.policy)
+            try:
+                yield decoded
+            finally:
+                # Reap an interrupted helper BEFORE closing its retained source
+                # descriptor/tree and BEFORE the enclosing archive fence releases.
+                decoded.close()
+
+    @contextmanager
+    def inspect(self, candidate, *, check=lambda: None):
+        from modelark.artifact_preflight import inspect_original
+        from modelark.artifact_io import DecodeError
+        from modelark.codec_resources import CodecResourceRefusal
+        with self._stored(candidate, check) as (stream, attachment_check):
+            try:
+                inspect_original(stream, compressed=candidate.copy.compressed,
+                                 expected_bytes=candidate.copy.orig_bytes,
+                                 stored_bytes=candidate.copy.stored_bytes,
+                                 policy=self.policy, check=attachment_check)
+            except DecodeError as exc:
+                raise TransferRefusal(f"SOURCE_DECODE_{exc.kind}", exc.detail) from exc
+            except CodecResourceRefusal as exc:
+                raise TransferRefusal("SOURCE_DECODE_RESOURCE", str(exc)) from exc
+            yield None

--- a/modelark/slice/operator.py
+++ b/modelark/slice/operator.py
@@ -25,6 +25,7 @@ from .local_source import LocalArchiveReader
 from .paths import canonical_attachment
 from .io_errors import classify_io, io_boundary
 from .sources import FencedSources
+from modelark.artifact_policy import DecodePolicy, qualified_policy
 from .state import Store
 
 
@@ -91,9 +92,10 @@ def preview(catalog_path, destination_path, repo_ids, root):
             lambda: observer.recheck_attachment(tree, evidence),
             'DESTINATION_UNPROVEN', 'destination preview failed'):
         caps = capacity.capture(tree, evidence, proposal, private_state.HOST_STATE_DIR.absolute())
-        admission = {"version": "modelark.slice.direct.v1", "catalog": catalog_path, "capacity": caps}
+        admission = {"version": "modelark.slice.direct.v2", "catalog": catalog_path, "capacity": caps,
+                     "decode_policy": qualified_policy().to_record()}
         binding = t.DestinationBinding(evidence.device_id, evidence.fs_uuid,
-                                       "direct-v1:" + hashlib.sha256(d._json(admission)).hexdigest(),
+                                       "direct-v2:" + hashlib.sha256(d._json(admission)).hexdigest(),
                                        evidence.available_bytes)
         reserve = capacity.metadata_reserve_bytes(proposal, binding, caps, private_state.HOST_STATE_DIR.absolute())
         plan = t.TransferPlan(proposal, binding, metadata_reserve_bytes=reserve)
@@ -222,7 +224,9 @@ def start(tx, destination_path, attachments):
             # reconciliation belongs to the authenticated adapter, not fresh-start admission.
             destination = _CheckedDestination(tree, plan.destination, store, tx, observer, path,
                                               plan.proposal, admission["capacity"], admission["catalog"], evidence)
-            sources = FencedSources(admission["catalog"], LocalArchiveReader(attachments, observer=observer))
+            options = ({"policy": DecodePolicy.from_record(admission["decode_policy"])}
+                       if "decode_policy" in admission else {})
+            sources = FencedSources(admission["catalog"], LocalArchiveReader(attachments, observer=observer, **options))
             try:
                 session = t.start(store, tx, destination, sources)
             except KeyboardInterrupt:

--- a/modelark/slice/operator.py
+++ b/modelark/slice/operator.py
@@ -171,7 +171,10 @@ class _CheckedDestination(UsbDestination):
         self._observer.recheck_attachment(self.tree, self._evidence)
 
 
-def _acknowledge_interrupt(store, tx, destination, sources, session=None):
+def _acknowledge_interrupt(store, tx, destination, sources, session=None, *, error=None):
+    from .authority import PreclaimInterrupted
+    if isinstance(error, PreclaimInterrupted):
+        return error.outcome  # Already acknowledged while preclaim exclusion was held.
     store.request_stop(tx)
     try:
         if session is not None:
@@ -229,8 +232,8 @@ def start(tx, destination_path, attachments):
             sources = FencedSources(admission["catalog"], LocalArchiveReader(attachments, observer=observer, **options))
             try:
                 session = t.start(store, tx, destination, sources)
-            except KeyboardInterrupt:
-                return _result(_acknowledge_interrupt(store, tx, destination, sources), stop_requested=True)
+            except KeyboardInterrupt as exc:
+                return _result(_acknowledge_interrupt(store, tx, destination, sources, error=exc), stop_requested=True)
             if isinstance(session, t.Status):
                 return _result(session)
             with session:

--- a/modelark/slice/sources.py
+++ b/modelark/slice/sources.py
@@ -1,5 +1,6 @@
 """Read-only source-use gate sharing the archive writer's nonblocking drive fence."""
 from contextlib import ExitStack, contextmanager
+import json
 
 from modelark import drive_fence
 from modelark.drive_identity import FenceIdentity, UnprovenFenceIdentity
@@ -32,8 +33,22 @@ class FencedSources:
     def __init__(self, catalog_path, reader):
         self.catalog_path, self.reader = catalog_path, reader
 
+    @property
+    def requires_preflight(self):
+        return getattr(self.reader, "policy", None) is not None
+
     @contextmanager
     def open(self, candidate):
+        with self._open(candidate) as result:
+            yield result
+
+    @contextmanager
+    def open_checked(self, candidate, check):
+        with self._open(candidate, check=check) as result:
+            yield result
+
+    @contextmanager
+    def _open(self, candidate, *, check=None, inspect=False, artifact=None):
         def identity(drive):
             return FenceIdentity(drive.fs_uuid, drive.annex_uuid, drive.serial,
                                  drive.filesystem_capacity_bytes, drive.identity_epoch,
@@ -50,7 +65,15 @@ class FencedSources:
                               if drive.drive_label == candidate.drive.drive_label), None)
                 if fresh is None or identity(fresh) != captured:
                     raise TransferRefusal("SOURCE_EVIDENCE_UNAVAILABLE", "source identity changed")
-                stream = stack.enter_context(self.reader.open(candidate))
+                if inspect:
+                    from .transaction import _same_source
+                    if artifact is None or not _same_source(artifact, candidate, snapshot):
+                        raise TransferRefusal("SOURCE_CHANGED", candidate.drive.drive_label)
+                    stream = stack.enter_context(self.reader.inspect(candidate, check=check))
+                elif check is not None and getattr(self.reader, "policy", None) is not None:
+                    stream = stack.enter_context(self.reader.open(candidate, check=check))
+                else:
+                    stream = stack.enter_context(self.reader.open(candidate))
             except UnprovenFenceIdentity as exc:
                 raise TransferRefusal("SOURCE_EVIDENCE_UNAVAILABLE", str(exc)) from exc
             except drive_fence.FenceUnavailable as exc:
@@ -61,3 +84,30 @@ class FencedSources:
                 raise TransferRefusal("SOURCE_MISSING", candidate.drive.drive_label) from exc
             # Do not translate exceptions thrown by the destination/consumer inside this yield.
             yield snapshot, _SourceRead(stream, candidate.drive.drive_label)
+
+    def preflight(self, proposal, check=lambda: None):
+        """All attached alternatives, before output/one-attempt authority exists.
+
+        An absent alternative is not checked. It preserves the existing wait
+        option when no attached candidate is currently usable. One bad encoding
+        never invalidates another sealed representation of the same original.
+        """
+        if getattr(self.reader, "policy", None) is None:
+            return
+        for artifact in proposal.closure:
+            usable, errors = False, []
+            for candidate in artifact.sources:
+                check()
+                try:
+                    with self._open(candidate, check=check, inspect=True, artifact=artifact):
+                        pass
+                    usable = True
+                except TransferRefusal as exc:
+                    if not (exc.code.startswith("SOURCE_") or exc.code == "WAITING_SOURCE"):
+                        raise
+                    errors.append({"code": exc.code, "drive_label": candidate.drive.drive_label,
+                                   "detail": exc.detail})
+            if not usable:
+                waiting = any(error["code"] == "WAITING_SOURCE" for error in errors)
+                raise TransferRefusal("WAITING_SOURCE" if waiting else "SOURCE_BLOCKED", json.dumps({
+                    "repo_id": artifact.repo_id, "rfilename": artifact.rfilename, "candidates": errors}))

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -70,6 +70,11 @@ class Reservation(NamedTuple):
     stop_serial: int
     acknowledged_stop_serial: int
 
+    def resumes(self, state, serial, acknowledged):
+        """Only a Start issued after this exact Stop acknowledgment may resume."""
+        return (self.state == state == "stopped"
+                and self.stop_serial == self.acknowledged_stop_serial == serial == acknowledged)
+
 
 def _private_directory(path):
     for ancestor in (path, *path.parents):
@@ -363,32 +368,46 @@ class Store:
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
         if owner != (tx,):
             raise TransferRefusal("EXECUTION_FENCE_LOST")
-        resume = (reservation.state == state == "stopped"
-                  and reservation.stop_serial == reservation.acknowledged_stop_serial == serial == acknowledged)
+        resume = reservation.resumes(state, serial, acknowledged)
         if stop and not resume:
             raise TransferRefusal("STOPPED")
         if state not in RESUMABLE_STATES:
             raise TransferRefusal("NOT_RESUMABLE", state)
 
-    def refuse_preclaim(self, tx, device, refusal):
+    def refuse_preclaim(self, tx, device, reservation, refusal, *, interrupted=False):
         """Record read-only admission failure under exclusion; consume no FAT attempt.
 
         Only DeliveryAuthority calls this before publishing an attempt. Never
-        clears a stop: acknowledge it and let a later explicit Start resume.
+        clears a new Stop. The reservation may consume only its already
+        acknowledged Stop; a later serial always wins over a source outcome.
+        An interrupt requests and acknowledges Stop in this same transaction.
         """
         from .authority import refusal_state
-        from .transaction import TransferRefusal
+        from .transaction import TransferRefusal, Status
         with self._connection() as con:
             owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
             if owner != (tx,):
                 raise TransferRefusal("EXECUTION_FENCE_LOST")
-            stop, serial = con.execute("SELECT stop,stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
-            state = "stopped" if stop else refusal_state(refusal.code)
-            if stop:
-                con.execute("UPDATE transactions SET state='stopped',reason='STOPPED',"
-                            "acknowledged_stop_serial=? WHERE id=?", (serial, tx))
+            current, stop, serial, acknowledged = con.execute(
+                "SELECT state,stop,stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
+            if current not in RESUMABLE_STATES:
+                raise TransferRefusal("NOT_RESUMABLE", current)
+            resume = reservation.resumes(current, serial, acknowledged)
+            pending_stop = bool(stop) and not resume
+            if interrupted:
+                # Reuse an outstanding new Stop, but never confuse an old
+                # acknowledged resume with this interrupt's new request.
+                serial += not pending_stop
+            if pending_stop or interrupted or refusal.code == "STOPPED":
+                state, reason = "stopped", "STOPPED"
+                con.execute("UPDATE transactions SET state=?,reason=?,stop=1,stop_serial=?,"
+                            "acknowledged_stop_serial=? WHERE id=?", (state, reason, serial, serial, tx))
             else:
-                con.execute("UPDATE transactions SET state=?,reason=? WHERE id=?", (state, str(refusal), tx))
+                state, reason = refusal_state(refusal.code), str(refusal)
+                # State moves away from stopped, so consume the authorized old
+                # stop flag now. The serials retain the historical evidence.
+                con.execute("UPDATE transactions SET state=?,reason=?,stop=0 WHERE id=?", (state, reason, tx))
+            return Status(tx, state, reason)
 
     def claim(self, tx, device, attempt, reservation):
         """Publish an attempt only while its caller holds exclusion and its live marker."""
@@ -413,8 +432,7 @@ class Store:
                     raise TransferRefusal("FAT32_NEW_ROOT_REQUIRED", "this intent has spent its only attempt")
             con.execute("UPDATE owners SET attempt=? WHERE device=? AND tx=?", (attempt.token, device, tx))
             # Only a Start issued AFTER this exact stop was acknowledged may clear it.
-            resume = (reservation.state == state == "stopped"
-                      and reservation.stop_serial == reservation.acknowledged_stop_serial == serial == acknowledged)
+            resume = reservation.resumes(state, serial, acknowledged)
             if stop and not resume:
                 con.execute("UPDATE transactions SET state='stopped',reason='STOPPED',"
                             "acknowledged_stop_serial=stop_serial WHERE id=?", (tx,))

--- a/modelark/slice/state.py
+++ b/modelark/slice/state.py
@@ -32,9 +32,9 @@ def _load_plan(payload):
         record = _decode(payload)
         if type(record) is not dict:
             raise ValueError("plan envelope required")
-        if record.get("version") == "modelark.slice.native-transaction.v1":
+        if record.get("version") in {"modelark.slice.native-transaction.v1", "modelark.slice.native-transaction.v2"}:
             return NativePlan.from_json(payload)
-        if record.get("version") == "modelark.slice.fat32-transaction.v1":
+        if record.get("version") in {"modelark.slice.fat32-transaction.v1", "modelark.slice.fat32-transaction.v2"}:
             return Fat32Plan.from_json(payload)
         return TransferPlan.from_json(payload)
     except (ValueError, TypeError) as exc:
@@ -229,16 +229,22 @@ class Store:
     def _validate_admission(plan, admission):
         from .transaction import TransferRefusal
         try:
-            valid = (type(admission) is dict and set(admission) == {"version", "catalog", "capacity"}
-                     and admission["version"] == "modelark.slice.direct.v1"
+            from modelark.artifact_policy import DecodePolicy
+            guarded = type(admission) is dict and admission.get("version") == "modelark.slice.direct.v2"
+            keys = {"version", "catalog", "capacity"} | ({"decode_policy"} if guarded else set())
+            valid = (type(admission) is dict and set(admission) == keys
+                     and admission["version"] in {"modelark.slice.direct.v1", "modelark.slice.direct.v2"}
                      and isinstance(admission["catalog"], str) and Path(admission["catalog"]).is_absolute()
                      and "\0" not in admission["catalog"]
                      and os.path.normpath(admission["catalog"]) == admission["catalog"]
                      and type(admission["capacity"]) is dict)
             digest = hashlib.sha256(_json(admission)).hexdigest()
+            if guarded:
+                DecodePolicy.from_record(admission.get("decode_policy"))
         except (TypeError, ValueError) as exc:
             raise TransferRefusal("ADMISSION_CORRUPT", "invalid direct admission record") from exc
-        if not valid or plan.destination.mount_id != "direct-v1:" + digest:
+        prefix = "direct-v2:" if guarded else "direct-v1:"
+        if not valid or plan.destination.mount_id != prefix + digest:
             raise TransferRefusal("ADMISSION_CORRUPT", "direct admission differs from sealed binding")
 
     def load_admission(self, tx):
@@ -348,6 +354,42 @@ class Store:
             row = con.execute("SELECT consumed_attempt FROM transactions WHERE id=?", (tx,)).fetchone()
         return bool(row and row[0] is not None)
 
+    def guard_preclaim(self, tx, device, reservation):
+        """Read-only stop check while the caller holds device exclusion, before claim."""
+        from .transaction import TransferRefusal
+        with self._connection(write=False) as con:
+            state, stop, serial, acknowledged = con.execute(
+                "SELECT state,stop,stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
+            owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
+        if owner != (tx,):
+            raise TransferRefusal("EXECUTION_FENCE_LOST")
+        resume = (reservation.state == state == "stopped"
+                  and reservation.stop_serial == reservation.acknowledged_stop_serial == serial == acknowledged)
+        if stop and not resume:
+            raise TransferRefusal("STOPPED")
+        if state not in RESUMABLE_STATES:
+            raise TransferRefusal("NOT_RESUMABLE", state)
+
+    def refuse_preclaim(self, tx, device, refusal):
+        """Record read-only admission failure under exclusion; consume no FAT attempt.
+
+        Only DeliveryAuthority calls this before publishing an attempt. Never
+        clears a stop: acknowledge it and let a later explicit Start resume.
+        """
+        from .authority import refusal_state
+        from .transaction import TransferRefusal
+        with self._connection() as con:
+            owner = con.execute("SELECT tx FROM owners WHERE device=?", (device,)).fetchone()
+            if owner != (tx,):
+                raise TransferRefusal("EXECUTION_FENCE_LOST")
+            stop, serial = con.execute("SELECT stop,stop_serial FROM transactions WHERE id=?", (tx,)).fetchone()
+            state = "stopped" if stop else refusal_state(refusal.code)
+            if stop:
+                con.execute("UPDATE transactions SET state='stopped',reason='STOPPED',"
+                            "acknowledged_stop_serial=? WHERE id=?", (serial, tx))
+            else:
+                con.execute("UPDATE transactions SET state=?,reason=? WHERE id=?", (state, str(refusal), tx))
+
     def claim(self, tx, device, attempt, reservation):
         """Publish an attempt only while its caller holds exclusion and its live marker."""
         from .transaction import TransferRefusal, Status
@@ -369,7 +411,6 @@ class Store:
             if getattr(plan, "session_only", False):
                 if consumed is not None:
                     raise TransferRefusal("FAT32_NEW_ROOT_REQUIRED", "this intent has spent its only attempt")
-                con.execute("UPDATE transactions SET consumed_attempt=? WHERE id=?", (attempt.token, tx))
             con.execute("UPDATE owners SET attempt=? WHERE device=? AND tx=?", (attempt.token, device, tx))
             # Only a Start issued AFTER this exact stop was acknowledged may clear it.
             resume = (reservation.state == state == "stopped"
@@ -378,6 +419,10 @@ class Store:
                 con.execute("UPDATE transactions SET state='stopped',reason='STOPPED',"
                             "acknowledged_stop_serial=stop_serial WHERE id=?", (tx,))
                 return Status(tx, "stopped", "STOPPED")
+            if getattr(plan, "session_only", False):
+                # A stop observed in this same atomic claim must not spend the
+                # one-shot authority before any destination session can begin.
+                con.execute("UPDATE transactions SET consumed_attempt=? WHERE id=?", (attempt.token, tx))
             con.execute("UPDATE transactions SET state='starting',reason='',stop=0 WHERE id=?", (tx,))
             return Status(tx, "starting")
 

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -241,7 +241,13 @@ def start(store, tx, destination: DestinationPort, sources: SourcePort, *, fault
     if isinstance(serial, Status):
         return serial
     (fault or (lambda point: None))("reservation_committed")
-    authority = DeliveryAuthority.acquire(store, tx, plan.destination.device_id, serial)
+    inspect = getattr(sources, "preflight", None)
+    # Existing native partial output is authenticated by Session recovery and
+    # actual source-use checks. Completed files must not require sources online.
+    preflight = ((lambda check: inspect(plan.proposal, check))
+                 if inspect is not None and getattr(sources, "requires_preflight", True)
+                 and not store.events(tx) else None)
+    authority = DeliveryAuthority.acquire(store, tx, plan.destination.device_id, serial, preflight=preflight)
     if isinstance(authority, Status):
         return authority
     try:
@@ -602,7 +608,10 @@ class Session:
         errors = []
         for source in artifact.sources:
             try:
-                with self.sources.open(source) as (snapshot, stream):
+                checked = getattr(self.sources, "open_checked", None)
+                context = (checked(source, self._boundary) if checked is not None
+                           else self.sources.open(source))
+                with context as (snapshot, stream):
                     if not _same_source(artifact, source, snapshot):
                         raise TransferRefusal("SOURCE_CHANGED", source.drive.drive_label)
                     return self._write(op, stream, asdict(source))

--- a/modelark/streamznn.py
+++ b/modelark/streamznn.py
@@ -55,6 +55,7 @@ DEALINGS IN THE SOFTWARE.
 from __future__ import annotations
 
 import hashlib
+from contextlib import nullcontext
 import os
 import re
 import struct
@@ -189,36 +190,16 @@ def read_zipnn_frame(stream: BinaryIO, *, max_stored_bytes: int, max_decoded_byt
     return bytes(decoded)
 
 
-def iter_decompress(stream: BinaryIO, *, max_stored_frame_bytes: int = _MAX_BLOB,
-                    max_decoded_frame_bytes: int | None = None,
-                    max_total_bytes: int | None = None, read_size: int = _HASH_READ,
-                    prefix: bytes = b"",
-                    frame_reader: Callable[[BinaryIO, int, int | None], bytes] | None = None):
-    """Yield restored frames from a caller-owned, possibly non-seekable stream.
-
-    Handles short reads and bounds each input request by `read_size`. `prefix`
-    is container magic already consumed by a dispatcher. Closing the iterator
-    never closes the supplied stream. IO and frame-reader exceptions propagate.
-
-    Default decoding preserves the historical standalone ZipNN acceptance and
-    exception behavior. Optional decoded/total limits are checked AFTER default
-    native decoding, not a native RAM guard. For untrusted byte frames, inject a
-    reader using `read_zipnn_frame` to validate headers before native allocation.
-    The callback receives (stream, stored_length, remaining_total_or_None), must
-    consume exactly that frame, and retains its own input-read/resource policy.
-    """
+def iter_frame_lengths(stream: BinaryIO, *, max_stored_frame_bytes: int = _MAX_BLOB,
+                       read_size: int = _HASH_READ, prefix: bytes = b""):
+    """Shared container framing. Caller consumes each yielded frame before next()."""
     _positive_bound(max_stored_frame_bytes, "stored frame bound")
     _positive_bound(read_size, "read size")
-    for value, name in ((max_decoded_frame_bytes, "decoded frame bound"),
-                        (max_total_bytes, "total bound")):
-        if value is not None:
-            _positive_bound(value, name, zero=True)
     if not isinstance(prefix, bytes) or len(prefix) > len(MAGIC):
         raise ValueError("invalid container prefix")
     magic = prefix + _read_exact(stream, len(MAGIC) - len(prefix), read_size=read_size)
     if magic != MAGIC:
         raise StreamZnnError(f"bad magic {magic!r}: not a StreamZNN container")
-    total = 0
     while True:
         head = stream.read(1)
         if head == b"":
@@ -231,20 +212,64 @@ def iter_decompress(stream: BinaryIO, *, max_stored_frame_bytes: int = _MAX_BLOB
             raise StreamZnnError("implausible frame length 0")
         if blob_len > max_stored_frame_bytes:
             raise DecodeLimitExceeded("stored StreamZNN frame exceeds bound")
+        yield blob_len
+
+
+def iter_decompress(stream: BinaryIO, *, max_stored_frame_bytes: int = _MAX_BLOB,
+                    max_decoded_frame_bytes: int | None = None,
+                    max_total_bytes: int | None = None, read_size: int = _HASH_READ,
+                    prefix: bytes = b"",
+                    frame_reader: Callable[[BinaryIO, int, int | None], bytes] | None = None,
+                    frame_stream=None):
+    """Yield restored frames from a caller-owned, possibly non-seekable stream.
+
+    Handles short reads and bounds each input request by `read_size`. `prefix`
+    is container magic already consumed by a dispatcher. Closing the iterator
+    never closes the supplied stream. IO and frame-reader exceptions propagate.
+
+    Default decoding preserves the historical standalone ZipNN acceptance and
+    exception behavior. Optional decoded/total limits are checked AFTER default
+    native decoding, not a native RAM guard. For untrusted byte frames, inject a
+    reader using `read_zipnn_frame` to validate headers before native allocation.
+    The callback receives (stream, stored_length, remaining_total_or_None), must
+    consume exactly that frame, and retains its own input-read/resource policy.
+    Alternatively, frame_stream returns a context manager yielding bounded byte
+    pieces for one frame. Its context closes before advancing to the next frame,
+    including on iterator close/failure. The two hooks are mutually exclusive.
+    """
+    _positive_bound(max_stored_frame_bytes, "stored frame bound")
+    if frame_reader is not None and frame_stream is not None:
+        raise ValueError("choose one frame reader")
+    _positive_bound(read_size, "read size")
+    for value, name in ((max_decoded_frame_bytes, "decoded frame bound"),
+                        (max_total_bytes, "total bound")):
+        if value is not None:
+            _positive_bound(value, name, zero=True)
+    total = 0
+    for blob_len in iter_frame_lengths(stream, max_stored_frame_bytes=max_stored_frame_bytes,
+                                      read_size=read_size, prefix=prefix):
         remaining = None if max_total_bytes is None else max_total_bytes - total
-        if frame_reader is None:
+        if frame_stream is not None:
+            context = frame_stream(stream, blob_len, remaining)
+        elif frame_reader is None:
             blob = _read_exact(stream, blob_len, read_size=read_size)
             restored = bytes(_zipnn().decompress(blob))
+            context = nullcontext((restored,))
         else:
             restored = frame_reader(stream, blob_len, remaining)
-        if not isinstance(restored, bytes):
-            raise StreamZnnError("frame reader must return bytes")
-        if max_decoded_frame_bytes is not None and len(restored) > max_decoded_frame_bytes:
-            raise DecodeLimitExceeded("decoded StreamZNN frame exceeds bound")
-        total += len(restored)
-        if max_total_bytes is not None and total > max_total_bytes:
-            raise DecodeLimitExceeded("decoded total exceeds bound")
-        yield restored
+            context = nullcontext((restored,))
+        frame_total = 0
+        with context as pieces:
+            for restored in pieces:
+                if not isinstance(restored, bytes):
+                    raise StreamZnnError("frame reader must return bytes")
+                frame_total += len(restored)
+                if max_decoded_frame_bytes is not None and frame_total > max_decoded_frame_bytes:
+                    raise DecodeLimitExceeded("decoded StreamZNN frame exceeds bound")
+                total += len(restored)
+                if max_total_bytes is not None and total > max_total_bytes:
+                    raise DecodeLimitExceeded("decoded total exceeds bound")
+                yield restored
 
 
 def compress_file(

--- a/scripts/qualify_codec_resources.py
+++ b/scripts/qualify_codec_resources.py
@@ -154,13 +154,45 @@ def _guarded_roundtrip(encoded, size, expected_hash, policy):
             "parent_metrics_before": before, "parent_metrics_after": _metrics()}
 
 
-def run(*, large=False, output_parent=None, guarded_reader=False):
+def _slice_roundtrip(encoded, codec, size, expected_hash, memory):
+    from modelark.artifact_policy import qualified_policy
+    from modelark.artifact_preflight import inspect_original
+    from modelark.slice.decoding import original_stream
+    policy = qualified_policy()
+    if policy.memory != memory:
+        raise RuntimeError("Slice and writer qualification memory envelopes differ")
+    digest, total, maximum = hashlib.sha256(), 0, 0
+    evidence = []
+    before = _metrics()
+    with encoded.open("rb") as source:
+        inspect_original(source, compressed=True, stored_bytes=encoded.stat().st_size,
+                         expected_bytes=size, policy=policy)
+    with encoded.open("rb") as source:
+        reader = original_stream(source, compressed=True, expected_bytes=size,
+                                 policy=policy, on_frame_complete=evidence.append)
+        try:
+            while piece := reader.read(1 << 20):
+                total += len(piece)
+                maximum = max(maximum, len(piece))
+                digest.update(piece)
+        finally:
+            reader.close()
+    if total != size or digest.hexdigest() != expected_hash or maximum > 64 << 10 or not evidence:
+        raise RuntimeError("Slice original-byte round trip did not certify its bounded output")
+    return {"passed": True, "phase": "slice-reader", "codec": codec,
+            "decode_policy": policy.to_record(), "original_bytes": total,
+            "original_sha256": digest.hexdigest(), "maximum_output_piece": maximum,
+            "frames": evidence, "parent_metrics_before": before, "parent_metrics_after": _metrics()}
+
+
+def run(*, large=False, output_parent=None, guarded_reader=False, slice_reader=False):
     policy = CodecMemoryPolicy(8 << 30, 2 << 30)
     policy.admit(available_memory()["available_bytes"])
     output = Path(tempfile.mkdtemp(prefix="modelark-codec-qualification-", dir=output_parent))
     report = {"status": "running", "scope": "synthetic-codec-resource-qualification-only",
               "policy": policy.to_record(), "results": [], "large": large,
               "guarded_reader": guarded_reader,
+              "slice_reader": slice_reader,
               "production_adoption": False, "physical_USB_or_archive_test": False}
     checkout = Path(__file__).resolve().parent.parent
     report["implementation_sha256"] = {
@@ -168,6 +200,8 @@ def run(*, large=False, output_parent=None, guarded_reader=False):
             "modelark/codec_resources.py", "modelark/compress.py", "modelark/streamznn.py",
             "modelark/codec_worker.py", "modelark/codec_supervisor.py",
             "modelark/codec_process.py",
+            "modelark/artifact_io.py", "modelark/artifact_policy.py", "modelark/artifact_preflight.py",
+            "modelark/slice/decoding.py",
             "scripts/qualify_codec_resources.py")}
     print(f"Qualification directory: {output}", flush=True)
     index = 0
@@ -204,7 +238,7 @@ def run(*, large=False, output_parent=None, guarded_reader=False):
     try:
         launch({"phase": "allocation-refusal"})
         sizes = [99_630_640, 409_993_344] if large else [2 << 20]
-        if large and guarded_reader:
+        if large and (guarded_reader or slice_reader):
             sizes.insert(0, 64 << 20)  # Default StreamZNN-sized native work unit too.
         with tempfile.TemporaryDirectory(prefix="synthetic-", dir=output) as scratch:
             for size in sizes:
@@ -222,6 +256,10 @@ def run(*, large=False, output_parent=None, guarded_reader=False):
                         result = _guarded_roundtrip(case / "misleading.blob", size, digest, policy)
                         report["results"].append(result)
                         print(f"passed guarded reader: {size} original bytes", flush=True)
+                    if slice_reader:
+                        result = _slice_roundtrip(case / "misleading.blob", codec, size, digest, policy)
+                        report["results"].append(result)
+                        print(f"passed Slice reader: {codec} {size} original bytes", flush=True)
         if any(_sha(checkout / name) != digest
                for name, digest in report["implementation_sha256"].items()):
             raise RuntimeError("implementation changed during qualification; rerun unchanged code")
@@ -238,6 +276,7 @@ def run(*, large=False, output_parent=None, guarded_reader=False):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--large", action="store_true", help="qualify the two real failure sizes")
+    parser.add_argument("--slice-reader", action="store_true", help="qualify C2 preflight and Slice original-byte decoding")
     parser.add_argument("--output-parent", type=Path)
     parser.add_argument("--guarded-reader", action="store_true",
                         help="also qualify bounded parent/worker whole-frame transport")
@@ -247,7 +286,8 @@ def main():
     if args.worker:
         worker(args.worker, args.parent_pid)
     else:
-        print(run(large=args.large, output_parent=args.output_parent, guarded_reader=args.guarded_reader))
+        print(run(large=args.large, output_parent=args.output_parent, guarded_reader=args.guarded_reader,
+                  slice_reader=args.slice_reader))
 
 
 if __name__ == "__main__":

--- a/tests/test_codec_resources.py
+++ b/tests/test_codec_resources.py
@@ -40,6 +40,43 @@ def test_policy_roundtrip_and_closed_world():
             CodecMemoryPolicy.from_record(changed)
 
 
+@pytest.mark.parametrize("limits,allowed", [((-1, -1), True), ((4096, 4096), True),
+                                           ((8192, -1), True), ((4095, -1), False),
+                                           ((4095, 8192), False), ((4096, 4095), False)])
+def test_admission_and_install_share_read_only_environment_check(monkeypatch, limits, allowed):
+    import resource
+    policy = CodecMemoryPolicy(4096, 1024)
+    monkeypatch.setattr(resource, "getrlimit", lambda key: limits)
+    monkeypatch.setattr(resource, "setrlimit", lambda *a: pytest.fail("read-only admission changed limits"))
+    if allowed:
+        policy.check_worker_environment()
+        policy.admit(5120)
+    else:
+        for operation in (policy.check_worker_environment, lambda: policy.admit(5120), policy.install_in_worker):
+            with pytest.raises(CodecResourceRefusal, match="inherited AS ceiling"):
+                operation()
+
+
+@pytest.mark.parametrize("operation", ["check_worker_environment", "admit", "install_in_worker"])
+def test_unknown_environment_is_consistently_refused(monkeypatch, operation):
+    from modelark import codec_resources
+    policy = CodecMemoryPolicy(4096, 0)
+    with monkeypatch.context() as patch:
+        patch.setattr(codec_resources.sys, "platform", "unqualified-os")
+        with pytest.raises(CodecResourceRefusal, match="only qualified on Linux"):
+            getattr(policy, operation)(*([] if operation != "admit" else [4096]))
+
+
+def test_unreadable_limits_refuse_before_parent_mutation(monkeypatch):
+    import resource
+    def unreadable(key):
+        raise OSError("cannot inspect AS ceiling")
+    monkeypatch.setattr(resource, "getrlimit", unreadable)
+    monkeypatch.setattr(resource, "setrlimit", lambda *a: pytest.fail("changed parent guard"))
+    with pytest.raises(CodecResourceRefusal, match="could not inspect inherited"):
+        CodecMemoryPolicy(4096, 0).admit(4096)
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux worker guard")
 def test_real_child_ceiling_denies_allocation_and_does_not_change_parent():
     import resource

--- a/tests/test_serial_repair_public_slice.py
+++ b/tests/test_serial_repair_public_slice.py
@@ -245,6 +245,8 @@ def test_historic_serialless_seal_stales_but_completed_output_and_receipt_surviv
                                  {"drive-00": case.archive})
     assert stale_start["state"] == "blocked_source", stale_start
     assert "SOURCE_EVIDENCE_UNAVAILABLE" in stale_start["reason"]
+    assert not (case.parent / "approved-before-repair").exists()
+    assert state.Store().events(old["transaction_id"]) == []
     assert not (case.parent / "approved-before-repair" / REPO / NAME).exists()
     assert not (case.parent / "approved-before-repair/.modelark-slice-receipt.json").exists()
     assert state.Store().load(old["transaction_id"]) == old_plan

--- a/tests/test_slice_fat32_operator.py
+++ b/tests/test_slice_fat32_operator.py
@@ -152,6 +152,24 @@ def test_fat_preflight_returns_source_status_without_spending_attempt(setup, mon
     assert operator.start(tx, setup.parent / "delivery", {})["state"] == "complete"
 
 
+def test_fat_preflight_interrupt_returns_acknowledged_stop_without_reclaim(setup, monkeypatch):
+    tx = approved(setup)["transaction_id"]
+    def interrupted(self, proposal, check):
+        raise KeyboardInterrupt
+    monkeypatch.setattr(Sources, "preflight", interrupted, raising=False)
+    with monkeypatch.context() as patch:
+        patch.setattr(state.Store, "claim", lambda *a: pytest.fail("interrupted preflight claimed an attempt"))
+        outcome = operator.start(tx, setup.parent / "delivery", {})
+    assert outcome["state"] == "stopped" and outcome["stop_requested"]
+    assert not outcome["ok"] and not outcome["can_write"] and not outcome["new_root_required"]
+    assert not state.Store().attempt_consumed(tx)
+    assert state.Store().events(tx) == [] and not (setup.parent / "delivery").exists()
+    with state.Store()._connection(write=False) as con:
+        assert con.execute("SELECT stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?", (tx,)).fetchone() == (1, 1)
+    monkeypatch.setattr(Sources, "preflight", lambda self, proposal, check: check())
+    assert operator.start(tx, setup.parent / "delivery", {})["state"] == "complete"
+
+
 def test_unapproved_plan_refuses_before_observation(setup, monkeypatch):
     result = preview(setup)
     monkeypatch.setattr(fat, "Fat32FolderObserver", lambda: pytest.fail("unapproved Start observed destination"))

--- a/tests/test_slice_fat32_operator.py
+++ b/tests/test_slice_fat32_operator.py
@@ -126,6 +126,32 @@ def test_complete_export_receipt_and_control_stay_inside_child(setup, monkeypatc
     assert operator.start(result["transaction_id"], "/absent", {})["state"] == "complete"
 
 
+@pytest.mark.parametrize("code,expected", [("SOURCE_BLOCKED", "blocked_source"),
+                                           ("WAITING_SOURCE", "waiting_source"),
+                                           ("stop-race", "stopped")])
+def test_fat_preflight_returns_source_status_without_spending_attempt(setup, monkeypatch, code, expected):
+    result = approved(setup)
+    tx = result["transaction_id"]
+    def refuse(self, proposal, check):
+        check()
+        if code == "stop-race":
+            state.Store().request_stop(tx)
+        raise t.TransferRefusal("SOURCE_BLOCKED" if code == "stop-race" else code,
+                                "preflight source unavailable")
+    monkeypatch.setattr(Sources, "preflight", refuse, raising=False)
+    outcome = operator.start(tx, setup.parent / "delivery", {})
+    assert outcome["state"] == expected and not outcome["can_write"]
+    assert outcome["new_root_required"] is False
+    assert state.Store().events(tx) == [] and not (setup.parent / "delivery").exists()
+    assert not state.Store().attempt_consumed(tx)
+    if code == "stop-race":
+        assert state.Store().stop_requested(tx) and outcome["reason"] == "STOPPED"
+    else:
+        assert not outcome["ok"] and code in outcome["reason"]
+    monkeypatch.setattr(Sources, "preflight", lambda self, proposal, check: check())
+    assert operator.start(tx, setup.parent / "delivery", {})["state"] == "complete"
+
+
 def test_unapproved_plan_refuses_before_observation(setup, monkeypatch):
     result = preview(setup)
     monkeypatch.setattr(fat, "Fat32FolderObserver", lambda: pytest.fail("unapproved Start observed destination"))

--- a/tests/test_slice_folder_operator.py
+++ b/tests/test_slice_folder_operator.py
@@ -144,6 +144,23 @@ def test_native_preflight_returns_source_status_without_output(setup, monkeypatc
     assert operator.start(tx, parent / "delivery", {})["state"] == "complete"
 
 
+def test_native_preflight_interrupt_returns_acknowledged_stop_without_reclaim(setup, monkeypatch):
+    parent, _, _ = setup
+    tx = approved(setup)["transaction_id"]
+    def interrupted(self, proposal, check):
+        raise KeyboardInterrupt
+    monkeypatch.setattr(Sources, "preflight", interrupted, raising=False)
+    with monkeypatch.context() as patch:
+        patch.setattr(state.Store, "claim", lambda *a: pytest.fail("interrupted preflight claimed an attempt"))
+        outcome = operator.start(tx, parent / "delivery", {})
+    assert outcome["state"] == "stopped" and outcome["stop_requested"] and not outcome["can_write"]
+    assert state.Store().events(tx) == [] and not (parent / "delivery").exists()
+    with state.Store()._connection(write=False) as con:
+        assert con.execute("SELECT stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?", (tx,)).fetchone() == (1, 1)
+    monkeypatch.setattr(Sources, "preflight", lambda self, proposal, check: check())
+    assert operator.start(tx, parent / "delivery", {})["state"] == "complete"
+
+
 def test_unapproved_native_plan_refuses_before_observation(setup, monkeypatch):
     parent, catalog, _ = setup
     result = operator.preview(catalog, parent / "delivery", ("org/model",), None)

--- a/tests/test_slice_folder_operator.py
+++ b/tests/test_slice_folder_operator.py
@@ -126,6 +126,24 @@ def test_native_operator_roundtrip_and_completed_start_need_no_usb_observer(setu
     assert operator.start(tx, "/absent", {})["state"] == "complete"
 
 
+@pytest.mark.parametrize("code,expected", [("SOURCE_BLOCKED", "blocked_source"),
+                                           ("WAITING_SOURCE", "waiting_source")])
+def test_native_preflight_returns_source_status_without_output(setup, monkeypatch, code, expected):
+    parent, _, _ = setup
+    result = approved(setup)
+    tx = result["transaction_id"]
+    def refuse(self, proposal, check):
+        check()
+        raise t.TransferRefusal(code, "preflight source unavailable")
+    monkeypatch.setattr(Sources, "preflight", refuse, raising=False)
+    outcome = operator.start(tx, parent / "delivery", {})
+    assert outcome["state"] == expected and not outcome["ok"] and not outcome["can_write"]
+    assert code in outcome["reason"]
+    assert state.Store().events(tx) == [] and not (parent / "delivery").exists()
+    monkeypatch.setattr(Sources, "preflight", lambda self, proposal, check: check())
+    assert operator.start(tx, parent / "delivery", {})["state"] == "complete"
+
+
 def test_unapproved_native_plan_refuses_before_observation(setup, monkeypatch):
     parent, catalog, _ = setup
     result = operator.preview(catalog, parent / "delivery", ("org/model",), None)

--- a/tests/test_slice_guarded_decoding.py
+++ b/tests/test_slice_guarded_decoding.py
@@ -1,0 +1,456 @@
+"""C2: explicit policy, bounded container hooks and guarded source lifetime."""
+# ruff: noqa: F811 -- imported pytest fixtures deliberately name test parameters
+from contextlib import contextmanager
+from dataclasses import replace
+import hashlib
+import io
+import json
+import struct
+
+import pytest
+
+from modelark import artifact_io, artifact_preflight, codec_supervisor, streamznn
+from modelark.artifact_policy import DecodePolicy, qualified_policy
+from modelark.slice import state
+from modelark.slice.decoding import original_stream
+from modelark.slice.transaction import TransferRefusal
+from test_slice_local_source import attachment  # noqa: F401
+from test_slice_fat32_transactions import fat  # noqa: F401
+from test_slice_fence_integration import archive  # noqa: F401
+from test_slice_operator import store  # noqa: F401
+
+
+def header(original=128, stored=36):
+    result = bytearray(32)
+    result[:4] = b"ZN\x00\x05"
+    result[5], result[8], result[15] = 10, 1, 1
+    result[16:24], result[24:32] = original.to_bytes(8, "little"), stored.to_bytes(8, "little")
+    return bytes(result)
+
+
+def container(*frames):
+    return streamznn.MAGIC + b"".join(struct.pack("<I", len(frame)) + frame for frame in frames)
+
+
+def inspect(blob, expected, *, policy=None, check=lambda: None):
+    return artifact_preflight.inspect_original(
+        io.BytesIO(blob), compressed=True, stored_bytes=len(blob), expected_bytes=expected,
+        policy=policy or qualified_policy(), check=check)
+
+
+@pytest.mark.parametrize("kind", ["whole", "stream"])
+def test_later_headers_checked_without_native_decode(monkeypatch, kind):
+    monkeypatch.setattr(codec_supervisor, "_launch", lambda *a: pytest.fail("preflight launched worker"))
+    monkeypatch.setattr(artifact_preflight, "available_memory", lambda: {"available_bytes": 16 << 30})
+    frame = header() + b"abcd"
+    blob = frame if kind == "whole" else container(frame, frame)
+    inspect(blob, 128 if kind == "whole" else 256)
+    if kind == "stream":
+        with pytest.raises(artifact_io.DecodeError, match="LIMIT"):
+            inspect(container(frame, header(original=9 << 30) + b"abcd"), 16 << 30)
+
+
+@pytest.mark.parametrize("blob,expected,error", [
+    (header() + b"abc", 128, "INVALID"),
+    (header() + b"abcdextra", 128, "INVALID"),
+    (header() + b"abcd", 129, "INVALID"),
+    (container(header() + b"abcd", header() + b"abc"), 256, "INVALID"),
+    (b"something else", 14, "UNSUPPORTED"),
+])
+def test_preflight_framing_refusals(blob, expected, error):
+    with pytest.raises(artifact_io.DecodeError, match=error):
+        inspect(blob, expected)
+
+
+def test_preflight_checks_and_discards_payload_in_small_reads(monkeypatch):
+    monkeypatch.setattr(artifact_preflight, "available_memory", lambda: {"available_bytes": 16 << 30})
+    calls = []
+    class Source(io.BytesIO):
+        def read(self, size):
+            assert 0 < size <= 64 << 10
+            calls.append(size)
+            return super().read(min(size, 127))
+    blob = header(stored=100032) + bytes(100000)
+    checks = []
+    artifact_preflight.inspect_original(Source(blob), compressed=True, stored_bytes=len(blob),
+                                        expected_bytes=128, policy=qualified_policy(),
+                                        check=lambda: checks.append(1))
+    assert len(checks) >= 2 * len(calls)
+
+
+@pytest.mark.parametrize("field", ["version", "limits", "memory", "zstd_window_unit"])
+def test_policy_closed_world_and_missing_fields(field):
+    record = qualified_policy().to_record()
+    record.pop(field)
+    with pytest.raises(ValueError):
+        DecodePolicy.from_record(record)
+
+
+@pytest.mark.parametrize("location", [None, "limits", "memory"])
+def test_policy_unknown_fields_refused(location):
+    record = qualified_policy().to_record()
+    (record if location is None else record[location])["future"] = True
+    with pytest.raises(ValueError):
+        DecodePolicy.from_record(record)
+
+
+@pytest.mark.parametrize("kind", ["native", "fat32"])
+def test_both_folder_versions_roundtrip_without_widening_old_seals(kind):
+    if kind == "native":
+        from test_slice_folder_plan import plan
+        from modelark.slice.folder_plan import binding_for, POLICY_VERSION
+    else:
+        from test_slice_fat32_plan import plan
+        from modelark.slice.fat32_plan import binding_for, POLICY_VERSION
+    old = plan()
+    old_json = old.to_json()
+    assert "decode_policy" not in json.loads(old_json)
+    assert state._load_plan(old_json).to_json() == old_json
+    policy = qualified_policy()
+    binding = binding_for(old.destination.target, old.catalog, old.parent_path, old.backing_ids, policy)
+    new = replace(old, destination=binding, version=POLICY_VERSION, decode_policy=policy)
+    assert new.seal != old.seal and new.destination.admission_id != old.destination.admission_id
+    assert state._load_plan(new.to_json()) == new
+    for change in ({"decode_policy": None}, {"version": old.version}):
+        record = json.loads(new.to_json()) | change
+        with pytest.raises((TransferRefusal, ValueError)):
+            state._load_plan(json.dumps(record))
+    record = json.loads(new.to_json())
+    record["decode_policy"]["memory"]["reserve_bytes"] += 1
+    with pytest.raises(TransferRefusal, match="ADMISSION_CORRUPT"):
+        state._load_plan(json.dumps(record))
+    assert old.to_json() == old_json
+
+
+@pytest.mark.parametrize("kind", ["whole", "stream"])
+def test_guarded_dispatch_never_joins_worker_output_and_closes_context(monkeypatch, kind):
+    events = []
+    @contextmanager
+    def worker(source, **kwargs):
+        events.append("open")
+        try:
+            yield iter((b"abc", b"def"))
+        finally:
+            events.append("reaped")
+    monkeypatch.setattr(codec_supervisor, "guarded_zipnn_frame", worker)
+    blob = b"ZN000" if kind == "whole" else container(b"unused")
+    reader = original_stream(io.BytesIO(blob), compressed=True, expected_bytes=6, policy=qualified_policy())
+    assert reader.read(2) == b"ab"
+    assert events == ["open"]
+    reader.close()
+    assert events == ["open", "reaped"]
+
+
+def test_local_source_reaps_before_descriptor_release_and_preserves_consumer_error(attachment, monkeypatch):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    events = []
+    @contextmanager
+    def worker(source, **kwargs):
+        try:
+            yield iter((b"originaldata",))
+        finally:
+            # A fresh attachment proof remains usable until helper cleanup ends.
+            kwargs["check"]()
+            events.append("reaped")
+    monkeypatch.setattr(codec_supervisor, "guarded_zipnn_frame", worker)
+    (root / "org/model/model.safetensors").write_bytes(b"ZN0000000000")
+    candidate = replace(candidate, copy=replace(candidate.copy, compressed=True))
+    error = OSError(28, "destination full")
+    with pytest.raises(OSError) as caught:
+        with LocalArchiveReader({"drive-a": root}, observer=observer,
+                                policy=qualified_policy()).open(candidate) as reader:
+            assert reader.read(1) == b"o"
+            raise error
+    assert caught.value is error
+    assert events == ["reaped"]
+
+
+@pytest.mark.parametrize("failure", ["STOPPED", "DESTINATION_CHANGED", "SOURCE_MISSING"])
+def test_local_reader_idle_child_checks_and_reaps_before_context_exit(attachment, monkeypatch, failure):
+    from modelark.slice.local_source import LocalArchiveReader
+    from test_codec_supervisor import launch_fake, assert_reaped
+    root, candidate, observer, _ = attachment
+    frame = header(original=12) + b"abcd"
+    (root / "org/model/model.safetensors").write_bytes(frame)
+    candidate = replace(candidate, copy=replace(candidate.copy, compressed=True, stored_bytes=len(frame)))
+    monkeypatch.setattr(codec_supervisor, "available_memory", lambda: {"available_bytes": 16 << 30})
+    children = launch_fake(monkeypatch, "sys.stdin.buffer.read()\nwhile True: time.sleep(.02)")
+    error = TransferRefusal(failure)
+    def check():
+        if children and children[0].stdin.closed:
+            raise error
+    reader = LocalArchiveReader({"drive-a": root}, observer=observer, policy=qualified_policy())
+    with pytest.raises(TransferRefusal) as caught:
+        with reader.open(candidate, check=check) as source:
+            source.read(1)
+    assert caught.value is error
+    assert_reaped(children)
+
+
+def test_initial_destination_boundary_error_is_not_reclassified_as_source(attachment):
+    from modelark.slice.local_source import LocalArchiveReader
+    root, candidate, observer, _ = attachment
+    error = TransferRefusal("DESTINATION_CHANGED")
+    def check():
+        raise error
+    with pytest.raises(TransferRefusal) as caught:
+        with LocalArchiveReader({"drive-a": root}, observer=observer,
+                                policy=qualified_policy()).open(candidate, check=check):
+            pytest.fail("invalid destination boundary ignored")
+    assert caught.value is error
+
+
+@pytest.mark.parametrize("kind", ["whole", "stream"])
+def test_real_guarded_container_original_hash(monkeypatch, kind):
+    # Controlled admission sample: real child AS guard and original hash tested.
+    monkeypatch.setattr(codec_supervisor, "available_memory", lambda: {"available_bytes": 16 << 30})
+    original = bytes(range(128)) * 1024
+    frame = bytes(streamznn._zipnn(dtype="bfloat16", threads=1).compress(bytearray(original)))
+    blob = frame if kind == "whole" else container(frame, frame)
+    expected = original if kind == "whole" else original * 2
+    reader = original_stream(io.BytesIO(blob), compressed=True, expected_bytes=len(expected), policy=qualified_policy())
+    digest = hashlib.sha256()
+    try:
+        while data := reader.read(1 << 20):
+            assert len(data) <= 64 << 10
+            digest.update(data)
+    finally:
+        reader.close()
+    assert digest.hexdigest() == hashlib.sha256(expected).hexdigest()
+
+
+@pytest.mark.parametrize("known_size", [False, True])
+def test_new_zstd_policy_uses_bytes_while_legacy_approval_is_unchanged(known_size):
+    zstd = pytest.importorskip("zstandard")
+    data = bytes(256 << 10)
+    blob = zstd.ZstdCompressor(write_content_size=known_size).compress(data)
+    inspect(blob, len(data))
+    new = original_stream(io.BytesIO(blob), compressed=True, expected_bytes=len(data), policy=qualified_policy())
+    assert b"".join(iter(lambda: new.read(4096), b"")) == data
+    if not known_size:
+        legacy = original_stream(io.BytesIO(blob), compressed=True, expected_bytes=len(data))
+        with pytest.raises(TransferRefusal, match="SOURCE_DECODE_INVALID"):
+            b"".join(iter(lambda: legacy.read(4096), b""))
+
+
+def test_direct_policy_binding_and_closed_world_reader(store):
+    from modelark.slice import domain as d, transaction as t
+    from test_slice_transaction import proposal
+    preview, approval, _ = proposal()
+    admission = {"version": "modelark.slice.direct.v2", "catalog": "/catalog.sqlite", "capacity": {},
+                 "decode_policy": qualified_policy().to_record()}
+    binding = t.DestinationBinding("test-device", "fs", "direct-v2:" + hashlib.sha256(d._json(admission)).hexdigest(),
+                                   1_000_000)
+    plan = t.TransferPlan(preview, binding, metadata_reserve_bytes=100_000)
+    tx = store.create(plan, approval, admission=admission)
+    assert store.load_admission(tx) == admission
+    for bad in ({k: v for k, v in admission.items() if k != "decode_policy"},
+                admission | {"decode_policy": None}, admission | {"version": "modelark.slice.direct.v1"},
+                admission | {"unknown": True}):
+        with pytest.raises(TransferRefusal, match="ADMISSION_CORRUPT"):
+            store._validate_admission(plan, bad)
+    admission["decode_policy"]["limits"]["decoded_frame_bytes"] -= 1
+    with pytest.raises(TransferRefusal, match="ADMISSION_CORRUPT"):
+        store._validate_admission(plan, admission)
+
+
+@pytest.mark.parametrize("refusal", ["SOURCE_BLOCKED", "WAITING_SOURCE", "STOPPED"])
+def test_preflight_refusal_never_creates_output_or_consumes_fat_attempt(fat, monkeypatch, refusal):
+    from modelark.slice import transaction as t
+    def preflight(proposal, check):
+        check()
+        assert not fat.store.attempt_consumed(fat.case.tx)
+        assert not (fat.parent / "delivery").exists()
+        if refusal == "STOPPED":
+            fat.store.request_stop(fat.case.tx)
+            check()
+            pytest.fail("stop was ignored")
+        raise TransferRefusal(refusal)
+    monkeypatch.setattr(fat.case.sources, "preflight", preflight, raising=False)
+    with pytest.raises(TransferRefusal, match=refusal):
+        t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources)
+    assert not fat.store.attempt_consumed(fat.case.tx)
+    assert fat.store.events(fat.case.tx) == []
+    assert not (fat.parent / "delivery").exists()
+    # New explicit Start can retry the same approval after the read-only refusal.
+    monkeypatch.setattr(fat.case.sources, "preflight", lambda proposal, check: check())
+    with t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources) as session:
+        assert session.run().state == "complete"
+
+
+def test_stop_between_preflight_and_atomic_claim_does_not_spend_fat(fat, monkeypatch):
+    from modelark.slice import transaction as t
+    original = fat.store.claim
+    def stopped_claim(*args):
+        fat.store.request_stop(fat.case.tx)
+        return original(*args)
+    monkeypatch.setattr(fat.store, "claim", stopped_claim)
+    monkeypatch.setattr(fat.case.sources, "preflight", lambda proposal, check: check(), raising=False)
+    with pytest.raises(TransferRefusal, match="STOPPED"):
+        t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources)
+    assert not fat.store.attempt_consumed(fat.case.tx)
+    assert not (fat.parent / "delivery").exists()
+    monkeypatch.setattr(fat.store, "claim", original)
+    with t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources) as session:
+        assert session.run().state == "complete"
+
+
+def test_changed_catalog_copy_is_refused_before_preflight_reads(archive, monkeypatch):
+    from modelark.slice import domain as d
+    from modelark.slice.catalog import read_catalog
+    from test_slice_domain import spec
+    path, con, _, reader, sources = archive
+    proposal = d.preview(spec(d), read_catalog(path, spec(d)))
+    con.execute("UPDATE archived SET stored_relpath='other.safetensors'")
+    reader.policy = qualified_policy()
+    monkeypatch.setattr(reader, "inspect", lambda *args, **kwargs: pytest.fail("stale candidate inspected"),
+                        raising=False)
+    with pytest.raises(TransferRefusal, match="SOURCE_BLOCKED"):
+        sources.preflight(proposal)
+
+
+def test_frame_bounds_come_from_shared_address_space_envelope():
+    policy = qualified_policy()
+    assert policy.limits.decoded_frame_bytes == policy.memory.address_space_bytes
+    assert policy.limits.stored_frame_bytes == policy.memory.address_space_bytes
+
+
+@pytest.mark.parametrize("outcome", ["complete", "stop", "unplug", "destination"])
+def test_actual_fenced_archive_reader_reaps_child_before_fence_release(archive, attachment, monkeypatch, outcome):
+    from modelark import drive_fence
+    from modelark.drive_identity import FenceIdentity
+    from modelark.slice import domain as d
+    from modelark.slice.catalog import read_catalog
+    from modelark.slice.local_source import LocalArchiveReader
+    from modelark.slice.sources import FencedSources
+    from test_slice_domain import spec
+    path, con, _, _, _ = archive
+    root, _, observer, _ = attachment
+    original = b"originaldata"
+    blob = bytes(streamznn._zipnn(dtype="bfloat16", threads=1).compress(bytearray(original)))
+    (root / "org/model/model.safetensors").write_bytes(blob)
+    digest = hashlib.sha256(original).hexdigest()
+    key = f"SHA256E-s{len(blob)}--{hashlib.sha256(blob).hexdigest()}"
+    con.execute("UPDATE files SET sha256=?", (digest,))
+    con.execute("UPDATE archived SET compressed=1,stored_bytes=?,orig_sha256=?,annex_key=?",
+                (len(blob), digest, key))
+    proposal = d.preview(spec(d), read_catalog(path, spec(d)))
+    candidate = proposal.closure[0].sources[0]
+    drive = candidate.drive
+    keys = FenceIdentity(drive.fs_uuid, drive.annex_uuid, drive.serial,
+                         drive.filesystem_capacity_bytes, drive.identity_epoch,
+                         drive.identity_fingerprint).lock_keys()
+    def fence_held():
+        with pytest.raises(drive_fence.FenceUnavailable):
+            with drive_fence.hold_drives_sorted(keys, blocking=False):
+                pytest.fail("source fence released before worker reaping")
+    children, reaps = [], []
+    real_launch = codec_supervisor._launch
+    def launch(*args):
+        child = real_launch(*args)
+        children.append(child)
+        wait = child.wait
+        def reap(*args, **kwargs):
+            fence_held()
+            result = wait(*args, **kwargs)
+            reaps.append(result)
+            return result
+        child.wait = reap
+        return child
+    monkeypatch.setattr(codec_supervisor, "_launch", launch)
+    monkeypatch.setattr(codec_supervisor, "available_memory", lambda: {"available_bytes": 16 << 30})
+    error = (OSError(28, "destination full") if outcome == "destination" else
+             TransferRefusal("STOPPED" if outcome == "stop" else "SOURCE_MISSING"))
+    def check():
+        fence_held()
+        if outcome in {"stop", "unplug"} and children and children[0].stdin.closed:
+            raise error
+    sources = FencedSources(path, LocalArchiveReader({"drive-a": root}, observer=observer,
+                                                     policy=qualified_policy()))
+    def consume():
+        with sources.open_checked(candidate, check) as (_, source):
+            data = source.read(1)
+            if outcome == "destination":
+                raise error
+            data += b"".join(iter(lambda: source.read(4096), b""))
+            assert hashlib.sha256(data).hexdigest() == proposal.closure[0].sha256
+    if outcome == "complete":
+        consume()
+    else:
+        with pytest.raises(type(error)) as caught:
+            consume()
+        assert caught.value is error
+    assert children and reaps and all(child.poll() is not None for child in children)
+    with drive_fence.hold_drives_sorted(keys, blocking=False):
+        pass  # only now can an archive writer acquire the same real fence
+
+
+def test_preflight_visits_all_alternatives_and_holds_source_fences(archive, monkeypatch):
+    from modelark import drive_fence
+    from modelark.drive_identity import FenceIdentity
+    from modelark.slice import domain as d
+    from modelark.slice.catalog import read_catalog
+    from test_slice_domain import spec
+    path, _, candidate, reader, sources = archive
+    preview = d.preview(spec(d), read_catalog(path, spec(d)))
+    # Keep the same sealed identity but exercise two admitted representations.
+    artifact = preview.closure[0]
+    alternative = replace(candidate, copy=replace(candidate.copy, compressed=not candidate.copy.compressed))
+    preview = replace(preview, closure=(replace(artifact, sources=(candidate, alternative)),))
+    visited = []
+    reader.policy = qualified_policy()
+    @contextmanager
+    def inspect_candidate(source, check):
+        check()
+        drive = source.drive
+        keys = FenceIdentity(drive.fs_uuid, drive.annex_uuid, drive.serial,
+                             drive.filesystem_capacity_bytes, drive.identity_epoch,
+                             drive.identity_fingerprint).lock_keys()
+        with pytest.raises(drive_fence.FenceUnavailable):
+            with drive_fence.hold_drives_sorted(keys, blocking=False):
+                pytest.fail("preflight released source fence")
+        visited.append(source)
+        if source is candidate:
+            raise TransferRefusal("SOURCE_DECODE_RESOURCE")
+        yield None
+    monkeypatch.setattr(reader, "inspect", inspect_candidate, raising=False)
+    # Isolate this test's alternate representation from fresh-evidence matching.
+    monkeypatch.setattr("modelark.slice.transaction._same_source", lambda *args: True)
+    sources.preflight(preview)
+    assert visited == [candidate, alternative]
+    @contextmanager
+    def absent(source, check):
+        raise TransferRefusal("WAITING_SOURCE")
+        yield
+    monkeypatch.setattr(reader, "inspect", absent)
+    with pytest.raises(TransferRefusal, match="WAITING_SOURCE"):
+        sources.preflight(preview)
+
+
+@pytest.mark.parametrize("backend,version", [("cffi", "0.25.0"), ("rust", "0.25.0"), ("cext", "0.23.0")])
+def test_unqualified_zstd_runtime_refused_early(monkeypatch, backend, version):
+    zstd = pytest.importorskip("zstandard")
+    blob = zstd.ZstdCompressor().compress(bytes(256 << 10))
+    monkeypatch.setattr(zstd, "backend", backend)
+    monkeypatch.setattr(zstd, "__version__", version)
+    with pytest.raises(artifact_io.DecodeError, match="UNSUPPORTED"):
+        inspect(blob, 256 << 10)
+
+
+@pytest.mark.parametrize("delta", [-1, 0, 1])
+@pytest.mark.parametrize("known_size", [False, True])
+def test_zstd_actual_window_below_at_above_bound(delta, known_size):
+    zstd = pytest.importorskip("zstandard")
+    original = bytes(256 << 10)
+    blob = zstd.ZstdCompressor(write_content_size=known_size).compress(original)
+    window = zstd.get_frame_parameters(blob).window_size
+    base = qualified_policy()
+    policy = replace(base, limits=replace(base.limits, zstd_window_bytes=window + delta))
+    if delta < 0:
+        with pytest.raises(artifact_io.DecodeError, match="LIMIT"):
+            inspect(blob, len(original), policy=policy)
+    else:
+        inspect(blob, len(original), policy=policy)
+        reader = original_stream(io.BytesIO(blob), compressed=True, expected_bytes=len(original), policy=policy)
+        assert b"".join(iter(lambda: reader.read(4096), b"")) == original

--- a/tests/test_slice_guarded_decoding.py
+++ b/tests/test_slice_guarded_decoding.py
@@ -268,8 +268,14 @@ def test_preflight_refusal_never_creates_output_or_consumes_fat_attempt(fat, mon
             pytest.fail("stop was ignored")
         raise TransferRefusal(refusal)
     monkeypatch.setattr(fat.case.sources, "preflight", preflight, raising=False)
-    with pytest.raises(TransferRefusal, match=refusal):
-        t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources)
+    if refusal == "STOPPED":
+        with pytest.raises(TransferRefusal, match=refusal):
+            t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources)
+    else:
+        result = t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources)
+        assert result == fat.store.status(fat.case.tx)
+        assert result.state == {"SOURCE_BLOCKED": "blocked_source", "WAITING_SOURCE": "waiting_source"}[refusal]
+        assert refusal in result.reason
     assert not fat.store.attempt_consumed(fat.case.tx)
     assert fat.store.events(fat.case.tx) == []
     assert not (fat.parent / "delivery").exists()

--- a/tests/test_slice_operator.py
+++ b/tests/test_slice_operator.py
@@ -189,6 +189,22 @@ def test_direct_preflight_returns_source_status_without_output(assembled, monkey
     assert operator.start(tx, destination.root, {})["state"] == "complete"
 
 
+def test_direct_preflight_interrupt_does_not_reclaim_or_request_stop_twice(assembled, monkeypatch):
+    operator, tx, store, _, destination, sources, _, _ = assembled
+    def interrupted(proposal, check):
+        raise KeyboardInterrupt
+    monkeypatch.setattr(sources, "preflight", interrupted, raising=False)
+    with monkeypatch.context() as patch:
+        patch.setattr(store, "claim", lambda *a: pytest.fail("interrupted preflight claimed an attempt"))
+        result = operator.start(tx, destination.root, {})
+    assert result["state"] == "stopped" and result["stop_requested"]
+    assert not result["can_write"] and store.events(tx) == [] and not list(destination.root.iterdir())
+    with store._connection(write=False) as con:
+        assert con.execute("SELECT stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?", (tx,)).fetchone() == (1, 1)
+    monkeypatch.setattr(sources, "preflight", lambda proposal, check: check())
+    assert operator.start(tx, destination.root, {})["state"] == "complete"
+
+
 def test_unsealed_attachment_label_never_observes(assembled):
     operator, tx, _, _, destination, _, _, calls = assembled
     with pytest.raises(t.TransferRefusal, match="SOURCE_ATTACHMENT_UNSEALED"):

--- a/tests/test_slice_operator.py
+++ b/tests/test_slice_operator.py
@@ -173,6 +173,22 @@ def test_start_uses_sealed_catalog_and_all_registry_exclusions(assembled):
     assert next(call for call in calls if call[0] == "sources")[1] == admission["catalog"]
 
 
+@pytest.mark.parametrize("code,expected", [("SOURCE_BLOCKED", "blocked_source"),
+                                           ("WAITING_SOURCE", "waiting_source")])
+def test_direct_preflight_returns_source_status_without_output(assembled, monkeypatch, code, expected):
+    operator, tx, store, _, destination, sources, _, _ = assembled
+    def refuse(proposal, check):
+        check()
+        raise t.TransferRefusal(code, "preflight source unavailable")
+    monkeypatch.setattr(sources, "preflight", refuse, raising=False)
+    result = operator.start(tx, destination.root, {})
+    assert result["state"] == expected and not result["ok"] and not result["can_write"]
+    assert code in result["reason"]
+    assert store.events(tx) == [] and not list(destination.root.iterdir())
+    monkeypatch.setattr(sources, "preflight", lambda proposal, check: check())
+    assert operator.start(tx, destination.root, {})["state"] == "complete"
+
+
 def test_unsealed_attachment_label_never_observes(assembled):
     operator, tx, _, _, destination, _, _, calls = assembled
     with pytest.raises(t.TransferRefusal, match="SOURCE_ATTACHMENT_UNSEALED"):

--- a/tests/test_slice_preclaim.py
+++ b/tests/test_slice_preclaim.py
@@ -1,0 +1,180 @@
+"""Unclaimed admission owns stop/resume outcomes and never spends FAT authority."""
+# ruff: noqa: F811 -- imported pytest fixtures deliberately name parameters
+import io
+import resource
+from contextlib import contextmanager
+
+import pytest
+
+from modelark import artifact_preflight
+from modelark.artifact_policy import qualified_policy
+from modelark.codec_resources import CodecResourceRefusal
+from modelark.slice import transaction as t
+from modelark.slice.authority import Lease, PreclaimInterrupted
+from test_slice_fat32_transactions import fat  # noqa: F401
+from test_slice_guarded_decoding import header
+
+
+def stop_serials(store, tx):
+    with store._connection(write=False) as con:
+        return con.execute("SELECT stop,stop_serial,acknowledged_stop_serial FROM transactions WHERE id=?",
+                           (tx,)).fetchone()
+
+
+def start(fat):
+    return t.start(fat.store, fat.case.tx, fat.case.adapter, fat.case.sources)
+
+
+def acknowledge(fat, monkeypatch):
+    monkeypatch.setattr(fat.case.sources, "preflight", lambda proposal, check: check(), raising=False)
+    fat.store.request_stop(fat.case.tx)
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        start(fat)
+    assert stop_serials(fat.store, fat.case.tx) == (1, 1, 1)
+
+
+def assert_unspent(fat):
+    assert not fat.store.attempt_consumed(fat.case.tx)
+    assert fat.store.events(fat.case.tx) == []
+    assert not (fat.parent / "delivery").exists()
+    lease = Lease(fat.case.plan.destination.device_id, "probe-after-preflight")
+    lease.close()
+
+
+@pytest.mark.parametrize("code,expected", [("SOURCE_BLOCKED", "blocked_source"),
+                                           ("WAITING_SOURCE", "waiting_source")])
+@pytest.mark.parametrize("new_stop", [False, True])
+def test_acknowledged_resume_preserves_source_outcome_unless_new_stop(fat, monkeypatch, code, expected, new_stop):
+    acknowledge(fat, monkeypatch)
+    def refusal(proposal, check):
+        check()  # Old acknowledged Stop permits this explicit resume.
+        if new_stop:
+            fat.store.request_stop(fat.case.tx)
+        raise t.TransferRefusal(code, "source unavailable")
+    monkeypatch.setattr(fat.case.sources, "preflight", refusal)
+    result = start(fat)
+    assert result.state == ("stopped" if new_stop else expected)
+    assert stop_serials(fat.store, fat.case.tx) == ((1, 2, 2) if new_stop else (0, 1, 1))
+    assert_unspent(fat)
+    if not new_stop:
+        # A second wait keeps the actionable result; it does not resurrect Stop.
+        assert start(fat).state == expected
+    monkeypatch.setattr(fat.case.sources, "preflight", lambda proposal, check: check())
+    with start(fat) as session:
+        assert session.run().state == "complete"
+
+
+@pytest.mark.parametrize("resume", [False, True])
+@pytest.mark.parametrize("new_stop", [False, True])
+@pytest.mark.parametrize("point", ["first-check", "source", "last-check"])
+def test_preclaim_interrupt_is_acknowledged_before_lease_release(fat, monkeypatch, resume, new_stop, point):
+    if resume:
+        acknowledge(fat, monkeypatch)
+    guard = fat.store.guard_preclaim
+    checks = []
+    def checked(*args):
+        checks.append(1)
+        guard(*args)
+        if (point == "first-check" and len(checks) == 1) or (point == "last-check" and len(checks) == 2):
+            if new_stop:
+                fat.store.request_stop(fat.case.tx)
+            raise KeyboardInterrupt
+    monkeypatch.setattr(fat.store, "guard_preclaim", checked)
+    def preflight(proposal, check):
+        if point == "source":
+            if new_stop:
+                fat.store.request_stop(fat.case.tx)
+            raise KeyboardInterrupt
+    monkeypatch.setattr(fat.case.sources, "preflight", preflight, raising=False)
+    close = Lease.close
+    outcomes_at_release = []
+    def closing(lease):
+        if lease.device == fat.case.plan.destination.device_id:
+            outcomes_at_release.append((fat.store.status(fat.case.tx).state,
+                                        stop_serials(fat.store, fat.case.tx)))
+        close(lease)
+    monkeypatch.setattr(Lease, "close", closing)
+    with pytest.raises(PreclaimInterrupted) as exc:
+        start(fat)
+    serial = 2 if resume else 1
+    assert exc.value.outcome == fat.store.status(fat.case.tx)
+    assert exc.value.outcome.state == "stopped" and exc.value.outcome.reason == "STOPPED"
+    assert outcomes_at_release == [("stopped", (1, serial, serial))]
+    assert_unspent(fat)
+    monkeypatch.setattr(fat.store, "guard_preclaim", guard)
+    monkeypatch.setattr(fat.case.sources, "preflight", lambda proposal, check: check())
+    with start(fat) as session:
+        assert session.run().state == "complete"
+
+
+def test_start_reserved_before_stop_ack_cannot_adopt_later_resume(fat, monkeypatch):
+    # Another request can be issued while no attempt owns the destination. Its
+    # reservation must not gain resume rights merely by waiting for exclusion.
+    fat.store.request_stop(fat.case.tx)
+    stale = fat.store.reserve(fat.case.tx, fat.case.plan.destination.device_id)
+    monkeypatch.setattr(fat.case.sources, "preflight", lambda proposal, check: check(), raising=False)
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        start(fat)
+    reserve = fat.store.reserve
+    monkeypatch.setattr(fat.store, "reserve", lambda *a: stale)
+    with pytest.raises(t.TransferRefusal, match="STOPPED"):
+        start(fat)
+    assert_unspent(fat)
+    assert stop_serials(fat.store, fat.case.tx) == (1, 1, 1)
+    monkeypatch.setattr(fat.store, "reserve", reserve)
+    with start(fat) as session:
+        assert session.run().state == "complete"
+
+
+@pytest.mark.parametrize("phase", ["owner-lost", "terminal", "write-fails"])
+def test_interrupt_cannot_claim_acknowledgment_without_persisting(fat, monkeypatch, phase):
+    def preflight(proposal, check):
+        if phase in {"owner-lost", "terminal"}:
+            with fat.store._connection() as con:
+                if phase == "owner-lost":
+                    con.execute("DELETE FROM owners")
+                else:
+                    con.execute("UPDATE transactions SET state='invalidated' WHERE id=?", (fat.case.tx,))
+        else:
+            original = fat.store._connection
+            @contextmanager
+            def failed(*, write=True):
+                if write:
+                    raise t.TransferRefusal("STATE_BUSY")
+                with original(write=False) as con:
+                    yield con
+            monkeypatch.setattr(fat.store, "_connection", failed)
+        raise KeyboardInterrupt
+    monkeypatch.setattr(fat.case.sources, "preflight", preflight, raising=False)
+    code = {"owner-lost": "EXECUTION_FENCE_LOST", "terminal": "NOT_RESUMABLE", "write-fails": "STATE_BUSY"}[phase]
+    with pytest.raises(t.TransferRefusal, match=code):
+        start(fat)
+    assert_unspent(fat)
+
+
+def test_inherited_limit_refusal_does_not_spend_fat_and_can_retry(fat, monkeypatch):
+    from modelark.slice.sources import FencedSources
+    policy = qualified_policy()
+    limits = [1 << 30, 1 << 30]
+    monkeypatch.setattr(resource, "getrlimit", lambda which: tuple(limits))
+    monkeypatch.setattr(resource, "setrlimit", lambda *a: pytest.fail("preflight changed parent limits"))
+    monkeypatch.setattr(artifact_preflight, "available_memory", lambda: {"available_bytes": 16 << 30})
+    # Exercise the real alternative/error aggregator with synthetic source IO.
+    sources = FencedSources("unused", type("Reader", (), {"policy": policy})())
+    @contextmanager
+    def inspect(*args, **kwargs):
+        try:
+            artifact_preflight.inspect_original(io.BytesIO(header() + b"abcd"), compressed=True,
+                                                expected_bytes=128, stored_bytes=36, policy=policy,
+                                                check=kwargs["check"])
+        except CodecResourceRefusal as exc:
+            raise t.TransferRefusal("SOURCE_DECODE_RESOURCE", str(exc)) from exc
+        yield
+    monkeypatch.setattr(sources, "_open", inspect)
+    monkeypatch.setattr(fat.case.sources, "preflight", sources.preflight, raising=False)
+    result = start(fat)
+    assert result.state == "blocked_source" and "inherited AS ceiling" in result.reason
+    assert_unspent(fat)
+    limits[:] = [resource.RLIM_INFINITY, resource.RLIM_INFINITY]
+    with start(fat) as session:
+        assert session.run().state == "complete"


### PR DESCRIPTION
## Summary

Stage C2 of the approved Slice representation/decode architecture, following merged PR #76.

- Route fresh Slice approvals through the qualified guarded ZipNN worker with bounded parent output. StreamZNN retains one shared framing loop and gains a caller-owned frame-stream context hook; standalone defaults remain non-spawning.
- Seal a closed-world original-decode policy into direct, native-folder and FAT32 v2 admission bindings. Frame bounds derive from the shared AS envelope; public profile remains 8 GiB AS plus 2 GiB sampled headroom. Preserve exact v1 canonical bytes/limits; actual installed old readers reject all three v2 forms.
- Inspect fresh attached candidates and every framed header under source fences before first output mutation or FAT attempt consumption. Preserve alternatives, offline waits and native partial resume. Handle Stop before consuming FAT's one-shot attempt, including arrival between preflight and atomic claim.
- Keep helper reaping inside the actual archive reader/fence lifetime on success, Stop, simulated source loss and destination failure. Preserve original length/hash and source-vs-destination error identity.
- Repair zstd native window units only for new policy, qualified against zstandard 0.25.0 cext; other backends/versions fail closed. Legacy approvals retain the old behavior.

## Validation

- Local Grok review rounds 1 and 2: ACCEPT. Round 2 covers the batched self-review corrections for shared frame bounds, fresh evidence before inspection, and the FAT stop/claim race.
- Final full Slice regression: **1,380 passed**, 16 optional-codec skips, followed by the four newly added real fence/worker tests passing separately. Optional codec paths are exercised in the focused suite below.
- Final focused optional-zstd/codec: **193 passed**. Final installed-wheel C2: **49 passed**. Standalone writer/canary and process-guard regressions: **46 passed**.
- Four actual archive-reader/fence/child integration cases prove reap-before-fence-release on success, Stop, simulated source loss, and destination failure.
- Unchanged-code installed-runtime qualification: **25 passed**, including whole and StreamZNN at 67,108,864 / 99,630,640 / 409,993,344 original bytes, output pieces <=65,536 bytes, actual per-child runtime/guard evidence, and matching implementation fingerprints. Report: `/tmp/modelark-codec-qualification-tn1wzy18/result.json`.
- Actual installed C1 readers preserve old native/FAT canonical bytes and direct v1 admission, and reject all three v2 envelopes.
- Full-project Ruff and diff whitespace checks pass.
- CI follow-up `49e2a3c`: the public serial-repair regression is fixed through shared DeliveryAuthority status handling. **146 focused regressions passed**, 11 optional-codec skips. **Local Grok round 3: ACCEPT**. All exact-head CI checks pass: **3,487 passed / 19 skipped on each of Python 3.10 and 3.12**, lint, installed-wheel checks and e2e.
- Full local suite: 3,444 passed, 43 failed, 19 skipped. The launch-path failures conflict with the existing live ModelArk singleton (including helper tests that suppress the SystemExit message). The live instance was not stopped or modified; isolated CI passes those tests.

## Approved preclaim follow-up — awaiting final remote review

Codex round 2 on `49e2a3c` returned three findings, all reproduced in disposable diagnostic probes (three passed assertions describing the defects, not fixes):

- P1: preflight checks memory headroom but misses an inherited AS ceiling that the worker deterministically rejects, potentially consuming FAT's one-shot attempt before refusal.
- P2: Ctrl+C during unclaimed FAT preflight returns `starting` plus an unacknowledged Stop instead of acknowledging `stopped`.
- P2: an old acknowledged Stop masks a new source wait/block outcome on explicit resume.

The operator approved the bounded correction. Reservation.resumes now owns the exact acknowledged-stop predicate shared by guard, refusal and claim. Preclaim refusal returns its atomic committed result, consuming only the reservation-authorized old Stop and preserving any new serial. Ctrl+C is acknowledged under exclusion and carried to every public adapter as PreclaimInterrupted, without a second Stop/claim. CodecMemoryPolicy.admit and install_in_worker share the same read-only platform/inherited-AS check. All worker installation/rechecks remain; no parent setrlimit or changed policy bytes/schema.

Validation for the follow-up: **283 passed / 11 optional-codec skips** in integrated resource, preclaim, public direct/native/FAT, authority and serial-repair tests; **197 existing transaction/recovery/FAT tests passed**; **70 installed-wheel preclaim/guarded-decode tests passed with zstd enabled**, imports pinned to `/tmp/modelark-preclaim-wheel.DWlgqy/installed`. Fresh installed-runtime qualification **25 passed**, with all 11 fingerprints matching, both formats at 64/100/410 MB, original hashes and <=64 KiB pieces; report `/tmp/modelark-codec-qualification-af4qfk05/result.json`. Full-project Ruff and diff checks pass.

Original Grok budget remains **3/3 used**. The operator explicitly granted additional local review budget for this bounded follow-up: **renewed round 1/3 ACCEPT**, no blockers (cumulative 4/6). Codex remains **2/3 used** until the final request on the new head; no reset and no Greptile. DEC-144 records the approved architecture, not the reviewer exception. The operator retains merge authority.

## Boundaries and review

No live service deployment/restart, catalog/archive migration or bytes change, physical USB operation,
stored-export/P2P feature, or host/cgroup configuration change. Shared production writer/canary/restore
adoption remains Stage D; full public-CLI qualification remains Stage E. Synthetic decoding is not
physical acceptance or a host-wide memory reservation.

Operator requested local Grok followed by **Codex only**, up to three rounds each for this C2 scope.
Greptile is not requested. The operator retains merge authority. The C2 review exception lives in
the mutable work tracker, not a decision-log entry; preserved DEC-143/AGENTS quota guidance originated
in the preceding stage.
