### PR TITLE
Guard production compression and share the in-child canary (D1)

### DIFF
--- a/docs/codec-resource-qualification.md
+++ b/docs/codec-resource-qualification.md
@@ -2,8 +2,10 @@
 
 DEC-138 requires one RAM-admission methodology for compression, canary, restore
 and Slice. Stage A implements an operation-neutral `CodecMemoryPolicy` and a
-disposable qualification runner. **No live caller adopts it yet.** This is not a
-claim that Slice's 64 MiB incompatibility is fixed.
+disposable qualification runner. C2 subsequently adopted it in Slice. D1 adds
+production fetch compression and its in-child canary; public legacy canary/deep
+verification and restore still await D2. This is code adoption, not deployment
+or a claim that the complete parity/physical qualification arc is finished.
 
 ## What the policy means
 
@@ -31,6 +33,13 @@ usage differ substantially. A successful run cannot certify all future workloads
 
 Qualification uses an **8 GiB AS ceiling plus 2 GiB observed headroom reserve**.
 These are experimental parameters for this runtime, not newly deployed defaults.
+The D1 writer uses C2's same qualified profile for execution, without changing
+wishlist codec preference or capacity bounds. Resource/unsupported-frame refusal
+preserves the downloaded original and takes the existing raw storage path;
+digest mismatch remains a failed canary. The non-spawning adapter verifies the
+already-installed child ceiling and reuses the neutral original-byte reader.
+Canary headroom is sampled again inside the worker; changing pressure can refuse
+the canary even after successful compression. No sample reserves resources.
 Whole and StreamZNN operations are performed in separate fresh processes with the
 same policy. Native diagnostics go to separate files; results use exclusive JSON
 files rather than stdout. Temporary synthetic bytes are removed on exit, while
@@ -43,6 +52,7 @@ From the checkout, with its dev Python:
 ```sh
 python -m pytest -q tests/test_codec_resources.py tests/test_codec_qualification.py
 python -m scripts.qualify_codec_resources --large --output-parent /tmp
+python -m scripts.qualify_codec_resources --large --production-writer --output-parent /tmp
 ```
 
 Without `--large`, the runner uses 2 MiB inputs. Large mode uses exactly
@@ -57,6 +67,10 @@ Reports include exact policy, source-code digests, Python/ZipNN/Torch versions,
 format magic, original/stored identities, and peak RSS/virtual memory by phase.
 Code changes during a run invalidate it. No source/encoded/runtime fixture is
 read from the live archive, and no application service is started or stopped.
+The production-writer option exercises the actual fetch child plus canary and
+then Slice on its output, retaining actual worker/admission evidence. The
+`production_adoption: false` report field refers to incomplete overall D adoption;
+`production_writer_exercised` distinguishes this new D1 path.
 
 ## Limits and next gates
 

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3083,3 +3083,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Shared Slice private-state/authority and public interrupt plumbing, plus operation-neutral codec policy admission. No new schema, changed sealed policy values, archive format, live-instance change, parent resource-limit mutation or production writer rollout. Regression and qualification work stays in the C2 tracker.
 - `docs_updated`: docs/decision_log.md, docs/plans/slice-c2-progress.md, docs/codec-resource-qualification.md
 - `related`: DEC-138, DEC-139, DEC-142, HYP-002
+
+### DEC-145: Apply shared codec guards to the production writer and its in-process canary
+- `id`: DEC-145
+- `date`: 2026-09-11
+- `status`: accepted
+- `triggered_by`: Operator continuation of DEC-138/DEC-139 Stage D after merged C2; caller inventory found canary also serves external deep verification.
+- `decision`: First adopt the qualified shared policy at production fetch writer admission and isolated guarded startup, then verify its output through the neutral original-byte decoder in that same child. Preserve codec-selection preferences and disk caps. Resource or unsupported-decoding refusal retains the downloaded original for raw fallback; hash mismatch remains a failed canary. Keep legacy external canary/restore behavior until the explicit D2 compatibility gate.
+- `rationale`: A compression child without an enforced envelope is only crash isolation. A nested decoder child would break the existing writer/fence lifetime model. Applying Slice's strict policy silently to external legacy callers would change their supported formats and evidence semantics.
+- `impact`: Fetch child startup, shared in-process execution adapter, writer canary and monitored-child cleanup; actual writer-to-Slice qualification. No changed archive format, catalog/approval schema, live deployment, retrieval, source fences or standalone StreamZNN policy. D2 remains mandatory for full production parity.
+- `docs_updated`: docs/decision_log.md, docs/codec-resource-qualification.md, docs/plans/codec-stage-d-progress.md
+- `related`: DEC-138, DEC-139, DEC-142, DEC-144

