### PR TITLE
Fix serial-less registration anchors with guarded evidence repair

### DIFF
--- a/docs/archive-serial-repair.md
+++ b/docs/archive-serial-repair.md
@@ -1,10 +1,17 @@
 # Archive serial-identity repair: attended handoff
 
-This repairs one evidence mismatch: the catalog already holds the correct disk
+This repairs two narrowly proven historical evidence mismatches. In the first,
+the catalog already holds the correct disk
 serial, but an older partition-only observation recorded a `serial: null` archive
 fingerprint. It does not change the saved serial or adopt a different disk.
-Registration without a canonical serial remains supported and is not eligible
-for this particular repair.
+In the second, the catalog serial is **NULL**, but a current clean anchor and its
+fingerprint include an observed serial. Older bootstrap code could produce this
+inconsistency without ever erasing a catalog serial. Explicit repair requires the
+old identity and fence proofs to agree, and fresh hardware to match that exact
+serial, UUIDs and capacity. It publishes a new **null-serial** identity/anchor,
+retaining actual observed serial separately as fence evidence. Registration stays
+serial-optional; no catalog serial is filled in. Dirty generations, empty-string
+serials, absent or contradictory proof are outside this second repair case.
 
 Implementation/review approval is not permission to deploy or repair an operating
 installation. Schedule a separate attended window. Replace the executable,
@@ -15,7 +22,7 @@ data/state/config paths and drive label in the examples with approved targets.
 | Item | Result |
 | --- | --- |
 | Identity epoch | Unchanged; this is not replacement or capacity transition |
-| Archive evidence | New generation and serial-bearing fingerprint/clean anchor |
+| Archive evidence | New generation and fingerprint/clean anchor matching the existing registration's serial contract |
 | Old generations, anchors and owner/session history | Retained |
 | Catalog reader floor | Explicitly becomes 8 during enrichment; table layout stays unchanged |
 | Affected Fill approvals | Superseded; fresh Preview → Approve → Start required |
@@ -66,6 +73,9 @@ attempt for live repair.
 - `legacy_clean`: eligible for fresh verification and enrichment.
 - `legacy_dirty`: requires the guarded legacy recovery bridge first. Prior proof,
   ended owner/child state and claims must remain provable.
+- `observed_serial_clean`: serial-less registration with a proven old serial-bearing
+  anchor. `required_live_serial` identifies the historical serial that must match
+  fresh observations. Repair keeps catalog serial NULL and does not bridge dirty state.
 - `already_correct`: no further identity correction needed.
 - `correct_identity_dirty`: not this legacy transition; use its appropriate
   ordinary recovery path without rewriting proof, fingerprint or owner fields.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3116,3 +3116,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Qualifies D2's resource-error classification claim: native zstd window/memory errors outside Python MemoryError can still become failed verification rather than UNKNOWN. Memory guards, format permissions and code remain unchanged. This disposition is specific to this finding; other findings, remaining Codex review rounds and operator merge authority are unchanged.
 - `docs_updated`: docs/decision_log.md, docs/codec-resource-qualification.md, docs/plans/codec-stage-d-progress.md
 - `related`: DEC-146, DEC-138, DEC-139
+
+### DEC-148: Repair proven observed-serial anchors without enriching serial-less registration
+- `id`: DEC-148
+- `date`: 2026-09-11
+- `status`: accepted
+- `triggered_by`: Operator approved a fresh reviewed repair PR after Drive-00 physical Slice preflight exposed catalog serial NULL with a current serial-bearing anchor and fingerprint.
+- `decision`: Extend explicit backup/rehearsal-first serial repair only to current clean anchors whose strict identity and fence proofs reproduce the saved fingerprint and match fresh attached hardware. Preserve catalog serial NULL; append a new generation with canonical null-serial identity and actual observed serial in fence evidence. Derive both compatible lock keys inside proven repair only, retaining strict ordinary reader/writer admission. Reject dirty inverse cases, malformed or contradictory proof, changed hardware and stale intent.
+- `rationale`: Historical producers could include observed serial in identity without registering it. The correction must restore the existing optional-serial contract, not infer a new registration or weaken all consumers. Reuse the existing transaction/backup/approval machinery rather than direct SQL or a parallel repair engine.
+- `impact`: Shared strict proof parser, explicit repair recognition and compatible exclusion, new qualification coverage, unchanged schema layout and reader floor 8. Preserve epoch, UUIDs, serial, archive bytes/provenance and old evidence; invalidate only affected approvals and require fresh Slice preview. No live catalog repair, NAS remount or service rollout in this implementation PR.
+- `docs_updated`: docs/decision_log.md, docs/archive-serial-repair.md, docs/plans/serialless-anchor-repair.md
+- `related`: DEC-133, DEC-137

