### PR TITLE
perf(slice): reduce repeated observation and append overhead

### DIFF
--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3127,3 +3127,36 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Shared strict proof parser, explicit repair recognition and compatible exclusion, new qualification coverage, unchanged schema layout and reader floor 8. Preserve epoch, UUIDs, serial, archive bytes/provenance and old evidence; invalidate only affected approvals and require fresh Slice preview. No live catalog repair, NAS remount or service rollout in this implementation PR.
 - `docs_updated`: docs/decision_log.md, docs/archive-serial-repair.md, docs/plans/serialless-anchor-repair.md
 - `related`: DEC-133, DEC-137
+
+### DEC-149: Reuse mount syntax only for exact freshly read inventory text
+- `id`: DEC-149
+- `date`: 2026-09-11
+- `status`: accepted
+- `triggered_by`: Operator approved performance work after a correct 91 MB physical Slice took about 18 minutes; source profiling attributed 157 of 204 instrumented seconds to 75,982 repeated mount parses. Local Grok accepted the narrow design on its first pass.
+- `decision`: Memoize only the pure mount parser's successful immutable results, keyed by complete exact built-in strings, with two entries and a 262,144-character per-input retention bound. Oversized or non-exact-string inputs follow the unchanged uncached parser. Retain every fresh procfs read, descriptor/attachment check, source-read guard, authority callback and durable publication boundary.
+- `rationale`: Nested checks multiply syntax work although the freshly observed text rarely changes. Syntax reuse is not cached admission or attachment evidence. Start with this shared narrow fix, not time-based observation reuse or weaker codec callbacks; qualification must establish whether it is sufficient.
+- `impact`: Central host-observation parser and regression tests only; no schema, sealed policy, archive format, live catalog repair, NAS writes or service rollout. Require installed-runtime physical timing and exact hashes/receipts before cloud PR review; any remaining bottleneck returns to profiling and the scoped design review.
+- `docs_updated`: docs/decision_log.md, docs/plans/slice-observation-performance.md
+- `related`: DEC-138, DEC-142, DEC-145, DEC-146
+
+### DEC-150: Separate transfer liveness from destination I/O and normalize write quanta
+- `id`: DEC-150
+- `date`: 2026-09-11
+- `status`: accepted
+- `triggered_by`: DEC-149 physical qualification remained correct but took 395.65 seconds, missing the 60-second gate; operator authorized continued local design/code iterations and Grok accepted this second design pass.
+- `decision`: Expose an explicit polled source-use contract carrying only the existing attempt/Stop/journal-head guard while all source attachment and codec callbacks remain intact. Perform full destination checks before destination I/O, not inside source/pipe events. Gather short original reads into independently owned, at-most-1-MiB append quanta, polling before/after each read and retaining existing append/fsync/accounting/hash/publication ordering.
+- `rationale`: Codec pipe chunks are neither destination I/O nor allocation events. Passing the complete destination census through every decoder callback, then treating each short read as a separate durable append, multiplies independent work. Preserve the boundaries by responsibility rather than weakening or time-caching their evidence.
+- `impact`: Shared Slice session and fenced source adapter; no codec policy, actual-source-read guard, schema, archive or service change. Destination detachment during source-only waits is detected before the next destination access, not promised immediately at each pipe event; Stop/source guards retain existing polling. Existing checked-source callers keep their conservative behavior. Performance gate and final local/code review remain required in the work plan.
+- `docs_updated`: docs/decision_log.md, docs/plans/slice-observation-performance.md
+- `related`: DEC-149, DEC-142, DEC-144
+
+### DEC-151: Accept the measured 80-second Slice result and retain this implementation
+- `id`: DEC-151
+- `date`: 2026-09-11
+- `status`: accepted
+- `triggered_by`: Operator said "80s? that's fine - just keep it then" after reviewing the 80.252-second physical result, three local Grok passes, remaining overhead and possible parallelism.
+- `decision`: Accept the current correct 12-file, 91,306,390-byte NAS-to-USB result for this stage. Replace the exploratory 30-second aim / three-runs-within-60-second release gate with explicit acceptance of the measured result. Keep DEC-149/DEC-150 code; do not add threading, file parallelism, further guard refactoring or another local Grok round. Finish ordinary tests and the already-authorized cloud Codex PR review, with Greptile excluded under the current operator instruction.
+- `rationale`: The measured improvement from approximately 18 minutes to 80 seconds is sufficient for the operator's present use. Further optimization adds scope that is not needed to accept this bounded change.
+- `impact`: Acceptance criterion and work-plan status only; no additional implementation or live deployment. Preserve historical target misses, all correctness evidence and disclosed local-review notes. This is not a claim that the original target passed, that three uninstrumented runs met a new ceiling, or that larger/P2P workloads are performance-qualified. Operator retains merge authority.
+- `docs_updated`: docs/decision_log.md, docs/plans/slice-observation-performance.md
+- `related`: DEC-149, DEC-150

--- a/docs/plans/slice-observation-performance.md
+++ b/docs/plans/slice-observation-performance.md
@@ -169,7 +169,21 @@ lifecycle qualification. Neither suggestion is implemented or accepted here.
 
 The local review boundary was reached and summarized. DEC-151 now permits the
 existing PR workflow to proceed after tests; no fourth local review or new