--- a/docs/plans/codec-stage-d-progress.md
+++ b/docs/plans/codec-stage-d-progress.md
@@ -1,0 +1,87 @@
+# Stage D — production codec adoption
+
+Started 2026-09-11 after reboot, based on merged PR77 `83438eb`.
+Operator authorized continuing the approved DEC-138/139 arc.
+
+## Delivery increments
+
+1. D1: guarded production writer startup and shared-decoder canary inside that
+   same child, with explicit safe raw fallback on resource/format refusal.
+   Preserve codec selection, disk bounds, original retention, write fences,
+   monitored cancellation and result-file transport. No nested canary worker.
+2. D2: external canary/deep verification and restore adoption. Inventory unknown
+   original sizes, legacy formats/modes, zstd concatenation/window support and
+   return/error conventions before choosing a compatible caller adapter. Keep
+   restore retrieval/publication and verification evidence outside the decoder.
+3. Qualification: same-profile real writer/reader parity, installed runtime and
+   lifecycle/failure matrix. E public CLI and physical USB remain separate.
+
+D1 alone is NOT complete production parity or authority to deploy.
+
+## Caller inventory at the merged base
+
+| Caller | Existing contract | D1 disposition |
+|---|---|---|
+| fetch._compress_isolated | child result file; write-fence inheritance; crash/stall/output-cap raw fallback | add common admission and isolated guarded startup |
+| compress_worker.run | compress then canary; keep raw until success; no nested child | shared original decoder, exact original size/hash |
+| compress.canary_ok | called both in worker AND directly by verifier; no expected length parameter | leave public legacy path unchanged in D1 |
+| verifier deep checks | exceptions become failed evidence, not a resource-wait state | compatibility/evidence review in D2 |
+| compress.decompress_file | magic dispatch; native whole/standalone StreamZNN/zstd acceptance | preserve legacy behavior until D2 |
+| restore._materialize | own temporary, original hash, then atomic publication; retrieval separate | preserve in D1 |
+| standalone StreamZNN | MIT; broad native-mode compatibility; path wrappers share loop | no changes in D1 |
+| Slice original_stream | exact sealed size/policy, strict qualified formats, guarded child | keep default execution and seals unchanged |
+
+The 4x wishlist gate selects a codec; it is not an enforced process-memory bound.
+D1 retains that preference and adds the shared qualified envelope to actual
+execution. A refused compression keeps the verified downloaded original.
+
+## Review budget
+
+Stage D local Grok CLI: 2/3 used, round2 ACCEPT. Remote Codex: 0/3. Counts carry across D increments
+and pushes unless operator explicitly grants a separate cycle.
+No Greptile under the current operator exception; no ledger entry for that
+exception. Every new pushed PR head needs Codex review. Operator merges.
+After the cap: stop, summarize findings and shared architectural cause.
+
+## Restart
+
+Persistent worktree:
+`/home/phaze/PycharmProjects/modelark/claudedocs/operator-scratch/worktrees/codec-stage-d`
+Branch: `codex/codec-production-adoption`.
+Primary checkout is older and has unrelated files: preserve it.
+No live service/catalog/archive/USB operations. PR77 watcher stays paused.
+
+## Validation
+
+Initial existing codec tests: 48 passed, 2 optional-zstd skips.
+New production/startup/isolation tests: 38 passed.
+Broad codec/archive-boundary suite: 242 passed, 2 optional skips, one subprocess
+test double lacked poll(); updated the double, then all 48 affected tests passed.
+Both new ingestion resource/decode-refusal raw-publication tests passed.
+Installed-wheel tests: 81 passed with optional zstd0.25.0 and package origin
+pinned to /tmp/modelark-d1-wheel.m9eM9y/venv/lib/python3.10/site-packages.
+Full CI-equivalent suite: 3545 passed,19 skipped in766.52s.
+Grok round1 session `01a08ee8-ea80-74d2-9762-d05f5b42f7e0` was interrupted:
+its review checkpoint fabricated src/modelark/hf_fetch.py, IsolatedCodecError,
+environment flags and different limits. Exact checkout checks disprove those
+claims. No actual-code finding or acceptance is inferred from that invalid pass.
+Round2 is a fresh bounded snapshot-only CLI review, excluding contaminated
+memory and requiring exact quoted source evidence. Round1 still counts; no reset.
+Round2 session `01a08ef9-7dfa-73c1-84d1-ce2ddf5e52bc` ACCEPTED the supplied
+implementation and tests, with no blocking findings. Optional uncertainties were
+checked against the complete code: all compressor branches return dst and clean
+temporaries on BaseException, hash mismatch intentionally stays a failed canary,
+and bootstrap imports before initialize_worker are non-native. Guard validation
+failure remains fail-closed, not permission to publish or drop the original.
+Commit/PR publication follows local acceptance; remote review still pending.
+Old qualification files in /tmp were lost on reboot.
+
+Fresh D1 installed-dependency qualification:
+/tmp/modelark-codec-qualification-6tj5zb1z/result.json — 25 checks passed;
+all14 fingerprints match. Six actual production writer/in-child-canary to Slice
+round trips at64/100/410MB, whole/StreamZNN, exact original hashes and bounded
+Slice output under the same8GiB AS plus2GiB headroom. Legacy standalone
+compression/canary/restore and deliberate allocation refusal also passed.
+This is not D2 adoption or physical acceptance.
+Persistent copy of the exact report (cmp verified):
+`claudedocs/codec-stage-d-evidence/pre-review-result.json` (Git-ignored).

--- a/modelark/artifact_io.py
+++ b/modelark/artifact_io.py
@@ -87,9 +87,10 @@ def _zstd_header(stream, prefix, expected, limits, *, qualified=False):
     return zstd, header
 
 
-def _chunks(stream, compressed, expected, limits, policy, check, on_frame_complete):
+def _chunks(stream, compressed, expected, limits, policy, check, on_frame_complete, frame_stream):
     try:
-        yield from _decoded_chunks(stream, compressed, expected, limits, policy, check, on_frame_complete)
+        yield from _decoded_chunks(stream, compressed, expected, limits, policy, check,
+                                   on_frame_complete, frame_stream)
     except streamznn.DecodeLimitExceeded as exc:
         raise DecodeError("LIMIT", str(exc)) from exc
     except streamznn.UnsupportedFrame as exc:
@@ -102,7 +103,8 @@ def _chunks(stream, compressed, expected, limits, policy, check, on_frame_comple
         raise DecodeError("RESOURCE", str(exc)) from exc
 
 
-def _decoded_chunks(stream, compressed, expected, limits, policy, check, on_frame_complete):
+def _decoded_chunks(stream, compressed, expected, limits, policy, check, on_frame_complete,
+                    frame_stream):
     if not compressed:
         while chunk := stream.read(min(limits.read_bytes, 1 << 20)):
             yield chunk
@@ -117,6 +119,8 @@ def _decoded_chunks(stream, compressed, expected, limits, policy, check, on_fram
             read_size=min(limits.read_bytes, 1 << 20))
 
     def guarded(source, stored_length, remaining, prefix=b""):
+        if frame_stream is not None:
+            return frame_stream(source, stored_length, remaining, prefix=prefix)
         from .codec_supervisor import guarded_zipnn_frame
         return guarded_zipnn_frame(
             source, policy=policy.memory, max_stored_bytes=limits.stored_frame_bytes,
@@ -188,9 +192,11 @@ class _CheckedInput:
 
 
 class _OriginalStream:
-    def __init__(self, stream, compressed, expected, limits, check, policy, on_frame_complete):
+    def __init__(self, stream, compressed, expected, limits, check, policy, on_frame_complete,
+                 frame_stream):
         self._chunks = iter(_chunks(_CheckedInput(stream, limits.read_bytes, check),
-                                    compressed, expected, limits, policy, check, on_frame_complete))
+                                    compressed, expected, limits, policy, check, on_frame_complete,
+                                    frame_stream))
         self._pending = b""
         self._offset = 0
         self._total = 0