--- a/docs/plans/serialless-anchor-repair.md
+++ b/docs/plans/serialless-anchor-repair.md
@@ -1,0 +1,56 @@
+# Serial-less registration / observed-serial anchor repair
+
+Approved scope: fresh PR from merged main `986241e`; local Grok up to three
+rounds, then cloud Codex up to three rounds. No Greptile for this PR; operator
+requested no Greptile for three more days on 2026-09-11. Operator merges.
+
+## Problem and boundary
+
+Drive 00 physical Slice preview refused before decoding or creating output:
+catalog serial NULL, current epoch/generation 1/1, but saved fingerprint and
+identity/fence proofs encode the connected NAS serial. UUIDs and capacity agree.
+Historical bootstrap code before `43ec31e` could produce this exact shape by
+using observed serial in a fingerprint without changing the registration column.
+This is a plausible producer, not proof of which invocation created the record.
+Current optional-serial producers already prevent this mismatch.
+
+NAS read-only mounting was explicitly requested with `mount -o ro`, not observed
+as an automatic failure transition. Leave it read-only. No NAS health claim,
+remount, archive rewrite, service rollout or live repair is part of this PR.
+
+## Implementation
+
+1. Strictly recognize NULL catalog serial plus a **current clean** serial-bearing
+   anchor: exact v1 JSON, identity/fence proof agreement, saved UUIDs, capacity,
+   authority and hash reproduction. Reject dirty state and empty-string serials.
+2. Derive both old observed-serial and canonical null-serial exclusion keys only
+   inside this explicit, evidence-bound repair. Keep ordinary FenceIdentity strict.
+3. Require the anchor's exact serial in fresh live observations before/after full
+   presence inventory and after actual SQLite writer-lock acquisition.
+4. Reuse controller/physical locks, writer-quiescence assertion, exact-state binding,
+   durable SQLite backup and catalog-only rehearsal. Append a new generation and
+   canonical null-serial anchor atomically; retain actual serial in fence proof.
+5. Preserve catalog serial, UUIDs, epoch, old anchors/generations, copy/provenance
+   and owner history. Reuse selective Fill approval supersession, revision bump,
+   reader floor 8 and fresh Slice preview requirements. No new schema/layout.
+
+The shared cause with Drive 07 is disagreement over **which serial facts form
+identity**, not damaged model bytes. One strict proof parser and the existing
+repair transaction owner handle both directions; no relaxed reader checks,
+implicit serial enrichment or manual live SQL workaround.
+
+## Validation and handoff
+
+- Regression-first: inverse repair failed on the old code before implementation.
+- Exercise malformed/duplicate proof, mismatched hardware, both physical aliases,
+  stale binding, backup/inventory/publication failures, rollback and idempotence.
+- Verify selective approvals and unchanged historical records on real disposable
+  SQLite; public Slice preview must refuse before repair and deliver verified
+  original bytes after repair with synthetic hardware and real filesystem I/O.
+- Run existing serial repair, optional-serial and broader regression suites.
+- Local Grok then fresh PR / cloud Codex; every pushed head gets cloud review.
+- After merge, separately qualify the installed artifact and rehearse the exact
+  catalog copy before any live application. Then retry the physical Slice test.
+
+Review counters and current test outcomes live in the ignored local handoff/evidence,
+not in the append-only decision ledger. Implementation is not live acceptance.

--- a/modelark/drive_bootstrap.py
+++ b/modelark/drive_bootstrap.py
@@ -48,7 +48,10 @@ from modelark import execution_authority as authority
 from modelark.drive_identity import FenceIdentity, UnprovenFenceIdentity, compatible_keys
 from modelark.core import db
 from modelark.catalog_versions import SUPPORTED_CATALOG_VERSIONS, SERIAL_REPAIR_CATALOG_VERSION
-from modelark.serial_identity import recognize_legacy_anchor, SerialIdentityUnproven, is_legacy_serial_mismatch
+from modelark.serial_identity import (
+    recognize_legacy_anchor, SerialIdentityUnproven, is_legacy_serial_mismatch,
+    serialless_anchor_serial,
+)
 
 # Re-export the typed refusal so operator entry points (the `drive reconcile` CLI) can translate it to a
 # clean message via THIS module, without importing the fenced envelope directly — keeping the envelope
@@ -331,11 +334,6 @@ def _serial_repair_state_snapshot(con, label):
         raise dm.DriveMutationRefused("CATALOG_VERSION_UNSUPPORTED", drive=label)
     facts = _persisted(con, label)
     epoch, generation, fingerprint, capacity, write_authority, fs_uuid, annex_uuid, serial = facts
-    try:
-        identity = FenceIdentity(fs_uuid, annex_uuid, serial, capacity, epoch, fingerprint)
-        identity.lock_keys()
-    except UnprovenFenceIdentity as exc:
-        raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label, reason=str(exc)) from exc
     if write_authority != "dedicated_local" or type(generation) is not int or generation < 1:
         raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label)
     metadata = con.execute("SELECT lifecycle,eligibility FROM drives WHERE drive_label=?", [label]).fetchone()
@@ -364,9 +362,29 @@ def _serial_repair_state_snapshot(con, label):
     ).fetchone()
     canonical = capacity_evidence.identity_fingerprint_v1(
         fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=serial, filesystem_capacity_bytes=capacity)