-performance architecture changes are part of this stage. Cloud Codex: 0/3 so far.
+performance architecture changes are part of this stage.
+
+Cloud Codex round 1 found an EOF-to-flush boundary omission: an empty gathered
+read bypassed the append-loop destination check, permitting the final flush
+before the next full proof. The fix adds the full boundary immediately before
+that flush. Regression cases cover successful completion, detached destination
+and changed destination after a prior append; all three failed on the unfixed
+code because flush preceded the check. Failure cases must not flush, publish
+the output or create a receipt. This closes a missed transition in DEC-150's
+existing contract, not a new guard architecture. The 80.252-second physical
+measurement predates this added final check and has not been remeasured.
+Post-fix local validation: transfer/transaction/guarded-decoding suites 200 passed,
+11 skipped; native/FAT32 transaction and public-gate suites 91 passed. Repository
+lint and diff whitespace checks passed. Full remote CI must pass the pushed fix.
+Subsequent exact-head review state is kept in the ignored operator evidence.
 
 Operator evidence: `claudedocs/operator-scratch/slice-performance-2MUAJY/` in the
 primary checkout, including per-run JSON, profiler data, review prompts/state,

--- a/docs/plans/slice-observation-performance.md
+++ b/docs/plans/slice-observation-performance.md
@@ -1,0 +1,180 @@
+# Slice observation performance — implementation and qualification
+
+Operator authorized profiling-informed implementation, local Grok review and a
+fresh PR with cloud Codex, with performance proved before remote review. No
+Greptile under the explicit current three-day exclusion. Local Grok budget three
+passes total (including this design consultation); cloud Codex three rounds total.
+Operator retains merge authority. No service deployment or archive data repair.
+
+**Current acceptance (DEC-151):** operator accepted the measured 80.252-second
+result and instructed us to keep this implementation. The original timing gate
+below is historical and was not met; it no longer blocks this stage. No threading,
+file parallelism, further performance refactor or fourth local Grok pass. Complete
+ordinary tests and cloud Codex review under the existing three-round budget.
+
+## Measured baseline and acceptance
+
+Actual Snowflake/snowflake-arctic-embed-xs projection, NAS -> PRINTER FAT32,
+12 original files / 91,306,390 bytes: ~18 minutes; all output hashes correct.
+Worker CPU ~4s, parent >16min. Source-only profile:15192 attachment checks,
+75982 mount parses;157/204 instrumented seconds in parse_mounts. FAT2000rechecks
+perform26000mountparses;300unprofiledchecks cost5.175s.
+
+Actual PRINTER SanDisk3.2Gen1 serial00018510111520223455, UUID20A0-2FDD,
+negotiated5000Mbps. Three new-file90,272,656-byte64KiB-chunk writes from preloaded
+verified originals, file+directory fsync:3.318/7.091/6.203s (27.2/12.7/14.6MB/s).
+Independent read+SHA:0.757/0.748/0.781s. Payloads retained in
+/media/phaze/PRINTER1/modelark-performance-baseline-2MUAJY. No existingfileschanged.
+
+Original exploratory target: <=30s public preview/approve/start plus independent
+verification; hard initial qualification ceiling <=60s each of three fresh-root
+physical runs on this91MBfixture. Record actual source/cache state, runtime,
+link/mount and per-phase timing; don't claim a cold-NAS/device benchmark or use
+USB theoretical bandwidth as achievable throughput. This initially blocked cloud
+review; DEC-151 subsequently accepts the measured 80-second result. Preserve durable result,
+hashes, real guards, same worker policy, receipts and sibling isolation.
+
+## Design candidates (Grok consultation before implementation)
+
+Prefer the narrowest change that passes the measured gate:
+
+1. Reuse the immutable result of parsing the EXACT freshly read mount-table text.
+   Every existing caller still reads procfs on every check; changed bytes require
+   full reparse and validation, read failures still fail, malformed input isn't
+   cached as success. A bounded memo of pure parse results is NOT cached live
+   admission, identity or capacity, and must not skip source/destination IO guards.
+   Bound entries and maximum retained input size; preserve parse error semantics.
+   This central seam serves BoundTree, source and native/FAT observers uniformly.
+2. Re-profile. If still insufficient, distinguish codec transport cancellation/
+   authority polling from source guards around actual stored-byte reads and from
+   destination IO guards. Do not silently replace the existing generic callback
+   with a weaker one, remove actual read checks, or change every-read semantics.
+   Before broader callback changes, specify exact boundaries and test Stop,
+   detached/replaced media and completion ordering. No global time-based identity
+   cache, widened authority, or unqualified fast mode.
+
+## Verification
+
+- Tests prove repeated identical fresh reads avoid repeated parsing, changes
+  (including remove/re-add and malformed records) are observed immediately,
+  read errors propagate and cached immutable values can't be mutated.
+- Existing attachment-loss/backing/namespace/protected-role checks, native/FAT
+  publication, Stop/preclaim and codec worker lifetime tests must remain intact.
+- Bound memory retention and concurrent callers; no schema/seal/policy change.
+- Full suite and installed-wheel tests. Test installed code from cwd outside repo.
+- Three real public CLI copies to fresh USB child folders were independently
+  verified: one parser-only, one final-code uninstrumented, one final-code
+  instrumented. They are not three equivalent timing samples. NAS stays read-only.
+- Local Grok review of actual final patch, then fresh PR and @codex review on each
+  pushed head, at most3rounds; stop/summarize if exhausted. No Greptile tags.
+
+## Selected architecture (DEC-149, DEC-150)
+
+Local Grok accepted both designs and the final actual code in three total passes.
+Its performance refusal against the original target remains historical evidence;
+DEC-151 records the operator's subsequent acceptance, not a new Grok verdict.
+
+- Pure parser memo: two entries; exact built-in strings up to 262,144 characters;
+  larger inputs use the unchanged parser. No live observation is cached.
+- Explicit `FencedSources.open_polled(candidate, poll)` separates the caller's
+  attempt/Stop/journal-head checks from destination storage checks. Source
+  attachment checks and every codec callback remain unchanged. Existing
+  `open_checked` callers keep their full callback behavior.
+- `Session._poll` contains the existing authority and journal checks only.
+  `_boundary` adds the unchanged destination check. Destination detachment during
+  a source-only wait may be detected later, but every subsequent destination
+  access still requires its full current proof. Immediate destination-unplug
+  reporting during an idle worker wait is not promised; Stop/source guards stay.
+- A session-owned buffer gathers short reads up to the already-requested 1 MiB
+  write quantum. It polls before/after each read, including EOF, copies each
+  piece, and is never reused or mutated after returning it. The previous quantum
+  is released before gathering another. At most a bounded quantum plus an input
+  piece and allocator overhead are retained; no whole-file buffer or changed
+  codec envelope. Invalid binary reads refuse without relabeling callback errors.
+- RAM-buffered bytes are not counted as disk allocation. The full destination
+  boundary, parent authentication, append/fsync, ownership accounting, digest,
+  fault point, final preparation and publication ordering remain intact.
+
+## Qualification record
+
+Parser-only candidate:
+
+- Focused source and installed-wheel tests: 57 passed; lint passed.
+- Installed Slice transaction/guard/FAT observer suite: 295 passed, 11 skipped.
+- FAT 2,000 rechecks: 18.106s instrumented (was 74.239s); 300 uninstrumented:
+  1.740s (was 5.175s). Source-only decoding: 49.579s instrumented (was 203.767s),
+  90,272,656 original bytes and SHA verified. 15,206 source attachment callbacks
+  still ran; shared parser cache recorded one miss and 105,967 hits overall.
+- Physical run 1: 395.648s total = preview 0.541 + approve 0.429 + start 394.419
+  + independent verification 0.259. All 12 originals and exact receipts passed;
+  **performance gate failed**. A sandbox test run overlapped its initial portion
+  and was stopped, so this is not a clean isolated throughput benchmark.
+- The sandbox full suite was interrupted at 38 failed / 1,216 passed / 10 skipped
+  after socket EPERM failures. It is not a passing suite; host-permission rerun
+  is required. No code relaxation was made for the sandbox.
+
+Second candidate: authority/destination separation and bounded output gathering.
+New polling/quantum regressions: 19 passed; existing transaction/fault tests:
+196 passed in the same run before correction of one new journal-test assertion.
+Physical run 2 (unprofiled) passed correctness in **80.252s**: preview 0.517,
+approve 0.407, start 79.069, independent verification 0.259. This is about 13x
+faster than the original approximate 18-minute run, but **missed the original gate**.
+DEC-151 accepts this result without further optimization. The first permitted
+full suite was stopped at the operator's discussion request: 2,994 passed,
+16 skipped, no failures, incomplete. The fresh permitted CI-equivalent rerun
+completed: **3,722 passed, 28 skipped, 5 deprecation warnings in 673.35s**
+(`pytest -q --ignore=tests/test_e2e_portal.py`). Repository-wide
+`ruff check modelark scripts tests` and `git diff --check` passed.
+Local Grok code review is complete.
+
+Physical run 3 was instrumented, not an acceptance timing: 110.786s total,
+all hashes/receipts correct. Full Start profile: 17,629 source callbacks / 54.138s
+in attachment checks; 2,606 FAT live checks / 29.560s; 145,517 fresh procfs reads /
+23.329s; 862,817 libc binding constructions / 14.299s; 244,430 SQLite executes /
+7.094s; 138 fsyncs / 7.525s. Cumulative times overlap and instrumentation changes
+cost: do not sum these or subtract them directly from the unprofiled result.
+Profile retains the unchanged actual-source-read guards and normalized appends.
+The tested polling/gathering wheel SHA-256 is
+`ad24d11f7012453fd0758c7dfc4b26f955603daa85d0efd90aed1011a90c1bdf`;
+the later source change to its `_poll` docstring is nonfunctional.
+
+## Further performance ideas (not selected for this stage)
+
+The common cause is repeating a complete observation at nested internal callback
+layers, not excessive codec CPU or USB link speed. A possible next bounded stage
+would give actual stored-byte reads, buffered decoder transport and destination
+I/O distinct guard owners, using the existing source/representation/delivery
+separation. Preserve fresh before/after proof for every actual source read and
+proof before accepting decoded output; do not time-cache hardware evidence.
+Any change to source-unplug responsiveness during an idle decoder wait must be
+explicitly specified and tested, not silently weakened. Separately, investigate
+reusing process-local libc call bindings (not syscall results) to eliminate
+wrapper construction. These are proposals, not qualifications or shipped fixes.
+The operator elected to keep the current result instead. File-level parallelism
+was also discussed, not implemented; it would require coordinated journal,
+allocation, fencing and aggregate decoder RAM ownership.
+
+The third local Grok pass **accepted the supplied code diff/tests, not performance**.
+Nonblocking notes: per-call mutable buffers rely on trusted append ports not
+mutating them (both current ports use memoryview only for writing); authority
+polls remain duplicated; unchecked legacy sources now receive EOF liveness
+checks; buffer-discard and exact-error tests could be more precise. The changed
+fault granularity is one checkpoint per gathered append, not per short read.
+
+Do not adopt Grok's suggested larger source reads on its stated inference:
+17,629 callbacks are not 17,629 actual reads. The worker performed 1,148 bounded
+input reads; nested wrappers/polls explain the amplification. Its suggestion to
+retain mountinfo descriptors would also need explicit namespace/freshness and
+lifecycle qualification. Neither suggestion is implemented or accepted here.
+
+The local review boundary was reached and summarized. DEC-151 now permits the
+existing PR workflow to proceed after tests; no fourth local review or new
+performance architecture changes are part of this stage. Cloud Codex: 0/3 so far.
+
+Operator evidence: `claudedocs/operator-scratch/slice-performance-2MUAJY/` in the
+primary checkout, including per-run JSON, profiler data, review prompts/state,
+and qualification harness. USB outputs use fresh `modelark-observation-2MUAJY-N`
+children under `/media/phaze/PRINTER1`; NAS `/mnt/drive-00` remains read-only.
+No cache eviction was forced: these are attended workflow timings, not cold-NAS
+or sustained-device bandwidth claims. The initial parser-only wheel is retained
+under `/tmp/modelark-observation-wheel.Be0Mtf/parser-only/`.

