### PR TITLE
release: prepare 0.4.0 Public Beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,28 @@ jobs:
       - name: Static correctness checks
         run: ruff check modelark scripts tests
 
-      - name: Build distribution wheel
+      - name: Build source archive and wheel from that archive
         if: matrix.python-version == '3.12'
-        run: python -m pip wheel . --no-deps --wheel-dir /tmp/modelark-wheel
+        run: python -m build --outdir /tmp/modelark-wheel
+
+      - name: Check source archive includes public documentation and linked assets
+        if: matrix.python-version == '3.12'
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import tarfile
+          archives = list(Path('/tmp/modelark-wheel').glob('modelark-*.tar.gz'))
+          assert len(archives) == 1, archives
+          required = [Path(p) for p in ('README.md', 'CHANGELOG.md', 'SECURITY.md', 'CODE_OF_CONDUCT.md')]
+          required += [p for folder in ('docs', 'contributing') for p in Path(folder).rglob('*') if p.is_file()]
+          with tarfile.open(archives[0]) as archive:
+              prefix = archives[0].name.removesuffix('.tar.gz') + '/'
+              for path in required:
+                  member = archive.extractfile(prefix + path.as_posix())
+                  assert member is not None and member.read() == path.read_bytes(), path
+              assert not any('/claudedocs/' in name for name in archive.getnames())
+          print(f'Validated {len(required)} public documentation files and assets in source archive')
+          PY
 
       - name: Smoke-test the installed wheel and packaged resources
         if: matrix.python-version == '3.12'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) wh
 
 ## Unreleased
 
-## 0.4.0 - 2026-09-11
+## 0.4.0 - Unreleased
 
 ModelArk 0.4.0 begins the **Public Beta** line. Linux storage operations remain
 operator-attended, and Beta is not a promise of stable pre-1.0 interfaces or support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) wh
 
 ## Unreleased
 
+## 0.4.0 - 2026-09-11
+
+ModelArk 0.4.0 begins the **Public Beta** line. Linux storage operations remain
+operator-attended, and Beta is not a promise of stable pre-1.0 interfaces or support
+for arbitrary filesystems and models. See [release notes](docs/releases/v0.4.0.md).
+
+### Added
+
+- Usable Slice preview, exact approval, original-byte folder delivery and verified
+  receipts, with qualified native ext4 authenticated resume and a separate,
+  narrowly admitted one-attempt FAT32 USB profile. Existing sibling files stay outside
+  the owned output folder; Slice does not fetch missing archive content.
+- Guarded whole-file ZipNN and StreamZNN decoding, sealed resource admission and
+  preflight, shared with production compression/canary and legacy original-byte readers.
+- Explicit backup/rehearsal-first repair of proven archive serial-evidence mismatches,
+  preserving optional serial registration, historical evidence and archive bytes.
+
+### Changed
+
+- Package/runtime version, README and development-status metadata now identify Beta.
+- Application launches use host-local singleton exclusion; attachment-bound source
+  observations follow qualified partition-to-parent identity rather than inferring it.
+- Pure mount parsing is memoized only for exact freshly read text; authority polling
+  is separated from destination checks, and short reads gather into bounded writes.
+
+### Fixed
+
+- Source archives now include the changelog, release notes and operator documentation.
+- Slice rechecks destination authority and identity after EOF before the final flush.
+- Source preflight, Stop handling, guarded worker lifetime and refusal reporting retain
+  their safety boundaries across direct, native and FAT32 delivery.
+
+### Compatibility
+
+- Catalog layout remains v7; readers accept catalog versions 7 and 8. Only explicit
+  serial repair raises an existing catalog's reader floor to 8; ordinary open does not.
+- Private Slice state version 8 and versioned approval envelopes are independent of
+  catalog versions. Back up private state before upgrading; older readers may refuse
+  new records. Do not lower version stamps or reinterpret existing approvals.
+
 ## 0.3.3 - 2026-09-03
 
 ModelArk 0.3.3 is an application-only safety patch over schema v7. It makes an interrupted exact

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CHANGELOG.md SECURITY.md
+recursive-include docs *.md
+recursive-include contributing *.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include CHANGELOG.md SECURITY.md
-recursive-include docs *.md
+include CHANGELOG.md SECURITY.md CODE_OF_CONDUCT.md
+recursive-include docs *.md *.png *.svg *.json
 recursive-include contributing *.md

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <p align="center">
   <a href="https://github.com/Auspex-Aerie/modelark/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Auspex-Aerie/modelark/actions/workflows/ci.yml/badge.svg"></a>