-    if not isinstance(serial, str) or not serial or serial != serial.strip() or anchor is None:
+    if anchor is None or (serial is not None and (
+            not isinstance(serial, str) or not serial or serial != serial.strip())):
         raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label, reason="serial or anchor missing")
-    if fingerprint == canonical:
+    required_serial = serial
+    if serial is None:
+        # Only explicit repair may derive exclusion from historical proof. Never
+        # enrich the catalog or relax FenceIdentity for ordinary readers/writers.
+        if not clean or current_anchor is None:
+            raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label,
+                                         reason="serial-less repair requires a current clean anchor")
+        columns = [r[1] for r in con.execute("PRAGMA table_info(drive_clean_anchors)")]
+        proof = dict(zip(columns, anchor))
+        try:
+            required_serial = serialless_anchor_serial(
+                fs_uuid=fs_uuid, annex_uuid=annex_uuid, fingerprint=fingerprint,
+                filesystem_capacity_bytes=capacity, anchor_identity_proof=proof["identity_proof"],
+                anchor_fence_proof=proof["fence_proof"], anchor_fingerprint=proof["identity_fingerprint"],
+                anchor_capacity_bytes=proof["filesystem_capacity_bytes"],
+                anchor_authority=proof["write_authority"])
+        except SerialIdentityUnproven as exc:
+            raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label, reason=str(exc)) from exc
+        status = "already_correct" if required_serial is None else "observed_serial_clean"
+    elif fingerprint == canonical:
         status = "already_correct" if clean else "correct_identity_dirty"
     else:
         columns = [r[1] for r in con.execute("PRAGMA table_info(drive_clean_anchors)")]
@@ -381,8 +399,13 @@ def _serial_repair_state_snapshot(con, label):
         except SerialIdentityUnproven as exc:
             raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label, reason=str(exc)) from exc
         status = "legacy_clean" if clean else "legacy_dirty"
+    try:
+        keys = FenceIdentity(fs_uuid, annex_uuid, required_serial, capacity, epoch, fingerprint).lock_keys()
+    except UnprovenFenceIdentity as exc:
+        raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label, reason=str(exc)) from exc
     return {"catalog_version": version, "drive_label": label, "facts": facts, "metadata": metadata,
             "dirty_generation": dirty, "owner_session": owner, "anchor": anchor, "status": status,
+            "required_live_serial": required_serial, "fence_keys": keys,
             "canonical_fingerprint": canonical,
             "affected_approvals": approved_proposals_bound_to_drive(con, label)}
 
@@ -406,6 +429,7 @@ def inspect_serial_identity(con, label: str) -> dict:
         return {"drive_label": label, "status": state["status"], "binding": _serial_binding(state),
                 "identity_epoch": epoch, "generation": generation, "old_fingerprint": fingerprint,
                 "canonical_fingerprint": state["canonical_fingerprint"],
+                "required_live_serial": state["required_live_serial"],
                 "affected_approvals": state["affected_approvals"], "requires_live_verification": True}
     finally:
         if own:
@@ -416,7 +440,8 @@ def _serial_live(con, label, state):
     ev = _live_evidence(con, label)
     facts = state["facts"]
     if (not ev.proven or not ev.path or ev.fs_uuid != facts[5] or ev.annex_uuid != facts[6]
-            or ev.serial != facts[7] or ev.capacity != facts[3]
+            or (state["required_live_serial"] is not None and ev.serial != state["required_live_serial"])
+            or ev.capacity != facts[3]
             or ev.fingerprint != state["canonical_fingerprint"]
             or type(ev.free) is not int or not 0 <= ev.free <= facts[3]):
         raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_LIVE_MISMATCH", drive=label)
@@ -459,7 +484,7 @@ def _serial_enrich_locked(con, label, state, final, now):
     """One composite transaction: old clean -> new generation -> new identity -> anchor."""
     from modelark.proposal import bump_revision, supersede_serial_repair_approvals
     _serial_guard(con, label, state)
-    if state["status"] != "legacy_clean":
+    if state["status"] not in {"legacy_clean", "observed_serial_clean"}:
         raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label)
     facts = state["facts"]
     generation = dm._advance_one(con, label, "serial_identity_repair", captured=facts)
@@ -543,13 +568,13 @@ def repair_serial_identity(con, label: str, *, expected_binding: str, now,
             if _serial_binding(state) != expected_binding:
                 raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_STALE", drive=label)
             facts = state["facts"]
-            keys = FenceIdentity(facts[5], facts[6], facts[7], facts[3], facts[0], facts[2]).lock_keys()
+            keys = state["fence_keys"]
             with drive_fence.hold_drives_sorted(keys, blocking=blocking):
                 _serial_guard(con, label, state)
                 first = _serial_live(con, label, state)
                 if state["status"] == "already_correct":
                     return {**inspect_serial_identity(con, label), "observed_serial": first.serial}
-                if state["status"] not in {"legacy_clean", "legacy_dirty"}:
+                if state["status"] not in {"legacy_clean", "legacy_dirty", "observed_serial_clean"}:
                     raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label)
                 owner = _capture_recovery_owner(con, label, facts)
                 inventory = _require_complete_inventory(con, label, first.path, progress=progress)