--- a/modelark/slice/host_observation.py
+++ b/modelark/slice/host_observation.py
@@ -5,6 +5,7 @@ This is NOT attachment confinement: destination/archive BoundTree roots remain n
 IO failures stay OSError for the caller's attachment-aware classification boundary.
 """
 from dataclasses import dataclass
+from functools import lru_cache
 import os
 from pathlib import Path
 import re
@@ -50,7 +51,29 @@ class Mount:
     source: str
 
 
+_MOUNT_CACHE_MAX_CHARS = 262144
+
+
 def parse_mounts(text):
+    """Interpret fresh mountinfo text, never cache the observation itself.
+
+    Only exact built-in strings can be keys. Bound retained inputs as well as
+    entry count; unusually large tables still receive the same full validation.
+    Callers must continue reading procfs and checking live descriptors each time.
+    """
+    if type(text) is str and len(text) <= _MOUNT_CACHE_MAX_CHARS:
+        return _cached_mounts(text)
+    return _parse_mounts(text)
+
+
+@lru_cache(maxsize=2)
+def _cached_mounts(text):
+    # Successful tuples contain only frozen Mount records and immutable fields.
+    # Exceptions are not cached; changed/malformed input cannot reuse a proof.
+    return _parse_mounts(text)
+
+
+def _parse_mounts(text):
     result = []
     try:
         for line in proc_lines(text):

--- a/modelark/slice/sources.py
+++ b/modelark/slice/sources.py
@@ -48,6 +48,17 @@ class FencedSources:
             yield result
 
     @contextmanager
+    def open_polled(self, candidate, poll):
+        """Poll caller authority without destination I/O while reading/decoding.
+
+        Source guards/fences are unchanged. The consumer must perform full
+        destination checks before its next destination access; destination loss
+        during a source-only wait is not promised immediate detection here.
+        """
+        with self._open(candidate, check=poll) as result:
+            yield result
+
+    @contextmanager
     def _open(self, candidate, *, check=None, inspect=False, artifact=None):
         def identity(drive):
             return FenceIdentity(drive.fs_uuid, drive.annex_uuid, drive.serial,

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -391,10 +391,14 @@ class Session:
             if getattr(self.plan, "session_only", False):
                 self.destination.end_session()
 
-    def _boundary(self):
+    def _poll(self):
+        """Session liveness without destination I/O, for source/codec callbacks."""
         head = self.authority.boundary()
         if head != self.head:
             raise TransferRefusal("JOURNAL_CORRUPT", "journal changed outside its fenced writer")
+
+    def _boundary(self):
+        self._poll()
         self.destination.check(self.plan.destination, self._allocated_bytes, self._required_bytes)
 
     def _check(self):
@@ -559,6 +563,26 @@ class Session:
             self._verified_files.add(op["token"])
         return op
 
+    def _read_chunk(self, stream):
+        """Gather short reads into the existing 1 MiB destination-write quantum.
+
+        Reader-owned source guards still bracket each actual read. Polls here
+        guard authority, including EOF, but perform no destination accounting.
+        The returned buffer is owned by this call and is never reused/mutated.
+        """
+        data = bytearray()
+        while len(data) < 1024 * 1024:
+            remaining = 1024 * 1024 - len(data)
+            self._poll()
+            piece = stream.read(remaining)
+            self._poll()
+            if not isinstance(piece, bytes) or len(piece) > remaining:
+                raise TransferRefusal("SOURCE_READ_FAILED", "source violated bounded binary read")
+            if not piece:
+                break
+            data.extend(piece)
+        return data
+
     def _write(self, op, stream, source=None):
         path, temp, kind = op["path"], op["temporary"], op["kind"]
         self._check()
@@ -576,7 +600,7 @@ class Session:
         self._refresh_parent(temp)
         self._fault("temporary_created" if kind == "file" else kind + "_created")
         digest, size = hashlib.sha256(), 0
-        while data := stream.read(1024 * 1024):
+        while data := self._read_chunk(stream):
             self._boundary()
             self._check_parents(temp)
             size += len(data)
@@ -587,6 +611,7 @@ class Session:
             digest.update(data)
             # Intent and ownership certificate authenticate actual in-flight allocation on recovery.
             self._fault("chunk_written" if kind == "file" else kind + "_chunk_written")
+            del data  # Do not retain the previous quantum while gathering the next.
         if size != op["size"] or digest.hexdigest() != op["sha"]:
             raise TransferRefusal("SOURCE_DIGEST_MISMATCH")
         self.destination.flush(temp)
@@ -608,8 +633,10 @@ class Session:
         errors = []
         for source in artifact.sources:
             try:
+                polled = getattr(self.sources, "open_polled", None)
                 checked = getattr(self.sources, "open_checked", None)
-                context = (checked(source, self._boundary) if checked is not None
+                context = (polled(source, self._poll) if polled is not None else
+                           checked(source, self._boundary) if checked is not None
                            else self.sources.open(source))
                 with context as (snapshot, stream):
                     if not _same_source(artifact, source, snapshot):

--- a/modelark/slice/transaction.py
+++ b/modelark/slice/transaction.py
@@ -614,6 +614,7 @@ class Session:
             del data  # Do not retain the previous quantum while gathering the next.
         if size != op["size"] or digest.hexdigest() != op["sha"]:
             raise TransferRefusal("SOURCE_DIGEST_MISMATCH")
+        self._boundary()  # EOF is source-only work; recheck before destination flush.
         self.destination.flush(temp)
         self._fault(kind + "_flushed")
         op = self._record(dict(op, source=source), "prepared")

--- a/tests/test_slice_guarded_decoding.py
+++ b/tests/test_slice_guarded_decoding.py
@@ -323,7 +323,8 @@ def test_frame_bounds_come_from_shared_address_space_envelope():
 
 
 @pytest.mark.parametrize("outcome", ["complete", "stop", "unplug", "destination"])
-def test_actual_fenced_archive_reader_reaps_child_before_fence_release(archive, attachment, monkeypatch, outcome):
+@pytest.mark.parametrize("opener", ["open_checked", "open_polled"])
+def test_actual_fenced_archive_reader_reaps_child_before_fence_release(archive, attachment, monkeypatch, outcome, opener):
     from modelark import drive_fence
     from modelark.drive_identity import FenceIdentity
     from modelark.slice import domain as d
@@ -375,7 +376,7 @@ def test_actual_fenced_archive_reader_reaps_child_before_fence_release(archive, 
     sources = FencedSources(path, LocalArchiveReader({"drive-a": root}, observer=observer,
                                                      policy=qualified_policy()))
     def consume():
-        with sources.open_checked(candidate, check) as (_, source):
+        with getattr(sources, opener)(candidate, check) as (_, source):
             data = source.read(1)
             if outcome == "destination":
                 raise error

--- a/tests/test_slice_mount_parse_cache.py
+++ b/tests/test_slice_mount_parse_cache.py
@@ -1,0 +1,145 @@
+"""Pure syntax reuse must not turn a fresh attachment check into a cached one."""
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from modelark.slice import host_observation as host, linux
+from modelark.slice.io_errors import ProbeFailure
+from modelark.slice.transaction import TransferRefusal
+
+ROW = '12 1 8:1 / /mnt/test rw - ext4 /dev/test rw\n'
+
+
+@pytest.fixture(autouse=True)
+def isolated_cache():
+    host._cached_mounts.cache_clear()
+    yield
+    host._cached_mounts.cache_clear()
+
+
+def test_identical_fresh_reads_reuse_only_parse(monkeypatch):
+    reads, parses = [], []
+    original = host._parse_mounts
+
+    def read(path):
+        assert str(path) == '/proc/self/mountinfo'
+        reads.append(path)
+        return ROW.encode()
+
+    def parse(text):
+        parses.append(text)
+        return original(text)
+
+    monkeypatch.setattr(Path, 'read_bytes', read)
+    monkeypatch.setattr(host, '_parse_mounts', parse)
+    for _ in range(5):
+        assert linux._mount_ids() == frozenset({12})
+    assert len(reads) == 5 and parses == [ROW]
+
+
+@pytest.mark.parametrize('changed', [
+    ROW.replace('12 1', '13 1'), ROW.replace('8:1', '8:2'),
+    ROW.replace('/mnt/test', '/mnt/other'), ROW.replace('/dev/test', '/dev/other'),
+    ROW.replace(' rw -', ' ro -'), ROW.replace(' rw\n', ' ro\n'),
+    ROW + '51 1 0:4 net:[4026533226] /run/netns/example rw - nsfs nsfs rw\n',
+])
+def test_every_changed_byte_is_a_new_parse(changed):
+    first = host.parse_mounts(ROW)
+    assert host.parse_mounts(changed) != first
+    assert host._cached_mounts.cache_info().misses == 2
+    assert host.parse_mounts(ROW) is first
+
+
+@pytest.mark.parametrize('malformed', ['', 'garbage', ROW + ROW,
+                                      ROW.replace('/mnt/test', '/mnt/\\000')])
+def test_invalid_inventory_never_reuses_warm_success(malformed):
+    valid = host.parse_mounts(ROW)
+    for _ in range(2):
+        with pytest.raises(TransferRefusal):
+            host.parse_mounts(malformed)
+    assert host._cached_mounts.cache_info().currsize == 1
+    assert host._cached_mounts.cache_info().misses == 3
+    assert host.parse_mounts(ROW) is valid
+
+
+def test_read_error_after_warm_cache_still_refuses(monkeypatch):
+    host.parse_mounts(ROW)
+    error = OSError('procfs read denied')
+
+    def fail(path):
+        raise error
+
+    monkeypatch.setattr(Path, 'read_bytes', fail)
+    with pytest.raises(ProbeFailure) as caught:
+        linux._mount_ids()
+    assert caught.value.__cause__ is error
+    assert host._cached_mounts.cache_info().hits == 0
+
+
+def test_detached_inventory_latches_even_when_old_text_returns(tmp_path, monkeypatch):
+    # Real descriptor identities; only procfs text is a synthetic attachment view.
+    with linux.BoundTree(tmp_path) as probe:
+        retained = probe.mount_id
+    attached = ROW.replace('12 1', f'{retained} 1')
+    detached = ROW.replace('12 1', f'{retained + 1} 1')
+    current = attached
+    monkeypatch.setattr(linux, 'read_fs_text', lambda path: current)
+    with linux.BoundTree(tmp_path) as tree:
+        current = detached
+        with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
+            tree.check()
+        current = attached
+        assert host.parse_mounts(current)[0].mount_id == retained
+        with pytest.raises(TransferRefusal, match='WAITING_DESTINATION'):
+            tree.check()
+
+
+def test_cached_result_is_immutable():
+    mounts = host.parse_mounts(ROW)
+    with pytest.raises(TypeError):
+        mounts[0] = mounts[0]
+    with pytest.raises(FrozenInstanceError):
+        mounts[0].path = '/changed'
+    with pytest.raises(AttributeError):
+        mounts[0].options.add('ro')
+    assert host.parse_mounts(ROW) is mounts
+
+
+def test_entry_count_and_input_retention_are_bounded():
+    first = host.parse_mounts(ROW)
+    host.parse_mounts(ROW.replace('12 1', '13 1'))
+    host.parse_mounts(ROW.replace('12 1', '14 1'))
+    assert host._cached_mounts.cache_info().currsize == 2
+    assert host.parse_mounts(ROW) is not first  # LRU eviction, same semantics.
+    limit = host._MOUNT_CACHE_MAX_CHARS
+    exact = ROW.replace('/mnt/test', '/' + 'x' * (limit - len(ROW) + 8))
+    assert len(exact) == limit
+    assert host.parse_mounts(exact) is host.parse_mounts(exact)
+    oversized = exact + '\n'
+    before = host._cached_mounts.cache_info()
+    one, two = host.parse_mounts(oversized), host.parse_mounts(oversized)
+    assert one == two and one is not two
+    assert host._cached_mounts.cache_info() == before
+    with pytest.raises(TransferRefusal):
+        host.parse_mounts(oversized + 'malformed')
+    assert host._cached_mounts.cache_info() == before
+
+
+def test_string_subclass_never_uses_custom_cache_equality():
+    class StrangeText(str):
+        def __hash__(self):
+            pytest.fail('subclass used as cache key')
+
+    one, two = host.parse_mounts(StrangeText(ROW)), host.parse_mounts(StrangeText(ROW))
+    assert one == two and one is not two
+    assert host._cached_mounts.cache_info().currsize == 0
+
+
+def test_concurrent_different_texts_cannot_cross_contaminate():
+    rows = [ROW.replace('12 1', f'{number} 1') for number in range(12, 32)] * 5
+    with ThreadPoolExecutor(max_workers=4) as workers:
+        values = list(workers.map(host.parse_mounts, rows))
+    assert [value[0].mount_id for value in values] == [int(row.split()[0]) for row in rows]
+    assert host._cached_mounts.cache_info().currsize <= 2

--- a/tests/test_slice_transfer_quantum.py
+++ b/tests/test_slice_transfer_quantum.py
@@ -162,3 +162,68 @@ def test_checked_only_source_retains_full_destination_callback(setup):
     with start(setup) as session:
         assert session.run().state == 'complete'
     assert called
+
+
+@pytest.mark.parametrize('condition', ['complete', 'detached', 'changed'])
+def test_final_eof_rechecks_destination_before_flush(setup, condition):
+    t, store, plan, tx, dest, sources = setup
+    appends, after_eof = [], []
+    append, check, flush = dest.append, dest.check, dest.flush
+
+    def appended(path, token, data):
+        if sources.fenced:
+            appends.append(bytes(data))
+        return append(path, token, data)
+
+    def checked(*args):
+        if after_eof:
+            after_eof.append('check')
+        return check(*args)
+
+    def flushed(path):
+        if after_eof:
+            after_eof.append('flush')
+        return flush(path)
+
+    dest.append, dest.check, dest.flush = appended, checked, flushed
+
+    @contextmanager
+    def polled(candidate, poll):
+        sources.fenced = True
+
+        class FinalEOF(io.BytesIO):
+            def read(self, size):
+                data = super().read(size)
+                # The first gather includes a short tail and EOF. Change the
+                # destination only at the next empty gather, after its append.
+                if not data and appends:
+                    assert not after_eof
+                    after_eof.append('eof')
+                    if condition == 'detached':
+                        dest.available = False
+                    elif condition == 'changed':
+                        dest.changed = True
+                return data
+
+        try:
+            yield sources.snapshot, FinalEOF(DATA)
+        finally:
+            sources.fenced = False
+
+    sources.open_polled = polled
+    with start(setup) as session:
+        if condition == 'changed':
+            with pytest.raises(TransferRefusal) as caught:
+                session.run()
+            assert caught.value.code == 'DESTINATION_CHANGED'
+        else:
+            expected = 'complete' if condition == 'complete' else 'waiting_destination'
+            assert session.run().state == expected
+    assert appends == [DATA]
+    assert after_eof[:2] == ['eof', 'check']
+    if condition == 'complete':
+        assert after_eof[2] == 'flush'
+    else:
+        assert 'flush' not in after_eof
+        assert not (dest.root / 'models/org/model/model.safetensors').exists()
+    assert (store.receipt(tx) is not None) == (condition == 'complete')

--- a/tests/test_slice_transfer_quantum.py
+++ b/tests/test_slice_transfer_quantum.py
@@ -1,0 +1,164 @@
+"""Source polling must not become destination I/O; bounded writes retain guards."""
+# ruff: noqa: F811 -- pytest fixtures imported from the disposable transaction suite
+from contextlib import contextmanager
+import io
+from types import SimpleNamespace
+
+import pytest
+
+from modelark.slice.transaction import Session, TransferRefusal
+from test_slice_transaction import DATA, api, setup, start  # noqa: F401
+
+
+def bare(poll=lambda: None):
+    session = object.__new__(Session)
+    session._poll = poll
+    return session
+
+
+@pytest.mark.parametrize('size', [0, 1, (1 << 20) - 1, 1 << 20, (1 << 20) + 17])
+def test_gather_short_reads_bounded_and_owned(size):
+    checks, reads = [], []
+
+    class Short(io.BytesIO):
+        def read(self, size):
+            assert 0 < size <= 1 << 20
+            reads.append(size)
+            return super().read(min(size, 4093))
+
+    stream = Short(b'x' * size)
+    session = bare(lambda: checks.append(True))
+    chunks = []
+    while chunk := session._read_chunk(stream):
+        chunks.append(chunk)
+    assert b''.join(chunks) == b'x' * size
+    assert all(len(chunk) == 1 << 20 for chunk in chunks[:-1])
+    assert len(checks) == 2 * len(reads)
+    assert len({id(chunk) for chunk in chunks}) == len(chunks)
+
+
+@pytest.mark.parametrize('invalid', [None, 'text', memoryview(b'x'), b'x' * ((1 << 20) + 1)])
+def test_bad_read_contract_refuses(invalid):
+    with pytest.raises(TransferRefusal, match='SOURCE_READ_FAILED'):
+        bare()._read_chunk(SimpleNamespace(read=lambda size: invalid))
+
+
+@pytest.mark.parametrize('where', ['before', 'read', 'after', 'eof'])
+def test_gather_preserves_exception_identity_and_discards_buffer(where):
+    error = OSError('authority or source failure')
+    calls = []
+
+    def poll():
+        calls.append('poll')
+        if where == 'before' or where == 'after' and len(calls) == 3:
+            raise error
+        if where == 'eof' and len(calls) == 6:
+            raise error
+
+    def read(size):
+        calls.append('read')
+        if where == 'read':
+            raise error
+        return b'a' if len(calls) == 2 else b''
+
+    with pytest.raises(OSError) as caught:
+        bare(poll)._read_chunk(SimpleNamespace(read=read))
+    assert caught.value is error
+
+
+def test_poll_is_only_authority_and_exact_head_check():
+    session = object.__new__(Session)
+    calls = []
+    session.head = (1, 'head')
+    session.authority = SimpleNamespace(boundary=lambda: calls.append('authority') or (1, 'head'))
+    session.destination = SimpleNamespace(check=lambda *args: pytest.fail('poll touched destination'))
+    session._poll()
+    assert calls == ['authority']
+    session.head = (2, 'changed')
+    with pytest.raises(TransferRefusal, match='JOURNAL_CORRUPT'):
+        session._poll()
+
+
+@pytest.mark.parametrize('condition', ['complete', 'stop', 'destination', 'journal'])
+def test_polled_short_reads_keep_full_check_before_append(setup, condition):
+    t, store, plan, tx, dest, sources = setup
+    appends, polls, during_read = [], [], []
+    append, check = dest.append, dest.check
+
+    def checked(*args):
+        assert not during_read, 'destination census inside a source read'
+        polls.append('destination')
+        return check(*args)
+
+    def appended(path, token, data):
+        if sources.fenced:
+            assert polls and polls[-1] == 'destination'
+            appends.append(bytes(data))
+        return append(path, token, data)
+
+    dest.check, dest.append = checked, appended
+
+    @contextmanager
+    def polled(candidate, poll):
+        sources.fenced = True
+
+        class Short(io.BytesIO):
+            def read(self, size):
+                during_read.append(True)
+                try:
+                    poll()
+                    data = super().read(min(size, 1))
+                    if data:
+                        if condition == 'stop':
+                            store.request_stop(tx)
+                        elif condition == 'destination':
+                            dest.changed = True
+                        elif condition == 'journal':
+                            with store._connection() as con:
+                                con.execute('UPDATE transactions SET journal_seq=journal_seq+1 WHERE id=?', (tx,))
+                    poll()
+                    return data
+                finally:
+                    during_read.pop()
+
+        try:
+            yield sources.snapshot, Short(DATA)
+        finally:
+            sources.fenced = False
+
+    sources.open_polled = polled
+    sources.open_checked = lambda *args: pytest.fail('polled capability ignored')
+    with start(setup) as session:
+        if condition in {'destination', 'journal'}:
+            with pytest.raises(TransferRefusal, match='DESTINATION_CHANGED|JOURNAL_CORRUPT'):
+                session.run()
+        else:
+            assert session.run().state == ('complete' if condition == 'complete' else 'stopped')
+    assert appends == ([DATA] if condition == 'complete' else [])
+    if condition == 'journal':
+        with pytest.raises(TransferRefusal, match='JOURNAL_CORRUPT'):
+            store.receipt(tx)
+        with store._connection(write=False) as con:
+            assert con.execute("SELECT count(*) FROM journal WHERE tx=? AND event='receipt'", (tx,)).fetchone()[0] == 0
+    else:
+        assert (store.receipt(tx) is not None) == (condition == 'complete')
+
+
+def test_checked_only_source_retains_full_destination_callback(setup):
+    t, store, plan, tx, dest, sources = setup
+    opening = sources.open
+    called = []
+
+    @contextmanager
+    def checked(candidate, check):
+        before = len(dest.trace)
+        check()
+        assert len(dest.trace) > before and dest.trace[-1][0] == 'check'
+        called.append(True)
+        with opening(candidate) as result:
+            yield result
+
+    sources.open_checked = checked
+    with start(setup) as session:
+        assert session.run().state == 'complete'
+    assert called


### PR DESCRIPTION
## Summary

Reduce repeated parent-side observation work in Slice without changing the codec
policy, actual-source-read guards, archive data or durable publication contract.

- Memoize only parsing of exact freshly read mountinfo strings (two entries,
  bounded input retention, immutable results). Every procfs read still happens.
- Separate attempt/Stop/journal polling from destination I/O through an explicit
  `open_polled` source capability; preserve the conservative `open_checked` fallback.
- Gather short decoded reads into the existing requested 1 MiB append quantum;
  retain full destination checks, append/fsync, accounting, hashing and publication.

Destination detachment during source-only waits is detected before the next
destination access, not promised immediately on every idle decoder poll. Source
attachment checks and Stop/attempt/journal checks retain their existing boundaries.

## Physical result and operator acceptance

Real read-only NAS -> USB FAT32, 12 files / 91,306,390 original bytes:

| Candidate | Public workflow + independent verification |
| --- | ---: |
| Original | approximately 18 minutes |
| Parser-only | 395.648 seconds |
| This implementation | **80.252 seconds** |

All output sizes/SHA-256 values and exact USB/host receipts/sealed plans matched.
A further instrumented full run also passed correctness (110.786s; not an
acceptance timing). USB link negotiated 5 Gbit/s; separate preloaded 90 MB
write+flush measurements were 3.3–7.1 seconds. No cold-cache/sustained-throughput
claim. Outputs were new child folders; existing USB files and NAS payloads unchanged.

The original <=30s aim / <=60s-per-run target **was not met**. After reviewing the
measurements and parallelism tradeoffs, the operator explicitly accepted 80s and
asked to keep the implementation (DEC-151). No further optimization or concurrency
is included. No production service deployment or live catalog mutation.

## Review and validation

- Local Grok CLI: **3/3 passes used**: two design acceptances, final supplied code
  diff/tests accepted. Its historical performance refusal is not relabeled as an
  acceptance; DEC-151 is the subsequent operator decision.
- Residual nonblocking review notes: duplicated authority polling, trusted-port
  reliance on not mutating owned buffers, and opportunities for more exact test
  assertions. No fourth local pass or unreviewed performance fix.
- Focused parser tests: 57 passed in checkout and installed wheel.
- Parser-only installed Slice lifecycle/FAT observation suite: 295 passed, 11 skipped.
- New polling/quantum regressions: 19 passed; unchanged transaction/fault tests passed.
- Repository-wide `ruff check modelark scripts tests` and diff whitespace checks passed.
- Full CI-equivalent suite (`pytest -q --ignore=tests/test_e2e_portal.py`):
  **3,722 passed, 28 skipped**, 5 deprecation warnings in 673.35s. This fresh
  host-permitted run supersedes the incomplete interrupted test attempts.

Decisions: DEC-149, DEC-150, DEC-151 in `docs/decision_log.md`.
Scope, measured evidence, limitations and review notes:
`docs/plans/slice-observation-performance.md`.

Cloud Codex review: up to three scoped rounds. Greptile excluded under the
operator's current quota instruction. Operator retains merge authority.