-  <a href="CHANGELOG.md#033---2026-09-03"><img alt="Release: v0.3.3 Public Alpha" src="https://img.shields.io/badge/release-v0.3.3%20Public%20Alpha-orange"></a>
+  <a href="docs/releases/v0.4.0.md"><img alt="Release: v0.4.0 Public Beta" src="https://img.shields.io/badge/release-v0.4.0%20Public%20Beta-blue"></a>
   <a href="pyproject.toml"><img alt="Python 3.10–3.12" src="https://img.shields.io/badge/python-3.10%E2%80%933.12-3776AB?logo=python&amp;logoColor=white"></a>
   <a href="docs/deployment.md"><img alt="Linux" src="https://img.shields.io/badge/platform-Linux-FCC624?logo=linux&amp;logoColor=black"></a>
   <a href="LICENSE"><img alt="Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
 </p>
 
-> **ModelArk 0.3.3 is a public alpha.** It is usable today as an operator-attended archive and
+> **ModelArk 0.4.0 is a public beta.** It is usable today as an operator-attended archive and
 > disaster-recovery system for open model artifacts. Storage work remains explicit and reviewable,
 > and interfaces can still change before 1.0.
 
@@ -35,8 +35,8 @@ Approval and execution are separate. Approving an exact placement never starts F
 | Install ModelArk on a new Linux host and create the first archive | [Fresh install and first archive](docs/getting-started.md) |
 | Operate plans, drives, Fill, verification, and restore | [Operating ModelArk](docs/operations.md) |
 | Preview and execute an attended direct-USB Slice | [Direct USB delivery and qualification limits](docs/usable-slice-direct.md) |
-| Project into a new ext4 or FAT32 folder (acceptance in progress) | [Folder workflow, safety limits and remaining gates](docs/usable-slice-folders.md) |
-| Upgrade a 0.2.0 or other pre-v7 catalog | [Upgrading ModelArk](docs/upgrading.md) |
+| Project into a new qualified ext4 or FAT32 folder | [Folder workflow, safety limits and evidence](docs/usable-slice-folders.md) |
+| Upgrade an existing installation, including pre-v7 catalogs | [Upgrading ModelArk](docs/upgrading.md) |
 | Install or update the supervised user service | [Deploying ModelArk](docs/deployment.md) |
 | Perform the stopped side-by-side provenance migration | [Live cutover procedure](docs/provenance-live-cutover.md) |
 
@@ -80,15 +80,24 @@ the detailed contracts.
 - **No automatic deletion of extras.** Reconciliation reports unclaimed content but does not adopt
   or remove it.
 
-## What changed in v0.3.3
+## What changed in v0.4.0
 
-Version 0.3.3 makes placement review recoverable. If a browser reload or disconnect interrupts an
-exact proposal review, the Fill page restores that same immutable draft and keeps Start disabled
-until it is approved or explicitly discarded. It retains the bounded replacement-drive workflow and
-schema v7; no catalog migration is required.
+The first Beta brings **Usable Slice**: preview a complete selected model set, approve its exact
+plan, then reconstruct and hash-check original files in a new output folder. Slice does not need
+to own the whole destination drive. Native ext4 supports authenticated resume; the narrowly admitted
+FAT32 USB profile is one-attempt and requires a new folder after an interrupted attempt.
 