--- a/modelark/serial_identity.py
+++ b/modelark/serial_identity.py
@@ -85,6 +85,56 @@ def _invalid_constant(value):
     raise SerialIdentityUnproven(f'non-JSON identity proof value: {value}')
 
 
+def _identity_proof(text):
+    """Strict v1 parsing shared by both explicit legacy repair directions."""
+    if not isinstance(text, str):
+        raise SerialIdentityUnproven('identity proof must be JSON text')
+    try:
+        proof = json.loads(text, object_pairs_hook=_unique_object, parse_constant=_invalid_constant)
+    except (ValueError, RecursionError) as exc:
+        raise SerialIdentityUnproven('malformed identity proof JSON') from exc
+    if not isinstance(proof, dict) or set(proof) != {'v', 'fs_uuid', 'annex_uuid', 'serial'}:
+        raise SerialIdentityUnproven('identity proof must contain exactly the v1 identity fields')
+    if type(proof['v']) is not int or proof['v'] != 1:
+        raise SerialIdentityUnproven('identity proof version must be integer 1')
+    for key in ('fs_uuid', 'annex_uuid', 'serial'):
+        _normalized_string(proof[key], 'proof ' + key, optional=True)
+    return proof
+
+
+def serialless_anchor_serial(*, fs_uuid, annex_uuid, fingerprint,
+                           filesystem_capacity_bytes, anchor_identity_proof,
+                           anchor_fence_proof, anchor_fingerprint,
+                           anchor_capacity_bytes, anchor_authority):
+    """Prove a serial-less registration's anchor; return its identity serial.
+
+    Non-null means the historical producer included observed serial implicitly.
+    Null means the anchor is already canonical. This cannot authorize a dirty
+    recovery or a live repair; callers must prove the exact current clean state.
+    """
+    _normalized_string(fs_uuid, 'fs_uuid', optional=True)
+    _normalized_string(annex_uuid, 'annex_uuid', optional=True)
+    if fs_uuid is None and annex_uuid is None:
+        raise SerialIdentityUnproven('filesystem or annex UUID required')
+    _capacity(filesystem_capacity_bytes, 'filesystem_capacity_bytes')
+    _capacity(anchor_capacity_bytes, 'anchor_capacity_bytes')
+    if anchor_capacity_bytes != filesystem_capacity_bytes or anchor_authority != 'dedicated_local':
+        raise SerialIdentityUnproven('anchor capacity or authority disagrees')
+    proof = _identity_proof(anchor_identity_proof)
+    fence = _identity_proof(anchor_fence_proof)
+    for document in (proof, fence):
+        if document['fs_uuid'] != fs_uuid or document['annex_uuid'] != annex_uuid:
+            raise SerialIdentityUnproven('proof UUIDs disagree with saved UUIDs')
+    if proof['serial'] is not None and fence != proof:
+        raise SerialIdentityUnproven('observed-serial identity and fence proofs disagree')
+    expected = identity_fingerprint_v1(fs_uuid=fs_uuid, annex_uuid=annex_uuid,
+                                     serial=proof['serial'],
+                                     filesystem_capacity_bytes=filesystem_capacity_bytes)
+    if fingerprint != expected or anchor_fingerprint != expected:
+        raise SerialIdentityUnproven('anchor does not reproduce the exact saved identity')
+    return proof['serial']
+
+
 def recognize_legacy_anchor(
     *, fs_uuid, annex_uuid, serial, fingerprint, filesystem_capacity_bytes,
     anchor_identity_proof, anchor_fingerprint, anchor_capacity_bytes, anchor_authority,
@@ -106,21 +156,7 @@ anchor, prove a drive is mounted, or grant authority to publish either identity.
         raise SerialIdentityUnproven('anchor fingerprint disagrees with saved null-serial identity')
     if anchor_authority != 'dedicated_local':
         raise SerialIdentityUnproven('anchor dedicated_local authority required')
-    if not isinstance(anchor_identity_proof, str):
-        raise SerialIdentityUnproven('identity proof must be JSON text')
-    try:
-        proof = json.loads(anchor_identity_proof, object_pairs_hook=_unique_object,
-                           parse_constant=_invalid_constant)
-    except SerialIdentityUnproven:
-        raise
-    except (ValueError, RecursionError) as exc:
-        raise SerialIdentityUnproven('malformed identity proof JSON') from exc
-    if not isinstance(proof, dict) or set(proof) != {'v', 'fs_uuid', 'annex_uuid', 'serial'}:
-        raise SerialIdentityUnproven('identity proof must contain exactly the v1 identity fields')
-    if type(proof['v']) is not int or proof['v'] != 1:
-        raise SerialIdentityUnproven('identity proof version must be integer 1')
-    _normalized_string(proof['fs_uuid'], 'proof fs_uuid', optional=True)
-    _normalized_string(proof['annex_uuid'], 'proof annex_uuid', optional=True)
+    proof = _identity_proof(anchor_identity_proof)
     if proof['serial'] is not None:
         raise SerialIdentityUnproven('identity proof serial must be null')
     if proof['fs_uuid'] != fs_uuid or proof['annex_uuid'] != annex_uuid:

--- a/tests/test_serial_repair_public_slice.py
+++ b/tests/test_serial_repair_public_slice.py
@@ -93,10 +93,10 @@ def workflow(tmp_path, monkeypatch, hardware, native, request):
     canonical = identity_fingerprint_v1(fs_uuid=leaf["uuid"], annex_uuid=ANNEX,
                                         serial=disk["serial"], filesystem_capacity_bytes=capacity)
     mode = getattr(request, "param", "legacy")
-    stored_serial = None if mode == "serialless" else disk["serial"]
-    stored_fp = canonical if mode == "canonical" else old
+    stored_serial = None if mode in {"serialless", "observed_serial"} else disk["serial"]
+    stored_fp = canonical if mode in {"canonical", "observed_serial"} else old
     proof = json.dumps({"v": 1, "fs_uuid": leaf["uuid"], "annex_uuid": ANNEX,
-                        "serial": stored_serial if mode == "canonical" else None})
+                        "serial": disk["serial"] if mode in {"canonical", "observed_serial"} else None})
     con = sqlite3.connect(db.DB_PATH, isolation_level=None)
     con.executescript(db.SCHEMA_PATH.read_text())
     con.execute("PRAGMA user_version=7")