@@ -228,7 +234,8 @@ class _OriginalStream:
 
 
 def original_stream(stream, *, compressed, expected_bytes, limits: DecodeLimits,
-                    check=lambda: None, policy=None, on_frame_complete=lambda evidence: None):
+                    check=lambda: None, policy=None, on_frame_complete=lambda evidence: None,
+                    frame_stream=None):
     """Decode caller-owned bytes; no paths, source authority or output publication.
 
     Original length is enforced here; the caller must verify the original digest.
@@ -236,13 +243,19 @@ def original_stream(stream, *, compressed, expected_bytes, limits: DecodeLimits,
     selects the guarded ZipNN helper and qualified byte-valued zstd window.
     Close this reader on early termination before releasing source ownership.
     on_frame_complete is per-child evidence, not artifact/destination success.
+    An explicit frame_stream may supply a non-spawning frame context for an
+    already-guarded caller. It owns enforcement of the same policy; it is never
+    selected implicitly and is not exposed by Slice's approval/reader adapters.
     """
     if type(expected_bytes) is not int or expected_bytes < 0:
         raise ValueError("nonnegative original size required")
     if not isinstance(limits, DecodeLimits):
         raise ValueError("explicit DecodeLimits required")
+    if frame_stream is not None and (policy is None or not callable(frame_stream)):
+        raise ValueError("a frame execution adapter requires an explicit policy")
     if policy is not None:
         from .artifact_policy import DecodePolicy
         if not isinstance(policy, DecodePolicy) or policy.limits != limits:
             raise ValueError("decode policy differs from supplied limits")
-    return _OriginalStream(stream, compressed, expected_bytes, limits, check, policy, on_frame_complete)
+    return _OriginalStream(stream, compressed, expected_bytes, limits, check, policy,
+                           on_frame_complete, frame_stream)

--- a/modelark/codec_inprocess.py
+++ b/modelark/codec_inprocess.py
@@ -1,0 +1,52 @@
+"""Non-spawning original-byte verification for an already guarded worker.
+
+Only the execution adapter differs from Slice: format interpretation, bounds,
+exact total length and original digest verification use the same neutral reader.
+No archive access, retrieval, publication, native format fork or nested worker.
+"""
+from contextlib import closing, contextmanager
+import hashlib
+import resource
+import sys
+
+from . import artifact_io, streamznn
+from .codec_resources import CodecResourceRefusal, available_memory
+
+
+def require_guard(policy):
+    """Observe the irreversible envelope; never install limits in this caller."""
+    if (sys.platform != "linux" or not sys.flags.isolated or not sys.flags.no_site
+            or resource.getrlimit(resource.RLIMIT_AS) != (
+                policy.memory.address_space_bytes, policy.memory.address_space_bytes)):
+        raise CodecResourceRefusal("non-spawning decode requires the installed worker guard")
+
+
+def frame_adapter(policy):
+    require_guard(policy)
+
+    @contextmanager
+    def frame(stream, stored_length, remaining, prefix=b""):
+        require_guard(policy)
+        data = streamznn.read_zipnn_frame(
+            stream, max_stored_bytes=policy.limits.stored_frame_bytes,
+            max_decoded_bytes=policy.limits.decoded_frame_bytes,
+            remaining_bytes=remaining, stored_length=stored_length, prefix=prefix,
+            read_size=policy.limits.read_bytes)
+        yield (data[offset:offset + (64 << 10)] for offset in range(0, len(data), 64 << 10))
+
+    return frame
+
+
+def verify_original(path, expected_sha256, expected_bytes, policy):
+    """The writer's canary: exact length/hash, entirely inside its own guard."""
+    require_guard(policy)
+    policy.memory.admit(available_memory()["available_bytes"])
+    if not expected_sha256:
+        return False
+    digest = hashlib.sha256()
+    with path.open("rb") as source, closing(artifact_io.original_stream(
+            source, compressed=True, expected_bytes=expected_bytes,
+            limits=policy.limits, policy=policy, frame_stream=frame_adapter(policy))) as reader:
+        while chunk := reader.read(policy.limits.read_bytes):
+            digest.update(chunk)
+    return digest.hexdigest() == expected_sha256

--- a/modelark/compress_worker.py
+++ b/modelark/compress_worker.py
@@ -7,14 +7,19 @@ fetch pipeline runs compression HERE, in a short-lived child: if this process ab
 dies and the parent (`fetch._compress_isolated`) falls back to storing that shard raw and moves on.
 
 Protocol — one-shot, no persistent state:
-    argv[1] = a JSON request {src, dst, dtype, codec, threads, expected_sha256, result}
+    argv[1] = a JSON request {src, dst, dtype, codec, threads, expected_sha256,
+                             expected_bytes, decode_policy, parent_pid, result}
 On a clean run this writes a JSON result to the `result` path and exits 0:
     {"ok": true,  "znn_path": ..., "znn_sha256": ..., "stored_bytes": ...}   canary passed
     {"ok": false}                                                            canary FAILED (.znn removed)
     {"ok": false, "over_cap": true, "detail": ...}                          safe raw fallback
+    {"ok": false, "resource_refused"|"decode_refused": true, "detail": ...}   safe raw fallback
 A native crash exits via a signal WITHOUT writing the result; the parent reads the negative return
 code and treats it as a crash. The result travels by file, never by stdout — the compressor
 libraries may write to stdout and would corrupt a stdout-based channel.