-Read the [v0.3.3 release notes](docs/releases/v0.3.3.md) or the
-[changelog](CHANGELOG.md) for the complete patch record.
+- Shared guarded codec workers support both StreamZNN containers and whole-file ZipNN, with the
+  same resource-policy machinery used by compression/canary and original-byte readers.
+- Source reads use attachment-bound identity evidence; explicit backup-first serial repair handles
+  proven legacy mismatches without silently changing drive registration.
+- Slice avoids repeated mount-text parsing and unnecessary per-chunk destination work. A small
+  physical compressed-source transfer improved from roughly 18 minutes to 80 seconds; this is a
+  measured fixture result, not a general throughput guarantee. It predates the final EOF safety
+  recheck; the [release notes](docs/releases/v0.4.0.md#qualification-and-performance) give the limits.
+
+Read the [v0.4.0 release notes](docs/releases/v0.4.0.md), [upgrade and rollback guidance](docs/upgrading.md),
+and [changelog](CHANGELOG.md). Updating the application does not itself repair a catalog or start Fill.
 
 ## What changed in v0.3.0
 
@@ -124,9 +133,10 @@ That same boundary supports local delivery today and future peer transport:
 - **Peer-to-peer transport:** exchange sealed artifact sets while preserving evidence instead of
   treating successful transport as proof of usability.
 
-Attended physical FAT32 delivery passed using uncompressed archive sources; this does not qualify
-every compressed source, filesystem, desktop mount setup or model for functional loading.
-Compressed-source physical acceptance and guided destination onboarding remain incomplete.
+Attended physical FAT32 delivery passed for a raw-source set and a small compressed-source set,
+including original hashes and receipts. This does not qualify every compressed source, filesystem,
+desktop mount setup, power-loss scenario or model for functional loading. Guided destination
+onboarding remains incomplete; qualified FAT32 mount settings still need operator preparation.
 Scratch transfer and P2P transport remain future work—not shipped features.
 
 ## Project and support

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ModelArk is pre-1.0 and built in public.
 
-During alpha, security fixes target the latest reviewed `main`; include the exact commit in every
+During pre-1.0 development, including Beta, security fixes target the latest reviewed `main`; include the exact commit in every
 report. Older commits are not maintained as separate supported release lines.
 
 ModelArk has no Auspex-operated application backend. The portal binds only to loopback; Hub fetches

--- a/contributing/contributions.md
+++ b/contributing/contributions.md
@@ -1,7 +1,7 @@
 # Contributing to ModelArk
 
 ModelArk is built in public and pre-1.0 — bug reports, fixes, docs, and curation ideas are all
-welcome. Expect rough edges, and read the [0.3.3 status](../README.md#what-changed-in-v033) first.
+welcome. Expect rough edges, and read the [0.4.0 Beta status](../README.md#what-changed-in-v040) first.
 
 By taking part you agree to the canonical [Code of Conduct](../CODE_OF_CONDUCT.md).
 
@@ -77,7 +77,7 @@ project's narrative; skim it to understand *why* things are the way they are.
 
 ## Pull requests
 
-At this alpha stage the project moves quickly, so the smoothest way to contribute is a **fork PR** —
+At this beta stage the project moves quickly, so the smoothest way to contribute is a **fork PR** —
 carrying local changes tends to get hard to merge as things shift under you:
 
 1. **Fork** the repo and branch on your fork.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3160,3 +3160,14 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Acceptance criterion and work-plan status only; no additional implementation or live deployment. Preserve historical target misses, all correctness evidence and disclosed local-review notes. This is not a claim that the original target passed, that three uninstrumented runs met a new ceiling, or that larger/P2P workloads are performance-qualified. Operator retains merge authority.
 - `docs_updated`: docs/decision_log.md, docs/plans/slice-observation-performance.md
 - `related`: DEC-149, DEC-150
+
+### DEC-152: Move the next release line to 0.4 Beta after the Slice performance change lands
+- `id`: DEC-152
+- `date`: 2026-09-11
+- `status`: accepted
+- `triggered_by`: Operator stated that after the next change lands, ModelArk moves to 0.4 Beta, no longer Alpha, with README and Git release updates required.
+- `decision`: Make the release following PR #82 the 0.4 Beta line. Prepare synchronized release identity, Beta maturity labeling and release documentation after the current performance change lands; keep that release work separate from PR #82's in-progress review.
+- `rationale`: The operator is explicitly advancing the product's maturity designation. Version output, package metadata, public documentation and the Git release must agree rather than retaining the 0.3.3 public-alpha identity.
+- `impact`: Follow-up release checklist in claudedocs/HANDOFF.md covers README/badge, package and runtime versions, development-status classifier, changelog, release notes, upgrade guidance, release-identity tests, build verification, Git tag and GitHub release. Preserve supported-platform and operator-attended safety limits; future P2P work remains future work. This decision does not itself publish a release, merge PR #82, deploy a runtime or authorize live-data changes.
+- `docs_updated`: docs/decision_log.md, claudedocs/HANDOFF.md
+- `related`: DEC-083, DEC-091, DEC-095, DEC-151

--- a/docs/plans/release-0.4-beta.md
+++ b/docs/plans/release-0.4-beta.md
@@ -44,3 +44,9 @@ schema, executable policy, codec behavior, archive bytes or deployed service.
 
 No Git tag or release has been published by preparation of this file. If merge or
 publication authority is unclear at execution time, ask rather than infer it.
+
+Keep the prepared changelog's `0.4.0 - Unreleased` heading until publication has
+actually occurred. Record the actual publication date in the GitHub release;
+date the changelog in a subsequent reviewed documentation update. Do not invent
+a release date during preparation or add an unreviewed date-only commit to the
+verified tag target.

--- a/docs/plans/release-0.4-beta.md
+++ b/docs/plans/release-0.4-beta.md
@@ -1,0 +1,46 @@
+# 0.4 Beta release checklist
+
+Decision: DEC-152. Prerequisite PR #82 merged as
+`e3c8b84d480febeb9b9ca1c884d472daaf3705af`.
+
+## Release identity and scope
+
+Use package/runtime version **0.4.0**, Git tag **v0.4.0**, and title
+**ModelArk v0.4.0 — Public Beta**. Beta is the product maturity label and package
+development classifier; this does not introduce a `0.4.0b1` version. The GitHub
+release is marked **pre-release**, consistent with the pre-1.0 Beta designation.
+Do not backfill or move historical version tags.
+
+The release change synchronizes README, package/runtime metadata, release tests,
+changelog, release notes, upgrade instructions and current operator-guide status.
+Preserve historical release notes and ledger entries. It changes no catalog
+schema, executable policy, codec behavior, archive bytes or deployed service.
+
+## Before merge
+
+- Verify the version and Beta classifier agree in the checkout and built wheel;
+  check installed distribution metadata, CLI version and packaged public assets.
+- Run release/CLI regressions and repository lint; require full CI on the final head.
+- Review documentation links, evidence scope and independent catalog/private-state
+  compatibility. Do not promote a fixture result to universal hardware support.
+- Local Grok CLI up to three review/fix rounds for this release scope, then a fresh
+  PR with cloud Codex up to three rounds. No Greptile under the current exclusion.
+  Review each pushed head; do not reset counters per commit. Mutable counters and
+  outputs belong in the operator handoff, not status-only PR commits.
+- Ask the operator explicitly in bold to merge when current-head review and CI pass.
+
+## After the operator merges
+
+1. Verify the actual merge commit and a clean source tree; rebuild release wheel
+   and source archive from that commit. Recheck installed identity and artifacts;
+   record SHA-256 checksums. Never label a pre-merge artifact as a merge-commit build.
+2. Verify that `v0.4.0` is absent remotely. Create the annotated tag against the
+   verified release commit, never a moving branch name; never overwrite a tag.
+3. Publish the GitHub **pre-release** with the versioned release notes, tested
+   wheel/source archive and checksums; verify tag, target commit, title and assets.
+4. Record the release URL and exact artifact identities. Keep the existing runtime,
+   journals and data unchanged. PyPI publishing and live service rollout are separate
+   operations, not part of this release checklist's authority.
+
+No Git tag or release has been published by preparation of this file. If merge or
+publication authority is unclear at execution time, ask rather than infer it.

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,78 @@
+# ModelArk v0.4.0 — Public Beta
+
+The 0.4 line moves ModelArk from Alpha to **Beta** (DEC-152). It adds attended
+Usable Slice delivery and shared guarded codec handling to the existing catalog,
+archive, evidence and recovery workflows. Interfaces can still change before 1.0.
+
+## What you can do
+
+- Select an existing catalog model set, preview its complete required file closure,
+  approve that exact plan, and materialize original files in a **new folder**.
+  Slice need not own the whole destination filesystem, unlike a dedicated archive
+  drive. It does not download missing content or fill gaps from the network.
+- Use the qualified Linux ext4 folder profile with authenticated resume, or the
+  narrowly qualified direct-USB FAT32 folder profile with one consumed attempt
+  and no resume. Existing sibling files are outside the owned output tree.
+- Decode StreamZNN containers and whole-file ZipNN through guarded workers. Shared
+  resource admission is used by compression/canary and original-byte readers;
+  supported format detection and original hashes determine success, not filename
+  extensions or the assumption that each compressed frame fits RAM.
+- Inspect and explicitly repair proven historical source serial-evidence mismatches
+  under backup/rehearsal and stopped-writer gates. Registration remains serial-optional;
+  repair does not adopt a new disk or rewrite archive payloads.
+
+Approval never starts copying. A completed Slice verifies original-byte lengths,
+SHA-256, output layout and receipts; it does not certify model inference or turn
+an old location record into fresh verification of every archive copy.
+
+## Qualification and performance
+
+The attended raw-source FAT32 test delivered nine files / 377,615,574 bytes.
+A subsequent real compressed-source workflow delivered the twelve-file
+`Snowflake/snowflake-arctic-embed-xs` set / 91,306,390 original bytes from a
+read-only NAS archive to FAT32 USB. All original sizes/hashes and exact receipts
+matched. The optimized uninstrumented run took **80.252 seconds**, down from
+roughly 18 minutes. The operator accepted that result; the original 60-second
+target was not met. No cold-cache or general sustained-throughput claim is made.
+
+The final PR #82 correction adds a full destination recheck after EOF and before
+flush. It passed regression tests and CI; the physical timing above predates
+that final safety check and has not been remeasured. Neither test qualifies
+physical unplug/power-loss survival, arbitrary USB mount profiles, all compressed
+models, or functional model loading.
+
+See [raw-source evidence](../acceptance/source-identity-usb-2026-09-10.md) and
+[compressed-source performance evidence](../plans/slice-observation-performance.md).
+
+## Upgrade and rollback
+
+Catalog table layout stays at v7. This release reads catalog versions **7 and 8**;
+ordinary open preserves the version. Only explicit serial repair raises the reader
+floor to 8, and affected approvals require fresh review. Do not downgrade that
+stamp to run an older executable.
+
+Private Slice store version 8 and versioned decode-policy approvals are separate
+from catalog versions. Back up the private journals as well as the catalog and
+runtime before updating. Existing approvals retain their policy; use fresh
+previews for the new behavior. An application-only rollback may be insufficient
+after serial repair or creation of newer private Slice records.
+
+Use [Upgrading ModelArk](../upgrading.md) for the complete stopped-writer, backup,
+deployment and rollback boundaries. The release does not automatically deploy,
+repair identities, approve a proposal or start Fill.
+
+## Limits and next work
+
+- Linux and explicitly admitted filesystem capabilities remain required. FAT32
+  files must fit its 2^32−1-byte per-file limit and the qualified mount settings.
+- FAT32 failures after claim consumption leave residue for the operator and
+  require a different new output folder. No automatic cleanup or resume is added.
+- Decoder bounds are shared safety methodology, not a RAM reservation or a promise
+  that every frame below a single size ceiling will decompress successfully.
+- Guided destination selection/mount commands remain deferred (DEF-044).
+- Slice currently delivers **original bytes**. Selecting stored/compressed export,
+  scratch transfer and peer-to-peer serving are future work. The identity and
+  verified-delivery boundaries are intended to support them later.
+
+Start with the [folder workflow](../usable-slice-folders.md). Beta is a maturity
+designation, not a relaxation of storage safety or an assertion of universal support.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,7 +6,22 @@ Canonical build order and parked work. **Design rationale** lives in the append-
 
 > Task numbers (`#NN`) are stable cross-reference labels; a live task board may assign its own IDs.
 
-## Public alpha — live; runtime acceptance active
+## 0.4 Beta
+
+DEC-152 establishes the 0.4 Beta line after merged PR #82. Slice folder
+delivery, guarded codecs and explicit serial-evidence repair are implemented.
+A small compressed-source physical USB workflow passed; this is bounded evidence,
+not universal device/model qualification. See the [0.4.0 notes](releases/v0.4.0.md)
+and [release checklist](plans/release-0.4-beta.md).
+
+The 0.4.0 package/runtime identity and release documentation are synchronized.
+Tagging and GitHub pre-release publication are post-merge maintainer steps in the
+release checklist, not evidence of a deployed runtime or authority for live data
+changes. Guided destination onboarding (DEF-044), stored-representation delivery,
+scratch transfer and P2P remain product follow-ons. The older milestones below are
+historical context, not instructions to repeat completed live operations.
+
+## Historical public-alpha launch gates
 
 The external audit's numbered code blockers are fixed, the canonical repository is public, and its
 public-project settings are hardened. Repository publication and archive activation remain separate

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,14 +4,42 @@ ModelArk upgrades application code normally, but it never silently rewrites an e
 schema is older than the installed release. Existing data is migrated through an explicit,
 backup-first, side-by-side procedure so the old runtime remains a usable rollback point.
 
+## The 0.3.x → 0.4.0 Beta boundary
+
+ModelArk 0.4.0 includes the reviewed Slice, guarded-codec and serial-evidence work.
+An ordinary application update preserves an existing v7 or v8 catalog version;
+it does not run serial repair, rewrite archive bytes, approve work or start Fill.
+Pre-v7 catalogs still require the separate provenance migration described below.
+
+Stop all ModelArk writers, retain a consistent backup of the catalog and its
+SQLite sidecars, application/configuration, and private Slice state before updating.
+Slice journals live separately in `~/.local/state/modelark/slice`, not just in the
+configured catalog data directory. Its private store version 8 and new approval
+envelopes require compatible readers; an old executable is not necessarily a
+safe rollback after opening or creating newer Slice state. Preserve the old
+runtime and state together, and do not discard later work to force a downgrade.
+
+Deploy the reviewed release against the same explicit data/state/config paths,
+without automatic Fill resume. Check `modelark --version` reports `0.4.0`, verify
+the installed catalog reader, and review the plan, drives, pending approvals and
+idle Fill state. Stop the portal before using the separately guarded Slice CLI.
+Fresh Slice previews are needed for the new decode policy; existing seals retain
+their old policy and are never silently rewritten.
+
+Only use [explicit serial repair](archive-serial-repair.md) for a proven matching
+legacy condition after its backup/rehearsal and stopped-writer gates. Repair may
+invalidate affected approvals and raises the catalog reader floor to 8. Rolling
+back the application alone after that repair is unsafe. Beta does not remove
+these boundaries or promise compatibility with arbitrary older development builds.
+
 ## Explicit archive serial repair and reader floor 8
 
 Builds carrying the reviewed serial-identity repair support the unchanged catalog
 layout at versions 7 and 8. Normal open leaves the version alone; only explicit
 repair raises the reader floor to 8 atomically with corrected identity evidence.
 This is distinct from the older provenance/table-layout migration below. Verify
-the exact installed build's read-only opener; the original 0.3.3 package version
-alone cannot identify a reader with this capability.
+the exact installed build's read-only opener. Version 0.4.0 carries this support;
+the original 0.3.3 package version alone cannot identify a development build with it.
 
 Follow [archive-serial-repair.md](archive-serial-repair.md) for quiescence, backups,
 copied rehearsal, bound inspection/repair and fresh approvals. Old binaries must
@@ -66,8 +94,8 @@ record behind that public procedure; ordinary upgrades should begin with the liv
 
 | Existing installation | Required action |
 |---|---|
-| Fresh install with no catalog | None. The current schema is created on first use. |
-| Existing catalog already at the current schema | Update/redeploy normally. |
+| Fresh install with no catalog | No migration. A fresh catalog is created at v7; only explicit serial repair raises its reader floor to 8. |
+| Catalog v7 or explicitly repaired v8 moving to 0.4.0 | Follow the 0.4.0 boundary above; preserve private Slice state and do not perform blanket serial repair. |
 | SQLite catalog at schema v1–v6, including catalogs created by the released ModelArk 0.2.0 | Run the one-time provenance migration before starting the new service. |
 | Legacy checkout with DuckDB or pre-canonical runtime layout | Follow [`legacy-cutover.md`](legacy-cutover.md) first; install the `migration` extra when DuckDB conversion is required. |
 

--- a/docs/usable-slice-folders.md
+++ b/docs/usable-slice-folders.md
@@ -6,7 +6,10 @@ public-flow and alias qualification passed. Reviewed merge `16e8b3f` was deploye
 the attended real-source FAT32 USB smoke test passed under the qualified mount profile described
 below. This is evidence for that tested configuration, not arbitrary USB or filesystem support.
 See the [acceptance record](acceptance/source-identity-usb-2026-09-10.md) for live repair,
-raw-source completion and the still-incomplete compressed-source follow-up.
+raw-source completion and the historical compressed-source preflight. The later
+[compressed-source qualification](plans/slice-observation-performance.md) passed
+the twelve-file Snowflake set and records the accepted 80-second fixture result.
+The [0.4.0 Beta notes](releases/v0.4.0.md) summarize current support and limits.
 
 ## Operator workflow
 
@@ -140,8 +143,9 @@ Native partial resume authenticates completed output without requiring its sourc
 
 No private schema migration is added by these v2 envelopes. An older binary rejects them, including
 while checking overlapping ownership; stores with v2 records require the upgraded reader. The
-[C2 tracker](plans/slice-c2-progress.md) separates synthetic implementation qualification from
-the still-required public CLI, live deployment and physical compressed-source acceptance gates.
+[C2 tracker](plans/slice-c2-progress.md) preserves its stage-local qualification history.
+Later public CLI and physical compressed-source qualification are summarized in the
+[0.4.0 notes](releases/v0.4.0.md); release publication still does not deploy a live service.
 
 ## FAT32 session workflow
 
@@ -187,6 +191,14 @@ says export verified, not host transaction committed; committed host status supp
 
 No reformat, permission rewriting, live deployment, archive reconciliation or deliberate media
 removal was performed as part of the native implementation.
+
+## Later compressed-source qualification
+
+The later compressed-source test delivered 12 files / 91,306,390 original bytes
+from a read-only NAS archive to a fresh FAT32 child, with independent hashes and
+exact receipts. See the [performance record](plans/slice-observation-performance.md)
+for timing, reviewed EOF follow-up and the limits of this one tested configuration.
+This does not change FAT32's no-resume rule or qualify physical power loss.
 
 ## Deferred destination onboarding
 

--- a/modelark/__init__.py
+++ b/modelark/__init__.py
@@ -1,3 +1,3 @@
 """modelark — catalog, fetch, and verify open model weights from the Hub."""
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modelark"
-version = "0.3.3"
+version = "0.4.0"
 description = "Catalog, fetch, and verify open model weights across an offline drive library."
 readme = "README.md"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",

--- a/tests/test_release_identity.py
+++ b/tests/test_release_identity.py
@@ -39,3 +39,10 @@ def test_current_release_is_beta_not_alpha():
     assert f"ModelArk {CURRENT_RELEASE} is a public beta" in readme
     assert f"Release: v{CURRENT_RELEASE} Public Beta" in readme
     assert f"ModelArk v{CURRENT_RELEASE} — Public Beta" in release
+
+
+def test_security_support_policy_covers_beta():
+    policy = (ROOT / "SECURITY.md").read_text(encoding="utf-8")
+    assert "During pre-1.0 development, including Beta" in policy
+    assert "security fixes target the latest reviewed `main`" in policy
+    assert "During alpha," not in policy

--- a/tests/test_release_identity.py
+++ b/tests/test_release_identity.py
@@ -1,4 +1,4 @@
-"""Release surfaces must identify one package/runtime artifact line (DEC-095)."""
+"""Release surfaces must identify one package/runtime artifact line (DEC-152)."""
 from __future__ import annotations
 
 import re
@@ -8,7 +8,7 @@ import modelark
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CURRENT_RELEASE = "0.3.3"
+CURRENT_RELEASE = "0.4.0"
 
 
 def _project_version() -> str:
@@ -28,3 +28,14 @@ def test_release_identity_surfaces_agree():
     release = ROOT / "docs" / "releases" / f"v{expected}.md"
     assert release.is_file()
     assert f"ModelArk v{expected}" in release.read_text(encoding="utf-8")
+
+
+def test_current_release_is_beta_not_alpha():
+    metadata = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    release = (ROOT / "docs" / "releases" / f"v{CURRENT_RELEASE}.md").read_text(encoding="utf-8")
+    assert '"Development Status :: 4 - Beta"' in metadata
+    assert '"Development Status :: 3 - Alpha"' not in metadata
+    assert f"ModelArk {CURRENT_RELEASE} is a public beta" in readme
+    assert f"Release: v{CURRENT_RELEASE} Public Beta" in readme
+    assert f"ModelArk v{CURRENT_RELEASE} — Public Beta" in release


### PR DESCRIPTION
## Summary

Prepare **ModelArk 0.4.0 — Public Beta** after merged PR #82, per DEC-152.

- Synchronize package/runtime version, README badge and Beta development classifier.
- Add changelog/release notes covering Slice, guarded codecs, source identity and
  measured physical qualification without claiming universal device/model support.
- Explain catalog versions 7/8 separately from private Slice state and new approval
  envelopes; preserve backup, explicit repair and rollback boundaries.
- Refresh current folder/roadmap/contributor pointers and include public documentation
  in source archives. Historical releases and ledger entries remain unchanged.
- Extend release identity tests to catch Alpha/Beta label drift.

No codec/storage behavior changes, live deployment, catalog/archive/USB mutations,
tag, GitHub release or PyPI publication are performed by this PR. After the operator
merges, rebuild from the actual merge commit before tagging and publishing the
GitHub pre-release. See `docs/plans/release-0.4-beta.md`.

## Validation

- Checkout release/CLI/runtime tests: 8 passed; repository Ruff and diff checks clean.
- Wheel and source archive built; isolated installed CLI reports `modelark 0.4.0`.
- All 132 wheel payload files match source and installed package; packaged SQL,
  portal assets, seed catalog, service unit and Beta metadata verified.
- Source archive contains release documentation and passes both release-identity tests.
- 58 relative link targets checked across eight release-facing Markdown files.
- Disposable installed environment reuses existing development dependencies; this
  does not claim a fresh dependency-resolution or live-service deployment test.
- Full CI must pass this PR's final head.

Local Grok: **ACCEPT on attempt 3/3**. Attempt 1 ended without a verdict;
attempt 2 caught overlapping upgrade guidance, stale roadmap release status and
an overly broad historical-Alpha test. Those and the timing-caveat pointer are
corrected; final review found no remaining blocking findings.

Cloud Codex: first of at most three rounds requested
after publication. No Greptile under the operator's current exclusion. Operator merges.