@@ -133,6 +133,25 @@ def _candidate(case):
     preview = domain.preview(spec, snapshot)
     assert preview.source_ready, preview.gaps
     return preview.closure[0].sources[0]
+
+
+@pytest.mark.parametrize('workflow', ['observed_serial'], indirect=True)
+def test_serialless_old_observed_anchor_repair_unblocks_public_slice(workflow):
+    case = workflow
+    blocked = operator.preview(case.path, case.parent / 'blocked-output', (REPO,), None)
+    assert blocked['state'] == 'blocked'
+    assert not (case.parent / 'blocked-output').exists()
+    intent = bootstrap.inspect_serial_identity(case.con, 'drive-00')
+    assert intent['status'] == 'observed_serial_clean'
+    report = bootstrap.repair_serial_identity(
+        case.con, 'drive-00', expected_binding=intent['binding'],
+        now='2026-09-11', writers_stopped=True)
+    assert report['canonical_fingerprint'] == case.old
+    assert case.con.execute('SELECT serial FROM drives').fetchone() == (None,)
+    preview = _preview(case, 'repaired-output')
+    _complete(case, preview, case.parent / 'repaired-output')
+    assert {str(p.relative_to(case.archive)): p.read_bytes()
+            for p in case.archive.rglob('*') if p.is_file()} == case.archive_bytes
 
 
 def _preview(case, name):

--- a/tests/test_serialless_anchor_proof.py
+++ b/tests/test_serialless_anchor_proof.py
@@ -1,0 +1,53 @@
+"""No guessed serial, permissive JSON, or contradictory historical proof."""
+import json
+
+import pytest
+
+from modelark.serial_identity import serialless_anchor_serial, SerialIdentityUnproven
+from test_drive_bootstrap import _FS, _ANX, _SER, _FP
+
+
+def facts():
+    proof = json.dumps(dict(v=1, fs_uuid=_FS, annex_uuid=_ANX, serial=_SER))
+    return dict(fs_uuid=_FS, annex_uuid=_ANX, fingerprint=_FP, filesystem_capacity_bytes=1000,
+                anchor_identity_proof=proof, anchor_fence_proof=proof, anchor_fingerprint=_FP,
+                anchor_capacity_bytes=1000, anchor_authority='dedicated_local')
+
+
+def test_exact_evidence_returns_serial_without_changing_facts():
+    original = facts()
+    assert serialless_anchor_serial(**original) == _SER
+    assert original == facts()
+
+
+@pytest.mark.parametrize('key', ['anchor_identity_proof', 'anchor_fence_proof'])
+@pytest.mark.parametrize('proof', [None, '{}', 'null', '[]', '{',
+    '{"v":1,"v":1,"fs_uuid":"fs-uuid-1","annex_uuid":"annex-uuid-1","serial":"serial-1"}',
+    '{"v":NaN,"fs_uuid":"fs-uuid-1","annex_uuid":"annex-uuid-1","serial":"serial-1"}',
+    '[' * 2000 + 'null' + ']' * 2000])
+def test_invalid_json_refuses(key, proof):
+    with pytest.raises(SerialIdentityUnproven):
+        serialless_anchor_serial(**(facts() | {key: proof}))
+
+
+@pytest.mark.parametrize('key', ['anchor_identity_proof', 'anchor_fence_proof'])
+@pytest.mark.parametrize('field,value', [('v', True), ('v', 1.0), ('v', 2),
+    ('serial', None), ('serial', ''), ('serial', 'different'), ('serial', ' serial-1'),
+    ('serial', 123), ('serial', '\ud800'), ('fs_uuid', 'other'), ('annex_uuid', None),
+    ('extra', True)])
+def test_proof_mismatch_refuses(key, field, value):
+    changed = facts()
+    proof = json.loads(changed[key])
+    proof[field] = value
+    changed[key] = json.dumps(proof)
+    with pytest.raises(SerialIdentityUnproven):
+        serialless_anchor_serial(**changed)
+
+
+@pytest.mark.parametrize('field,value', [('filesystem_capacity_bytes', True),
+    ('filesystem_capacity_bytes', 2000), ('anchor_capacity_bytes', 1000.0),
+    ('anchor_authority', 'unknown'), ('anchor_fingerprint', 'f' * 64),
+    ('fingerprint', _FP.upper()), ('fs_uuid', None)])
+def test_facts_cannot_be_inferred_from_proof(field, value):
+    with pytest.raises(SerialIdentityUnproven):
+        serialless_anchor_serial(**(facts() | {field: value}))