+Fresh isolated no-site startup installs the shared memory/parent-death guards
+before dependency hooks and native imports. Canary reuses the shared decoder
+inside this same guarded process; standalone/restore callers are unchanged.
 """
 from __future__ import annotations
 
@@ -22,12 +27,15 @@ import json
 import sys
 from pathlib import Path
 
-from modelark import compress
-
-
-def run(request: dict) -> dict:
+def run(request: dict, policy) -> dict:
     """Compress src -> dst and canary-verify, entirely in this process. A native abort in either the
     compress or the canary decompress kills the process before this returns."""
+    from modelark import compress
+    from modelark.artifact_io import DecodeError
+    from modelark.codec_inprocess import require_guard, verify_original
+    from modelark.codec_resources import CodecResourceRefusal
+
+    require_guard(policy)
     src = Path(request["src"])
     dst = Path(request["dst"])
     dtype = request["dtype"]
@@ -37,19 +45,40 @@ def run(request: dict) -> dict:
 
     try:
         znn = compress.compress_file(src, dst, dtype=dtype, codec=codec, threads=threads)
+        if verify_original(znn, expected_sha256, request["expected_bytes"], policy):
+            return {"ok": True, "znn_path": str(znn),
+                    "znn_sha256": compress.sha256_file(znn), "stored_bytes": znn.stat().st_size}
     except compress.OutputCapExceeded as exc:
         dst.unlink(missing_ok=True)
         return {"ok": False, "over_cap": True, "detail": str(exc)}
-    if compress.canary_ok(znn, expected_sha256, dtype):
-        return {"ok": True, "znn_path": str(znn),
-                "znn_sha256": compress.sha256_file(znn), "stored_bytes": znn.stat().st_size}
-    znn.unlink(missing_ok=True)                 # round-trip did not certify → never keep the compressed file
+    except (CodecResourceRefusal, MemoryError) as exc:
+        dst.unlink(missing_ok=True)
+        return {"ok": False, "resource_refused": True, "detail": str(exc) or "worker allocation refused"}
+    except DecodeError as exc:
+        dst.unlink(missing_ok=True)
+        if exc.kind in {"RESOURCE", "LIMIT", "UNSUPPORTED"}:
+            return {"ok": False, "decode_refused": True, "detail": str(exc)}
+        return {"ok": False, "detail": str(exc)}
+    dst.unlink(missing_ok=True)                 # round-trip did not certify → never keep the compressed file
     return {"ok": False}
 
 
 def main(argv: list[str]) -> int:
+    from modelark.artifact_policy import DecodePolicy
+    from modelark.codec_process import initialize_worker, runtime_record, validate_runtime
+    from modelark.codec_resources import CodecResourceRefusal
+
     request = json.loads(argv[1])
-    result = run(request)                        # a native abort in here kills the child; no result is written
+    policy = DecodePolicy.from_record(request["decode_policy"])
+    try:
+        initialize_worker(policy.memory, request["parent_pid"])
+        result = run(request, policy)           # native abort: no result, parent's raw fallback
+        if result["ok"]:
+            result["worker"] = validate_runtime(runtime_record(), policy.memory)
+    except (CodecResourceRefusal, MemoryError) as exc:
+        Path(request["dst"]).unlink(missing_ok=True)
+        result = {"ok": False, "resource_refused": True,
+                  "detail": str(exc) or "worker allocation refused"}
     Path(request["result"]).write_text(json.dumps(result))
     return 0
 

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -41,6 +41,9 @@ from huggingface_hub.errors import GatedRepoError, HfHubHTTPError, RepositoryNot
 from modelark.core import db
 from modelark import archive_hash, archive_manifest, capacity_evidence, compress, drive_mutation
 from modelark import register, wishlist
+from modelark.artifact_policy import qualified_policy
+from modelark.codec_process import isolated_command, validate_runtime
+from modelark.codec_resources import CodecResourceRefusal, available_memory
 
 # Download-stall resilience (INC-004 + the DEC-023 stage-2 watchdog). The built-in read timeout did
 # NOT catch a multi-hour hang (hf blocked/retried internally and never returned control; on 2026-07-09
@@ -468,22 +471,29 @@ def _run_monitored(cmd: list[str], progress: Callable[[], int], stall_secs: floa
         with open(err_path, "w") as errf:
             proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=errf,
                                     pass_fds=tuple(inherit_fds))
-            best, last_grow = -1, time.monotonic()
-            while True:
-                try:
-                    rc = proc.wait(timeout=_MONITOR_POLL)   # NOT a deadline — just the sample interval
-                    break                                    # the child exited on its own
-                except subprocess.TimeoutExpired:
-                    pass
-                if should_stop():
-                    proc.kill(); proc.wait(); outcome = "stopped"; break
-                cur = progress()
-                now = time.monotonic()
-                if cur > best:
-                    best, last_grow = cur, now
-                elif now - last_grow >= stall_secs:
-                    proc.kill(); proc.wait(); outcome = "stalled"; break
-        stderr = Path(err_path).read_text(errors="replace").strip()[-2000:]   # after errf closed → flushed
+            try:
+                best, last_grow = -1, time.monotonic()
+                while True:
+                    try:
+                        rc = proc.wait(timeout=_MONITOR_POLL)   # NOT a deadline — just the sample interval
+                        break                                    # the child exited on its own
+                    except subprocess.TimeoutExpired:
+                        pass
+                    if should_stop():
+                        proc.kill(); proc.wait(); outcome = "stopped"; break
+                    cur = progress()
+                    now = time.monotonic()
+                    if cur > best:
+                        best, last_grow = cur, now
+                    elif now - last_grow >= stall_secs:
+                        proc.kill(); proc.wait(); outcome = "stalled"; break
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                proc.wait()  # callbacks/interrupts must not release a still-writing child
+        with open(err_path, "rb") as tail:
+            tail.seek(max(0, os.fstat(tail.fileno()).st_size - 8192))
+            stderr = tail.read(8192).decode(errors="replace").strip()[-2000:]
     finally:
         Path(err_path).unlink(missing_ok=True)
     return {"outcome": outcome, "rc": rc, "stderr": stderr}
@@ -500,13 +510,28 @@ def _compress_isolated(local: Path, dtype: str, codec: str, threads: int,
         "crash"   — child died from a signal (e.g. SIGABRT double-free) → caller stores the shard RAW
         "stalled" — child made no progress for the (size-scaled) stall window, killed → caller stores RAW
         "over-cap"— compressed output would exceed the guaranteed disk ceiling → caller stores RAW
+        "resource"/"decode-refused" — shared guard/reader admission refused → caller stores RAW
         "error"   — child exited non-zero without a signal (unexpected; surface it)
     Raises _StopRequested if a stop is requested mid-compress (the child is killed first)."""