--- a/tests/test_serialless_anchor_repair.py
+++ b/tests/test_serialless_anchor_repair.py
@@ -1,0 +1,215 @@
+"""Repair old observed-serial anchors without enriching serial-less registration."""
+import json
+import sqlite3
+from dataclasses import replace
+
+import pytest
+
+from modelark import drive_bootstrap as bootstrap, drive_fence
+from modelark.drive_identity import FenceIdentity
+from test_drive_bootstrap import _catalog, _dirty_gen, _FS, _ANX, _SER, _FP
+from test_serial_repair_workflow import OLD, seed, live_setup
+
+
+def seed_observed(con, *, dirty=False, anchor_changes=None):
+    proof = json.dumps({'v': 1, 'fs_uuid': _FS, 'annex_uuid': _ANX, 'serial': _SER})
+    seed(con, dirty=dirty, anchor=False)
+    con.execute('UPDATE drives SET serial=NULL,identity_fingerprint=?', [_FP])
+    values = dict(generation=1, filesystem_capacity_bytes=1000, identity_fingerprint=_FP,
+                  identity_proof=proof, fence_proof=proof)
+    if anchor_changes is not None:
+        values.update(anchor_changes)
+    if values['generation'] != 1:
+        _dirty_gen(con, gen=values['generation'])
+    con.execute("INSERT INTO drive_clean_anchors(drive_label,identity_epoch,generation,"
+                "anchor_free_bytes,filesystem_capacity_bytes,identity_fingerprint,write_authority,"
+                "identity_proof,fence_proof,observed_at) "
+                "VALUES('drive-00',1,:generation,900,:filesystem_capacity_bytes,:identity_fingerprint,"
+                "'dedicated_local',:identity_proof,:fence_proof,'2026-09-11')", values)
+
+
+def setup_live(monkeypatch, tmp_path):
+    archive = live_setup(monkeypatch, tmp_path)
+    ev = bootstrap._LiveEvidence(str(archive), _FS, _ANX, _SER, 1000, 900, 4096,
+                                 OLD, True, serial_in_identity=False)
+    monkeypatch.setattr(bootstrap, '_live_evidence', lambda *_: ev)
+    return archive, ev
+
+
+def run(con, binding):
+    return bootstrap.repair_serial_identity(con, 'drive-00', expected_binding=binding,
+                                           now='2026-09-11', writers_stopped=True)
+
+
+def test_backup_rehearsal_repair_and_noop_keep_serial_optional(tmp_path, monkeypatch):
+    with _catalog(tmp_path) as con:
+        seed_observed(con)
+        archive, _ = setup_live(monkeypatch, tmp_path)
+        before = tuple(con.iterdump())
+        anchors = con.execute('SELECT * FROM drive_clean_anchors').fetchall()
+        intent = bootstrap.inspect_serial_identity(con, 'drive-00')
+        assert intent['status'] == 'observed_serial_clean'
+        assert intent['old_fingerprint'] == _FP
+        assert intent['canonical_fingerprint'] == OLD
+        assert intent['required_live_serial'] == _SER
+        assert tuple(con.iterdump()) == before
+        result = run(con, intent['binding'])
+        assert result['status'] == 'repaired'
+        assert result['legacy_recovered'] is False
+        assert con.execute('SELECT serial,identity_epoch,write_generation,identity_fingerprint '
+                           'FROM drives').fetchone() == (None, 1, 2, OLD)
+        assert con.execute('SELECT * FROM drive_clean_anchors ORDER BY generation').fetchall()[:1] == anchors
+        proof, fence = con.execute('SELECT identity_proof,fence_proof FROM drive_clean_anchors '
+                                   'WHERE generation=2').fetchone()
+        assert json.loads(proof)['serial'] is None
+        assert json.loads(fence)['serial'] == _SER
+        with sqlite3.connect(result['backup']) as backup:
+            assert tuple(backup.iterdump()) == before
+        with sqlite3.connect(result['rehearsal']) as rehearsal:
+            assert rehearsal.execute('SELECT serial,identity_fingerprint FROM drives').fetchone() == (None, OLD)
+        assert (archive / 'untouched.txt').read_bytes() == b'unchanged archive sentinel'
+        fresh = bootstrap.inspect_serial_identity(con, 'drive-00')
+        before_noop = tuple(con.iterdump())
+        assert run(con, fresh['binding'])['status'] == 'already_correct'
+        assert tuple(con.iterdump()) == before_noop
+
+
+@pytest.mark.parametrize('changes,mutation', [
+    ({}, "UPDATE drives SET serial=''"),
+    ({}, "UPDATE drives SET lifecycle='lost'"),
+    ({'identity_proof': '{}'}, None),
+    ({'fence_proof': '{}'}, None),
+    ({'generation': 2}, None),
+    ({'filesystem_capacity_bytes': 2000}, None),
+    ({'identity_fingerprint': 'f' * 64}, None),
+])
+def test_unproven_or_contradictory_saved_evidence_refuses(tmp_path, changes, mutation):
+    with _catalog(tmp_path) as con:
+        seed_observed(con, anchor_changes=changes)
+        if mutation is not None:
+            con.execute(mutation)
+        before = tuple(con.iterdump())
+        with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_UNPROVEN'):
+            bootstrap.inspect_serial_identity(con, 'drive-00')
+        assert tuple(con.iterdump()) == before
+
+
+def test_dirty_inverse_case_is_not_implicitly_extended(tmp_path):
+    with _catalog(tmp_path) as con:
+        seed_observed(con, dirty=True)
+        with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_UNPROVEN'):
+            bootstrap.inspect_serial_identity(con, 'drive-00')
+
+
+@pytest.mark.parametrize('field,value', [('serial', None), ('serial', 'other'),
+                                       ('fs_uuid', 'other'), ('annex_uuid', 'other'),
+                                       ('capacity', 2000), ('proven', False)])
+@pytest.mark.parametrize('at_commit', [False, True])
+def test_live_change_including_after_sqlite_acquisition_refuses(tmp_path, monkeypatch, field, value, at_commit):
+    with _catalog(tmp_path) as con:
+        seed_observed(con)
+        _, ev = setup_live(monkeypatch, tmp_path)
+        intent = bootstrap.inspect_serial_identity(con, 'drive-00')
+        before = tuple(con.iterdump())
+        monkeypatch.setattr(bootstrap, '_live_evidence', lambda *_:
+                            replace(ev, **{field: value}) if not at_commit or con.in_transaction else ev)
+        with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_LIVE_MISMATCH'):
+            run(con, intent['binding'])
+        assert tuple(con.iterdump()) == before
+
+
+@pytest.mark.parametrize('fingerprint', [_FP, OLD])
+def test_both_physical_aliases_exclude_repair(tmp_path, monkeypatch, fingerprint):
+    with _catalog(tmp_path) as con:
+        seed_observed(con)
+        setup_live(monkeypatch, tmp_path)
+        intent = bootstrap.inspect_serial_identity(con, 'drive-00')
+        before = tuple(con.iterdump())
+        with drive_fence.hold_drives_sorted([(fingerprint, 1)]):
+            with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_FENCE_UNAVAILABLE'):
+                run(con, intent['binding'])
+        assert tuple(con.iterdump()) == before
+
+
+def test_ordinary_identity_fences_still_refuse_inconsistent_serialless_row():
+    with pytest.raises(ValueError, match='fingerprint does not bind'):
+        FenceIdentity(_FS, _ANX, None, 1000, 1, _FP).lock_keys()
+
+
+@pytest.mark.parametrize('failure', ['inventory', 'backup', 'publication'])
+def test_failure_preserves_catalog_and_history(tmp_path, monkeypatch, failure):
+    with _catalog(tmp_path) as con:
+        seed_observed(con)
+        setup_live(monkeypatch, tmp_path)
+        intent = bootstrap.inspect_serial_identity(con, 'drive-00')
+        before = tuple(con.iterdump())
+        if failure == 'publication':
+            original = bootstrap.dm._publish_anchor_locked
+
+            def fail(connection, *args):
+                original(connection, *args)
+                if connection is con:
+                    raise RuntimeError('injected publication failure')
+
+            monkeypatch.setattr(bootstrap.dm, '_publish_anchor_locked', fail)
+        else:
+            def fail(*args, **kwargs):
+                raise RuntimeError('injected ' + failure + ' failure')
+
+            target = '_require_complete_inventory' if failure == 'inventory' else '_serial_backup_rehearsal'
+            monkeypatch.setattr(bootstrap, target, fail)
+        with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_FAILED'):
+            run(con, intent['binding'])
+        assert tuple(con.iterdump()) == before
+        assert not con.in_transaction
+
+
+def test_stale_binding_and_quiescence_required_before_backup(tmp_path, monkeypatch):
+    with _catalog(tmp_path) as con:
+        seed_observed(con)
+        setup_live(monkeypatch, tmp_path)
+        intent = bootstrap.inspect_serial_identity(con, 'drive-00')
+        con.execute("UPDATE drives SET eligibility='excluded'")
+        before = tuple(con.iterdump())
+        with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_STALE'):
+            run(con, intent['binding'])
+        with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_QUIESCENCE_REQUIRED'):
+            bootstrap.repair_serial_identity(con, 'drive-00', expected_binding=intent['binding'], now='now')
+        assert tuple(con.iterdump()) == before
+        assert not list(tmp_path.glob('.serial-repair-*'))
+
+
+def test_operator_cli_inspect_and_repair(tmp_path, monkeypatch, capsys):
+    from modelark import cli
+    from test_serial_repair_cli import args
+    with _catalog(tmp_path) as con:
+        seed_observed(con)
+        setup_live(monkeypatch, tmp_path)
+        cli.cmd_drive_reconcile(args(inspect_serial_identity=True))
+        intent = json.loads(capsys.readouterr().out)
+        assert intent['status'] == 'observed_serial_clean'
+        cli.cmd_drive_reconcile(args(repair_serial_identity=True, writers_stopped=True,
+                                     expected_binding=intent['binding']))
+        result = json.loads(capsys.readouterr().out)
+        assert result['canonical_fingerprint'] == OLD
+        assert result['observed_serial'] == _SER
+
+
+@pytest.mark.parametrize('binding', ['source_drive', 'target_drive', 'satisfying_drive'])
+def test_affected_approvals_superseded_without_rewriting_tasks(tmp_path, monkeypatch, binding):
+    from test_serial_repair_approvals import seed_proposal
+    with _catalog(tmp_path) as con:
+        seed_observed(con)
+        setup_live(monkeypatch, tmp_path)
+        con.execute("INSERT INTO plans(plan_id) VALUES('ark')")
+        con.execute("INSERT INTO models(repo_id) VALUES('org/a')")
+        seed_proposal(con, 'affected', binding=binding, drive='drive-00')
+        con.execute("UPDATE planner_state SET active_approved_proposal_id='affected'")
+        immutable = con.execute('SELECT * FROM proposal_tasks').fetchall()
+        intent = bootstrap.inspect_serial_identity(con, 'drive-00')
+        assert intent['affected_approvals'] == ('affected',)
+        result = run(con, intent['binding'])
+        assert result['superseded_approvals'] == ('affected',)
+        assert con.execute('SELECT lifecycle FROM placement_proposals').fetchone() == ('superseded',)
+        assert con.execute('SELECT active_approved_proposal_id FROM planner_state').fetchone() == (None,)
+        assert con.execute('SELECT * FROM proposal_tasks').fetchall() == immutable