+    if should_stop():
+        raise _StopRequested()
+    policy = qualified_policy()
+    try:
+        admission = available_memory()
+        policy.memory.admit(admission["available_bytes"])
+    except CodecResourceRefusal as exc:
+        if should_stop():
+            raise _StopRequested()
+        return {"status": "resource", "detail": str(exc), "stderr": ""}
+    if should_stop():
+        raise _StopRequested()
     dst = local.with_name(local.name + compress.ZNN_SUFFIX)
     res_fd, res_path = tempfile.mkstemp(dir=str(dst.parent), prefix=dst.name + ".", suffix=".result")
     os.close(res_fd)                                     # the child writes it; we just reserve the name
     request = json.dumps({"src": str(local), "dst": str(dst), "dtype": dtype, "codec": codec,
-                          "threads": threads, "expected_sha256": expected_sha256, "result": res_path})
+                          "threads": threads, "expected_sha256": expected_sha256, "result": res_path,
+                          "expected_bytes": local.stat().st_size,
+                          "decode_policy": policy.to_record(), "parent_pid": os.getpid()})
 
     def progress() -> int:                               # the growing .znn temp = compress liveness
         try:
@@ -517,13 +542,19 @@ def _compress_isolated(local: Path, dtype: str, codec: str, threads: int,
     # Window must cover the child's canary (which READS the .znn → temp flat, watchdog blind), so scale
     # it to the shard size; floor at _COMPRESS_STALL_SECS for small shards. See INC-011.
     stall = max(_COMPRESS_STALL_SECS, int(local.stat().st_size / 1e9 * _COMPRESS_STALL_PER_GB))
-    mon = _run_monitored([sys.executable, "-m", "modelark.compress_worker", request],
-                         progress, stall, should_stop, inherit_fds=inherit_fds)
     try:
+        mon = _run_monitored(isolated_command("modelark.compress_worker", request),
+                             progress, stall, should_stop, inherit_fds=inherit_fds)
         if mon["outcome"] == "exited" and mon["rc"] == 0:
             result = json.loads(Path(res_path).read_text())
+            if result["ok"]:
+                validate_runtime(result["worker"], policy.memory)
+                result["admission"] = admission
             result["status"] = ("ok" if result["ok"] else
-                                ("over-cap" if result.get("over_cap") else "canary"))
+                                ("over-cap" if result.get("over_cap") else
+                                 "resource" if result.get("resource_refused") else
+                                 "decode-refused" if result.get("decode_refused") else "canary"))
+            result.setdefault("stderr", "")
             return result
         for tmp in dst.parent.glob(dst.name + ".*.tmp"):  # sweep the half-written temp the dead/killed child left
             tmp.unlink(missing_ok=True)
@@ -950,7 +981,7 @@ def fetch_model(
                 dtype = compress.zipnn_dtype(f["quant"])
                 res = _compress_isolated(local, dtype, codec, compress_cfg["threads"], got,
                                          ctx.should_stop, inherit_fds=inherit_fds)
-                if res["status"] in ("crash", "stalled", "over-cap"):
+                if res["status"] in ("crash", "stalled", "over-cap", "resource", "decode-refused"):
                     # INC-005: the compressor died natively (ZipNN double-free) or hung on this shard. The
                     # child absorbed it — store the shard RAW so the fill routes around it instead of
                     # core-dumping the portal or looping. (A stop mid-compress raises _StopRequested.)
@@ -959,8 +990,10 @@ def fetch_model(
                         why = f"CRASHED (signal {res['signal']})"
                     elif res["status"] == "stalled":
                         why = f"HUNG ({_COMPRESS_STALL_SECS}s no progress)"
-                    else:
+                    elif res["status"] == "over-cap":
                         why = f"OUTPUT CAP ({res.get('detail', 'compressed data expanded')})"
+                    else:
+                        why = f"RESOURCE/DECODE REFUSAL ({res.get('detail', 'not admitted')})"
                     print(f"    [raw-fallback] {f['rfilename']} ({gb:.2f} GB) — compressor {why}, "
                           f"stored uncompressed :: {res['stderr']}")
                     ctx.on_progress({**base, "file_phase": "compress-crashed", "codec": "raw-fallback"})

--- a/scripts/qualify_codec_resources.py
+++ b/scripts/qualify_codec_resources.py
@@ -185,7 +185,8 @@ def _slice_roundtrip(encoded, codec, size, expected_hash, memory):
             "frames": evidence, "parent_metrics_before": before, "parent_metrics_after": _metrics()}
 
 
-def run(*, large=False, output_parent=None, guarded_reader=False, slice_reader=False):
+def run(*, large=False, output_parent=None, guarded_reader=False, slice_reader=False,
+        production_writer=False):
     policy = CodecMemoryPolicy(8 << 30, 2 << 30)
     policy.admit(available_memory()["available_bytes"])
     output = Path(tempfile.mkdtemp(prefix="modelark-codec-qualification-", dir=output_parent))
@@ -193,6 +194,7 @@ def run(*, large=False, output_parent=None, guarded_reader=False, slice_reader=F
               "policy": policy.to_record(), "results": [], "large": large,
               "guarded_reader": guarded_reader,
               "slice_reader": slice_reader,
+              "production_writer_exercised": production_writer,
               "production_adoption": False, "physical_USB_or_archive_test": False}
     checkout = Path(__file__).resolve().parent.parent
     report["implementation_sha256"] = {
@@ -200,6 +202,7 @@ def run(*, large=False, output_parent=None, guarded_reader=False, slice_reader=F
             "modelark/codec_resources.py", "modelark/compress.py", "modelark/streamznn.py",
             "modelark/codec_worker.py", "modelark/codec_supervisor.py",
             "modelark/codec_process.py",
+            "modelark/codec_inprocess.py", "modelark/compress_worker.py", "modelark/fetch.py",
             "modelark/artifact_io.py", "modelark/artifact_policy.py", "modelark/artifact_preflight.py",
             "modelark/slice/decoding.py",
             "scripts/qualify_codec_resources.py")}
@@ -238,7 +241,7 @@ def run(*, large=False, output_parent=None, guarded_reader=False, slice_reader=F
     try:
         launch({"phase": "allocation-refusal"})
         sizes = [99_630_640, 409_993_344] if large else [2 << 20]
-        if large and (guarded_reader or slice_reader):
+        if large and (guarded_reader or slice_reader or production_writer):
             sizes.insert(0, 64 << 20)  # Default StreamZNN-sized native work unit too.
         with tempfile.TemporaryDirectory(prefix="synthetic-", dir=output) as scratch:
             for size in sizes:
@@ -260,6 +263,21 @@ def run(*, large=False, output_parent=None, guarded_reader=False, slice_reader=F
                         result = _slice_roundtrip(case / "misleading.blob", codec, size, digest, policy)
                         report["results"].append(result)
                         print(f"passed Slice reader: {codec} {size} original bytes", flush=True)
+                    if production_writer:
+                        from modelark import fetch
+                        result = fetch._compress_isolated(source, "bfloat16", codec, 1, digest, lambda: False)
+                        if result["status"] != "ok" or _sha(source) != digest:
+                            raise RuntimeError(f"production writer did not certify fixture: {result}")
+                        encoded = Path(result["znn_path"])
+                        stored_digest = _sha(encoded)
+                        if result["znn_sha256"] != stored_digest:
+                            raise RuntimeError("production stored identity differs")
+                        check = _slice_roundtrip(encoded, codec, size, digest, policy)
+                        report["results"].append({
+                            **check, "phase": "production-writer-to-slice",
+                            "writer_admission": result["admission"], "writer_runtime": result["worker"],
+                            "stored_sha256": stored_digest, "stored_bytes": encoded.stat().st_size})
+                        print(f"passed production writer/canary to Slice: {codec} {size} bytes", flush=True)
         if any(_sha(checkout / name) != digest
                for name, digest in report["implementation_sha256"].items()):
             raise RuntimeError("implementation changed during qualification; rerun unchanged code")
@@ -277,6 +295,8 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--large", action="store_true", help="qualify the two real failure sizes")
     parser.add_argument("--slice-reader", action="store_true", help="qualify C2 preflight and Slice original-byte decoding")
+    parser.add_argument("--production-writer", action="store_true",
+                        help="also exercise D1 fetch writer/canary and Slice parity on synthetic files")
     parser.add_argument("--output-parent", type=Path)
     parser.add_argument("--guarded-reader", action="store_true",
                         help="also qualify bounded parent/worker whole-frame transport")
@@ -287,7 +307,7 @@ def main():
         worker(args.worker, args.parent_pid)
     else:
         print(run(large=args.large, output_parent=args.output_parent, guarded_reader=args.guarded_reader,
-                  slice_reader=args.slice_reader))
+                  slice_reader=args.slice_reader, production_writer=args.production_writer))
 
 
 if __name__ == "__main__":

--- a/tests/test_codec_process.py
+++ b/tests/test_codec_process.py
@@ -33,7 +33,8 @@ def hooked_venv(tmp_path):
     return target, packages, record
 
 
-@pytest.mark.parametrize("module", ["modelark.codec_worker", "scripts.qualify_codec_resources"])
+@pytest.mark.parametrize("module", ["modelark.codec_worker", "scripts.qualify_codec_resources",
+                                  "modelark.compress_worker"])
 def test_both_workers_guard_before_site_hooks_and_restore_venv(hooked_venv, tmp_path, module, monkeypatch):
     target, packages, record = hooked_venv
     monkeypatch.setattr(sys, "executable", str(target / "bin/python"))
@@ -51,6 +52,20 @@ def test_both_workers_guard_before_site_hooks_and_restore_venv(hooked_venv, tmp_
         os.close(read)
         assert result.returncode == 1
         assert response[:1] == b"I", result.stderr
+    elif module == "modelark.compress_worker":
+        from modelark.artifact_policy import qualified_policy
+        from dataclasses import replace
+        from modelark.codec_resources import CodecMemoryPolicy
+        decode_policy = replace(qualified_policy(), memory=CodecMemoryPolicy.from_record(policy),
+                                limits=cs_test_limits())
+        source = tmp_path / "source"
+        source.write_bytes(b"1234")
+        request = {"src": str(source), "dst": str(tmp_path / "encoded"), "dtype": "bfloat16",
+                   "codec": "zipnn-whole", "threads": 1, "expected_sha256": "0" * 64,
+                   "expected_bytes": 4, "parent_pid": os.getpid(),
+                   "decode_policy": decode_policy.to_record(), "result": str(tmp_path / "result")}
+        result = subprocess.run(isolated_command(module, json.dumps(request)), capture_output=True)
+        assert result.returncode == 1  # this hook-only venv deliberately lacks ZipNN
     else:
         request = tmp_path / "request.json"
         output = tmp_path / "result.json"
@@ -63,6 +78,11 @@ def test_both_workers_guard_before_site_hooks_and_restore_venv(hooked_venv, tmp_
     assert records
     assert all(r["as"] == [128 << 20] * 2 and r["signal"] == 9 for r in records)
     assert all(r["prefix"] == str(target) for r in records)
+
+
+def cs_test_limits():
+    from modelark.artifact_io import DecodeLimits
+    return DecodeLimits(128 << 20, 128 << 20, 1 << 20, 64 << 20)
 
 
 def test_parent_death_during_actual_site_hook(hooked_venv):

--- a/tests/test_codec_production.py
+++ b/tests/test_codec_production.py
@@ -1,0 +1,208 @@
+"""D1 writer integration; synthetic files only, never a live archive or catalog."""
+from contextlib import closing
+import hashlib
+import io
+import json
+from pathlib import Path
+import resource
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+from modelark import archive_manifest, artifact_io, codec_inprocess, compress, compress_worker, fetch, streamznn
+from modelark.core import db
+from modelark.artifact_policy import qualified_policy
+from modelark.codec_resources import CodecResourceRefusal
+
+
+def source(tmp_path):
+    path = tmp_path / "model.safetensors"
+    path.write_bytes(b"\0\x3f" * 4096)
+    return path, hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_parent_refuses_before_files_or_spawn(tmp_path, monkeypatch):
+    path, digest = source(tmp_path)
+    before = set(tmp_path.iterdir())
+    limits = resource.getrlimit(resource.RLIMIT_AS)
+    monkeypatch.setattr(fetch, "available_memory", lambda: {"available_bytes": 1})
+    monkeypatch.setattr(fetch, "_run_monitored", lambda *a, **kw: pytest.fail("spawned"))
+    result = fetch._compress_isolated(path, "bfloat16", compress.CODEC_WHOLE, 1, digest, lambda: False)
+    assert result["status"] == "resource"
+    assert set(tmp_path.iterdir()) == before
+    assert compress.sha256_file(path) == digest
+    assert resource.getrlimit(resource.RLIMIT_AS) == limits
+
+
+def test_stop_precedes_resource_refusal(tmp_path, monkeypatch):
+    path, digest = source(tmp_path)
+    answers = iter([False, True])
+    monkeypatch.setattr(fetch, "available_memory", lambda: {"available_bytes": 1})
+    with pytest.raises(fetch._StopRequested):
+        fetch._compress_isolated(path, "bfloat16", compress.CODEC_WHOLE, 1, digest, lambda: next(answers))
+
+
+def test_unguarded_inline_adapter_never_decodes(monkeypatch):
+    monkeypatch.setattr(streamznn, "read_zipnn_frame", lambda *a, **kw: pytest.fail("native reached"))
+    with pytest.raises(CodecResourceRefusal, match="installed worker guard"):
+        codec_inprocess.frame_adapter(qualified_policy())
+
+
+@pytest.mark.parametrize("codec", [compress.CODEC_WHOLE, compress.CODEC_STREAM, compress.CODEC_ZSTD])
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16", "float32"])
+def test_real_production_child_and_slice_agree(tmp_path, codec, dtype):
+    if codec == compress.CODEC_ZSTD:
+        pytest.importorskip("zstandard")
+    path, digest = source(tmp_path)
+    limits_before = resource.getrlimit(resource.RLIMIT_AS)
+    result = fetch._compress_isolated(path, dtype, codec, 1, digest, lambda: False)
+    assert result["status"] == "ok", result
+    assert result["worker"]["address_space_bytes"] == [8 << 30] * 2
+    assert result["worker"]["startup"] == "isolated-no-site-guard-then-site.v1"
+    assert result["admission"]["available_bytes"] >= 10 << 30
+    policy = qualified_policy()
+    got = hashlib.sha256()
+    with Path(result["znn_path"]).open("rb") as encoded, closing(artifact_io.original_stream(
+            encoded, compressed=True, expected_bytes=path.stat().st_size,
+            limits=policy.limits, policy=policy)) as reader:
+        while chunk := reader.read(policy.limits.read_bytes):
+            got.update(chunk)
+    assert got.hexdigest() == digest == compress.sha256_file(path)
+    assert resource.getrlimit(resource.RLIMIT_AS) == limits_before
+
+
+@pytest.mark.parametrize("failure,status", [
+    (CodecResourceRefusal("memory sample refused"), "resource_refused"),
+    (MemoryError(), "resource_refused"),
+    (artifact_io.DecodeError("LIMIT", "frame"), "decode_refused"),
+    (artifact_io.DecodeError("UNSUPPORTED", "format"), "decode_refused"),
+    (artifact_io.DecodeError("INVALID", "bad bytes"), None),
+])
+def test_worker_refusal_preserves_original_and_removes_uncertified_output(
+        tmp_path, monkeypatch, failure, status):
+    path, digest = source(tmp_path)
+    dest = tmp_path / "encoded"
+    monkeypatch.setattr(codec_inprocess, "require_guard", lambda p: None)
+    def fake_compress(*a, **kw):
+        dest.write_bytes(b"uncertified")
+        return dest
+    monkeypatch.setattr(compress, "compress_file", fake_compress)
+    def fail(*a, **kw):
+        raise failure
+    monkeypatch.setattr(codec_inprocess, "verify_original", fail)
+    result = compress_worker.run({"src": str(path), "dst": str(dest), "dtype": "bfloat16",
+                                  "codec": compress.CODEC_WHOLE, "threads": 1,
+                                  "expected_sha256": digest, "expected_bytes": path.stat().st_size},
+                                 qualified_policy())
+    assert result["ok"] is False
+    if status:
+        assert result[status] is True
+    assert not dest.exists()
+    assert compress.sha256_file(path) == digest
+
+
+@pytest.mark.parametrize("flag,status", [("resource_refused", "resource"), ("decode_refused", "decode-refused")])
+def test_parent_preserves_typed_worker_refusal(tmp_path, monkeypatch, flag, status):
+    path, digest = source(tmp_path)
+    def monitor(cmd, *a, **kw):
+        assert cmd[1:3] == ["-I", "-S"]
+        request = json.loads(cmd[-1])
+        assert request["expected_bytes"] == path.stat().st_size
+        assert request["decode_policy"] == qualified_policy().to_record()
+        Path(request["result"]).write_text(json.dumps({"ok": False, flag: True, "detail": "refused"}))
+        return {"outcome": "exited", "rc": 0, "stderr": ""}
+    monkeypatch.setattr(fetch, "_run_monitored", monitor)
+    result = fetch._compress_isolated(path, "bfloat16", compress.CODEC_WHOLE, 1, digest, lambda: False)
+    assert result["status"] == status and result["stderr"] == ""
+    assert not list(tmp_path.glob("*.result"))
+
+
+def test_spawn_failure_cleans_result_file(tmp_path, monkeypatch):
+    path, digest = source(tmp_path)
+    def fail(*a, **kw):
+        raise OSError("spawn")
+    monkeypatch.setattr(fetch, "_run_monitored", fail)
+    with pytest.raises(OSError, match="spawn"):
+        fetch._compress_isolated(path, "bfloat16", compress.CODEC_WHOLE, 1, digest, lambda: False)
+    assert not list(tmp_path.glob("*.result"))
+
+
+def test_inline_uses_same_parser_without_nested_child(tmp_path, monkeypatch):
+    path, digest = source(tmp_path)
+    encoded = compress.compress_file(path, tmp_path / "encoded", threads=1)
+    monkeypatch.setattr(codec_inprocess, "require_guard", lambda p: None)  # unit seam, no native guard claim
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: pytest.fail("nested child"))
+    assert codec_inprocess.verify_original(encoded, digest, path.stat().st_size, qualified_policy())
+    assert not codec_inprocess.verify_original(encoded, "0" * 64, path.stat().st_size, qualified_policy())
+    with pytest.raises(artifact_io.DecodeError):
+        codec_inprocess.verify_original(encoded, digest, path.stat().st_size - 1, qualified_policy())
+
+
+def test_frame_override_requires_explicit_policy():
+    with pytest.raises(ValueError, match="explicit policy"):
+        artifact_io.original_stream(io.BytesIO(), compressed=True, expected_bytes=0,
+                                    limits=qualified_policy().limits, frame_stream=lambda: None)
+
+
+@pytest.mark.parametrize("where", ["stop", "progress"])
+def test_monitor_callback_failure_reaps_before_return(tmp_path, monkeypatch, where):
+    real_popen = subprocess.Popen
+    children = []
+    def spawn(*a, **kw):
+        proc = real_popen(*a, **kw)
+        children.append(proc)
+        return proc
+    def fail():
+        raise RuntimeError("callback failed")
+    monkeypatch.setattr(subprocess, "Popen", spawn)
+    monkeypatch.setattr(fetch, "_MONITOR_POLL", .01)
+    try:
+        with pytest.raises(RuntimeError, match="callback failed"):
+            fetch._run_monitored([sys.executable, "-c", "import signal; signal.pause()"],
+                                 fail if where == "progress" else lambda: 0, 300,
+                                 fail if where == "stop" else lambda: False)
+        assert len(children) == 1 and children[0].poll() is not None
+    finally:
+        for proc in children:
+            if proc.poll() is None:
+                proc.kill()
+            proc.wait()
+
+
+@pytest.mark.parametrize("status", ["resource", "decode-refused"])
+def test_ingestion_publishes_verified_raw_after_refusal(tmp_path, monkeypatch, status):
+    con = sqlite3.connect(":memory:", isolation_level=None)
+    con.execute("PRAGMA foreign_keys=ON")
+    for statement in db._statements(db.SCHEMA_PATH.read_text()):
+        con.execute(statement)
+    con.execute(f"PRAGMA user_version={db._SCHEMA_VERSION}")
+    repo, name, drive = "org/model", "model.safetensors", "drive-00"
+    data = b"downloaded original"
+    digest = hashlib.sha256(data).hexdigest()
+    con.execute("INSERT INTO models(repo_id,status) VALUES(?,?)", [repo, "fetching"])
+    con.execute("INSERT INTO drives(drive_label) VALUES(?)", [drive])
+    con.execute("INSERT INTO files(repo_id,rfilename,size_bytes,sha256,format,quant) VALUES(?,?,?,?,?,?)",
+                [repo, name, len(data), digest, "safetensors", "bf16"])
+    manifest = (archive_manifest.ManifestFile(
+        rfilename=name, size_bytes=len(data), sha256=digest, format="safetensors",
+        quant="bf16", storage_action="compress"),)
+    def download(_ctx, _repo, filename, directory, _base, **kw):
+        path = directory / filename
+        path.write_bytes(data)
+        return path
+    monkeypatch.setattr(fetch, "_download_shard", download)
+    monkeypatch.setattr(compress, "plan_codec", lambda *a: compress.CODEC_WHOLE)
+    monkeypatch.setattr(fetch, "_compress_isolated",
+                        lambda *a, **kw: {"status": status, "detail": "refused", "stderr": ""})
+    archive = tmp_path / "archive"
+    try:
+        fetch.fetch_model(fetch.RunCtx(con=con), repo, archive, drive, False,
+                          {"max_compress_ram_gb": 4, "threads": 1}, manifest=manifest)
+        row = con.execute("SELECT compressed,orig_sha256,stored_relpath FROM archived").fetchone()
+        assert row[:2] == (0, digest)
+        assert (archive / repo / row[2]).read_bytes() == data
+        assert not list(archive.rglob("*.znn"))
+    finally:
+        con.close()

--- a/tests/test_transport_fence.py
+++ b/tests/test_transport_fence.py
@@ -396,6 +396,9 @@ def test_run_monitored_forwards_inherit_fds_to_child(tmp_path):
         def wait(self, timeout=None):
             return 0
 
+        def poll(self):
+            return self.returncode
+
         def kill(self):
             pass
 


### PR DESCRIPTION
## Scope

First Stage D increment: guarded production compression plus shared-decoder canary inside the SAME worker. Follows merged C2 (#77), DEC-138/139 and DEC-145.

- Fetch samples the shared host/cgroup headroom and uses the same qualified decode/memory policy as Slice.
- Isolated no-site worker startup installs parent-death and AS/core guards before dependency hooks/native imports; success includes checked actual-worker evidence.
- The canary uses the neutral original-byte reader, with exact original length/hash and a non-spawning frame adapter that requires the already-installed guard. No nested helper or new StreamZNN engine.
- Resource/unsupported-decode refusal retains the verified downloaded original and stores raw. Hash mismatch remains canary failure. Codec preferences, disk bounds and write-fence inheritance remain unchanged.
- Shared monitored-child cleanup now reaps on callback exceptions/interrupts; diagnostic-tail reading is bounded.

## Explicitly NOT complete

External canary/deep verification and legacy restore adoption are D2, not silently converted to Slice's stricter format rules. Full production parity, E public-CLI qualification, compressed-source physical USB acceptance and live deployment remain separate. No archive rewrite, retrieval change, catalog/seal migration, P2P implementation or live service/device action.

## Validation

- Fresh installed-dependency qualification: 25 checks, all14 implementation fingerprints matched; actual production writer/canary -> Slice whole/StreamZNN round trips at64/100/410MB retain original hashes under8GiB AS +2GiB headroom.
- Installed wheel: 81 tests passed with optional zstandard0.25.0; package imports pinned and package/source diff identical.
- Initial codec suite48 passed/2 optional skips; focused production/startup38 passed. Broader suite242 passed/2 skips plus one outdated subprocess test double; corrected the double and all48 affected tests passed. Both ingestion raw-publication refusal regressions passed.
- Full CI-equivalent suite: 3,545 passed,19 skipped in766.52s. Optional zstd cases covered by installed-wheel run. Ruff/diff checks pass.

## Review state

Stage D local Grok CLI round2/3 ACCEPTED the exact implementation snapshot with no blockers. Round1 was discarded after citing nonexistent files/functions; it still counts toward the cap. The replacement pass required actual quoted source evidence. Remote Codex1/3 requested on f6e38aac698d4df84a823e3450e515f4d4271f26 in comment5630091551; CI34567384640 running. Counts carry across increments/pushes; no automatic reset. No Greptile per operator instruction. Operator merges; no merge authority delegated.

See docs/plans/codec-stage-d-progress.md for the caller inventory and remaining gates.