### PR DESCRIPTION
## Summary

Repair one proven historical identity inconsistency through the existing explicit
operator workflow: registration serial is NULL, but its current clean anchor and
saved fingerprint contain an observed serial. Preserve serial optionality and
archive bytes; do not fill in the catalog serial or relax ordinary readers.

- Strict shared v1 proof parsing; require matching identity/fence proofs, saved
  UUIDs, capacity, authority and exact fingerprint reproduction.
- Require the historical serial on fresh attached hardware, including after
  SQLite writer-lock acquisition. Hold both old and prospective physical aliases.
- Reuse exact-state binding, writer quiescence, backup/integrity/fsync/rehearsal,
  atomic new generation/anchor, approval supersession and reader floor 8.
- Keep old anchors, generations, owner/history, bytes and hash provenance intact.
- Refuse dirty inverse cases, absent/contradictory proof and changed hardware.
- DEC-148 and attended repair guide document the boundary.

## Validation

- 333 targeted identity/repair/optional-serial/public Slice tests passed.
- Built wheel: 100 selected repair and public Slice tests passed; every loaded
  modelark module origin verified under the installed package. Test dependencies
  borrowed from the dev environment, user-site packages disabled.
- Ruff and git diff check passed.
- Full regression suite: 3,681 passed, 28 skipped, 5 warnings in 1,037.65s.
- CI run34647387220: Python3.10 passed9m14s, Python3.12 passed8m30s,
  E2E passed2m17s on exact head1bab1bbfd6cc6f2fd2cfae8faa8280cd76ccb6b3.
- Updated read-only inspector recognizes actual Drive-00 evidence and reports no
  affected Fill approvals. No live repair, archive reads/decode, USB output,
  deployment or remount performed. This is NOT physical Slice acceptance.

## Review

Local Grok accepted in round 2/3. Round 1 ended without a verdict because the CLI
offloaded the oversized prompt while tools were disabled; counted toward cap.
Round 2 used a smaller self-contained verbatim snapshot, no tools. No blocking
findings; optional isolated unit assertion is already covered by repair/noop test.

Cloud Codex accepted exact1bab1bbfd6 in round1/3, comment5640650542. No inline
findings or code-fix iterations were required. Every pushed head must be reviewed. No Greptile
per operator (three more days from 2026-09-11). Operator retains merge authority.

After merge: separately qualify the installed artifact and rehearse an exact
catalog backup before live repair, then resume physical Slice testing. NAS stays
intentionally read-only. Retained DEC-147 codec edge is unrelated and unchanged.
