### PR TITLE
Fix evidence-bound USB bridge serial repair and placement refusals

### DIFF
--- a/docs/archive-serial-repair.md
+++ b/docs/archive-serial-repair.md
@@ -1,6 +1,6 @@
 # Archive serial-identity repair: attended handoff
 
-This repairs two narrowly proven historical evidence mismatches. In the first,
+This repairs three narrowly proven historical evidence mismatches. In the first,
 the catalog already holds the correct disk
 serial, but an older partition-only observation recorded a `serial: null` archive
 fingerprint. It does not change the saved serial or adopt a different disk.
@@ -12,6 +12,17 @@ serial, UUIDs and capacity. It publishes a new **null-serial** identity/anchor,
 retaining actual observed serial separately as fence evidence. Registration stays
 serial-optional; no catalog serial is filled in. Dirty generations, empty-string
 serials, absent or contradictory proof are outside this second repair case.
+
+In the third, the registered serial is literal text but the current clean anchor
+records its exact ASCII-hex representation from a USB bridge. Both historical
+proofs must agree, and the freshly attached drive must report that exact recorded
+string with both UUIDs and capacity unchanged. Repair retains the registered
+serial, publishes canonical identity plus truthful raw fence evidence, and records
+one explicit transition per epoch. Later reads accept that one proven bridge
+readout through the shared evidence resolver, not through general hex decoding.
+Dirty state, a prior serial repair in the epoch, different fresh spelling or
+changed capacity/epoch are not supported by this third repair. See the
+[bridge repair contract](bridge-serial-repair-plan.md) (DEC-153).
 
 Implementation/review approval is not permission to deploy or repair an operating
 installation. Schedule a separate attended window. Replace the executable,
@@ -76,6 +87,10 @@ attempt for live repair.
 - `observed_serial_clean`: serial-less registration with a proven old serial-bearing
   anchor. `required_live_serial` identifies the historical serial that must match
   fresh observations. Repair keeps catalog serial NULL and does not bridge dirty state.
+- `bridge_encoded_clean`: known serial with exact historical ASCII-hex bridge
+  proofs. `required_live_serial` is the raw encoded spelling that must be freshly
+  observed. Requires both UUIDs and a current clean anchor; no dirty recovery or
+  additional alias registration. A mere reconnect/reconcile does not repair it.
 - `already_correct`: no further identity correction needed.
 - `correct_identity_dirty`: not this legacy transition; use its appropriate
   ordinary recovery path without rewriting proof, fingerprint or owner fields.
@@ -97,6 +112,9 @@ Use the binding from the immediately reviewed inspection of this installation:
 this mode with `--dedicated` or `--accept-drift`; it cannot adopt authority or accept
 changed capacity/identity. Known serial, UUIDs and capacity must match fresh
 attachment-bound observations. Compatible old/new physical locks remain mandatory.
+For `bridge_encoded_clean`, the exact historical raw serial must match; the
+registered literal spelling remains the canonical identity, not a replacement
+for what the hardware actually reported.
 Contention, stale intent, ambiguous topology and failed observations refuse.
 
 Inventory is report-only presence evidence, not full-byte verification. Extras and
@@ -134,6 +152,16 @@ separately. Preserve existing output and completed receipts. Begin with a tiny
 disposable output folder only after physical acceptance is separately approved.
 Software fixtures and copied-catalog rehearsal are not USB qualification or
 permission to format a device.
+
+For a bridge repair, verify a same-bridge read and preserve the raw encoded serial
+in its fence evidence. Slice keeps its existing format: the source gate resolves
+the unique repair transition, then verifies the exact already-sealed clean anchor
+and generation before granting encoded matching. A pre-repair or stale source seal cannot gain this
+permission. Standalone readers without the gate remain strict literal-serial readers.
+This extra proof is optional for ordinary literal/serial-less matching: missing,
+stale or invalid bridge proof grants no encoded-serial permission, but does not
+add a new rule to those ordinary read paths. Existing transaction-level stale-plan
+checks remain mandatory, and rejected serials retain their raw diagnostic evidence.
 
 ## Stop conditions and rollback
 

--- a/docs/bridge-serial-repair-plan.md
+++ b/docs/bridge-serial-repair-plan.md
@@ -1,0 +1,179 @@
+# Evidence-bound USB-bridge serial repair
+
+Status: bounded correction implemented and accepted in the one authorized extra local Grok pass. Cloud review and physical qualification remain required.
+
+## Goal and authority
+
+Repair the known Drive 01 mismatch (`VR1KV4LK` registered versus
+`5652314B56344C4B` historically observed) without changing its registered serial,
+old evidence or archive files. The operator approved the repair, consistent
+consumers and useful refusal messages. A generic serial-alias registry, new
+hardware support or weakened identity checks are not authorized.
+
+Local Grok review is capped at three rounds including design; cloud Codex at
+three rounds after the PR. No Greptile. The operator merges. Live repair follows
+reviewed merge, fresh backup and Drive 01 attachment; no automatic approval or
+Fill start.
+After the three-round stop below, the operator explicitly authorized the bounded
+DEC-154 correction and exactly one additional local review. This does not reset
+the default budget or authorize a fifth local pass.
+
+## Why a fingerprint-only repair is insufficient
+
+The USB bridge can continue reporting the encoded string on every connection.
+Changing only the catalog fingerprint would make the next read reject it again.
+Conversely, accepting the hex encoding of every registered serial would give
+unrelated drives a second accepted serial without drive-specific evidence.
+
+Canonical identity and raw observation must remain distinct. One shared matcher
+must require explicit, drive-bound repair evidence before accepting an alternate
+raw observation. Raw observations must never be rewritten in fence evidence.
+
+## Bounded implementation contract
+
+Use the existing append-only repair transition as the proof, not arbitrary old
+anchors and not a new mutable alias list:
+
+1. Before repair, require the exact current clean anchor, both nonempty UUIDs,
+   registered bounded printable ASCII serial S, and identical strict v1 identity
+   and fence proofs carrying E. E must be exactly the ASCII hex encoding of S
+   (hex-digit case is irrelevant only to recognizing the encoding relationship).
+   The old fingerprint must reproduce exactly with the recorded E and capacity.
+   Dirty recovery is unsupported for this third repair case.
+2. Under the existing controller and compatible physical locks, require a fresh
+   attachment with both UUIDs and capacity unchanged, and raw serial exactly E.
+   Keep full inventory, backup/rehearsal, repeated observation and atomic commit.
+3. Append generation g+1 with operation `serial_identity_repair` and a new clean
+   anchor: canonical identity proof serial S, **raw fence proof serial E**,
+   canonical fingerprint computed with S. Preserve generation g and its anchor.
+   Supersede affected approvals as the existing workflow does.
+4. Subsequent matching may accept only the literal registered S or that exact E.
+   E is authorized only by the validated adjacent transition above, for the same
+   drive label, epoch, both UUIDs, capacity, canonical fingerprint and serial.
+   No case folding of fresh observations, recursive decoding, alternate spelling,
+   unrelated old serials, NULL-serial repairs or hash-only repair authority.
+5. There must be exactly one `serial_identity_repair` record per drive epoch;
+   a previous repair prevents this bridge repair, and ambiguous history cannot
+   grant bridge matching. Resolve the transition through one catalog adapter and validate it with one
+   pure proof checker. Bootstrap/reconciliation and Fill use the same matcher.
+   Reconciliation and later writes retain raw E in fence evidence; later clean
+   generations can refer back to that one explicit transition in the same epoch.
+   This is not a scan for arbitrary old serials. If fresh hardware reports literal
+   S instead, the new raw fence proof honestly records S, not a fabricated E.
+6. Slice already seals source epoch, generation, canonical fingerprint and clean
+   anchor ID. Its source gate resolves authorization only from that unique transition
+   no newer than that sealed source generation, after verifying the exact sealed
+   anchor at exactly the sealed generation against the fresh catalog under the
+   physical fences. To grant encoded-serial matching, current source generation
+   must still equal the sealed one. This is not a new prerequisite for ordinary
+   literal/serial-less reads: absent, stale, malformed or ambiguous bridge proof
+   returns no binding. The reader then follows its original strict rules, while
+   the transaction's existing stale-plan checks remain unchanged.
+   Do not consult a
+   latest alias list or allow evidence added after the sealed generation. Pass
+   the ephemeral validated matching context to the local reader explicitly through
+   an internal trusted adapter seam, never CLI input or serialized alias data. Standalone
+   readers without that context remain literal-only. Raw attachment rechecks
+   still require the unchanged actual device/mount/serial tuple on every boundary.
+
+No new Slice evidence fields or unsealed runtime exception are permitted in
+this repair. The existing immutable anchor reference and exact sealed generation
+are the whole source-side boundary. If review or testing invalidates that proof,
+stop for scope confirmation instead of adding fields or bypasses. Missing or
+changed anchors, newer transitions, or duplicate repair transitions grant no
+bridge permission. Encoded reads without that permission still refuse.
+
+`FenceIdentity` stays strict. The repair locks both old encoded and new canonical
+fingerprint sets; their NULL-serial exclusion key overlaps. Lock aliases are
+exclusion only, never evidence admitting a source or repair.
+
+## Refusals and operator flow
+
+Before repair, approval identifies the affected drive and directs the operator
+to inspect the guarded serial repair, rather than looping through reconciliation.
+Only the exact supported proof gets this diagnostic; unknown inconsistency stays
+unproven. UI rendering uses textContent and includes drive and bounded reason.
+
+After successful repair the old proposal is stale: preview again and let the
+operator approve the resulting exact proposal. Do not auto-start any transfer.
+
+## Verification
+
+- Positive exact historical pair and same-bridge subsequent read/reconcile/Fill.
+- NULL/empty/malformed/duplicate-key proofs, either UUID/capacity/epoch mismatch,
+  dirty generation, missing or unrelated transitions and malformed serials refuse.
+- Never-repaired drives with an encoded-looking observed serial still refuse.
+- A Slice sealed before repair cannot acquire the new observation authority;
+  missing/changed sealed anchor and later-generation transition refuse.
+- Full raw observations and old rows stay intact; both lock sets contend;
+  stale binding, ownership changes and final-observation changes refuse.
+- Backup/rehearsal is retained, failures roll back atomically, archive bytes stay
+  unchanged and affected approvals become superseded, not silently rebound.
+- Existing literal-serial and serial-less tests remain unchanged in meaning,
+  including their low-level read gate after a later clean/dirty generation and
+  separate transaction-level stale-source refusal. Raw diagnostic fingerprints
+  survive an unsuccessful optional bridge lookup.
+
+Baseline: 163 existing pure serial/fence tests passed before implementation.
+
+## Operational limits
+
+This is not generic USB enclosure support. It supports exactly the proven raw
+spelling, not arbitrary hex casing on later connections. Identity epoch or
+capacity changes invalidate the bridge relationship. A different bridge that
+reports the literal registered serial retains the ordinary strict path; a new
+encoded observation or resize on an encoded-only connection requires separate
+explicit investigation, not automatic extension of this repair.
+
+The local 0.4.0 deployment and draft remain unchanged. Physical Drive 01
+qualification happens only after reviewed merge and reconnect. The synthetic
+public Slice test uses real disposable archive/output bytes with synthetic host
+inventory; it is not a physical USB or live archive qualification.
+
+## Review stop — 2026-09-12
+
+Grok rounds 1/2 requested the bounded design closures above; final code round 3
+returned NOT ACCEPT. Its high/medium findings share one cause: optional bridge
+compatibility was inserted as a mandatory verifier for all LocalArchiveReader
+sources. `load_bridge_binding` checks sealed generation/anchor before determining
+whether a bridge transition exists. An ordinary literal-serial source read gate
+therefore refuses after a later clean generation even though its physical
+identity is unchanged. A disposable reproduction passed on the released base
+and failed on this branch. This verifies the source-gate regression, not a claim
+that full execution should ignore its existing stale-plan checks.
+
+Separately, three existing archive-observation tests fail: unsupported serials
+still refuse but `_live_evidence` discards their raw diagnostic fingerprint.
+Those tests pass on the released base. Other targeted batches passed (510-test
+serial family,147-test source/API batch,1 JavaScript test); do not describe the
+whole validation as green. Two CLI parser failures caused by the running live
+singleton passed with test-only socket isolation; the service stayed running.
+
+Recommended correction, pending operator direction after the cap: make bridge
+authority a genuinely optional, fail-closed matching result. Missing/stale/
+ambiguous bridge proof yields no bridge permission, while literal/serial-less
+matching retains its existing behavior and raw diagnostic observation. Enforce
+the exact sealed anchor/generation only before granting encoded-serial matching.
+Do not weaken normal admission, stale-plan checks, locks or proof preservation.
+No new Slice fields or broad architecture rewrite is indicated by these findings.
+
+At that stop, no further implementation fix, fourth local review, PR, push,
+deployment or live repair was performed. The operator subsequently approved the
+bounded correction and one extra review (DEC-154). Review/evidence files are retained under
+`/tmp/modelark-bridge-review.5wGm7t`; cloud review rounds remain zero.
+
+## Authorized correction qualification — 2026-09-12
+
+DEC-154 separates optional bridge permission from ordinary matching. Unsupported
+bridge evidence now returns no binding, and known-serial mismatches retain the
+observed diagnostic fingerprint while remaining unproven. The source gate still
+requires exact sealed evidence before granting encoded matching; all existing
+transaction-level stale-source checks remain in place.
+
+The expanded serial/bridge/bootstrap/mutation/observation/approval/source suite
+passed 638 tests, including the regressions found at the stop. Two pre-existing
+Torch deprecation warnings remain. CLI tests used isolated test-only launch
+sockets without stopping the live portal. Repository-wide ruff and diff checks
+passed. These are disposable/synthetic qualifications, not physical-drive proof.
+Exactly one additional local Grok pass is authorized; review output and later
+cloud status belong in the review artifacts/PR, not a silent budget reset.

--- a/docs/decision_log.md
+++ b/docs/decision_log.md
@@ -3171,3 +3171,50 @@ incidents* — not tasks (those live in the work tracker / HANDOFF notes).
 - `impact`: Follow-up release checklist in claudedocs/HANDOFF.md covers README/badge, package and runtime versions, development-status classifier, changelog, release notes, upgrade guidance, release-identity tests, build verification, Git tag and GitHub release. Preserve supported-platform and operator-attended safety limits; future P2P work remains future work. This decision does not itself publish a release, merge PR #82, deploy a runtime or authorize live-data changes.
 - `docs_updated`: docs/decision_log.md, claudedocs/HANDOFF.md
 - `related`: DEC-083, DEC-091, DEC-095, DEC-151
+
+### INC-065: Historical bridge-encoded identity blocks exact placement approval
+- `id`: INC-065
+- `date`: 2026-09-12
+- `status`: open
+- `triggered_by`: Operator reported DRIVE_IDENTITY_UNPROVEN while approving draft 4c0d2ec8-14e7-4900-8f7a-e016f14e27c9 after the local 0.4.0 upgrade; read-only fence-fact inspection isolated drive-01.
+- `symptom`: Drive 01's baseline-only requirements still participate in approval fencing. Its saved fingerprint does not bind the registered literal serial, and the suggested ordinary reconciliation path also rejects those persisted facts.
+- `root_cause`: The August 29 clean anchor contains raw bridge serial 5652314B56344C4B, the ASCII-hex representation of registered VR1KV4LK. That exact raw serial reproduces the saved fingerprint; registered-literal and NULL forms do not. Strict FenceIdentity supports current/NULL forms, not this historical representation. INC-048/DEC-079 addressed passive drive correlation but did not repair the stored identity evidence or establish a shared active-consumer rule.
+- `blast_radius`: Exact placement approval involving this drive, and subsequent reconciliation/source admission until explicitly repaired. A fingerprint-only rewrite would still leave same-bridge reads failing. This is not a fresh offline disk change, proof of archive loss, or a recurrence of partition-versus-parent serial probing.
+- `why_not_caught_earlier`: Existing repair qualifications covered missing/observed serial bindings but omitted the already-documented bridge-encoding case across approval and actual consumers.
+- `planned_remediation`: DEC-153; bounded design and qualification in docs/bridge-serial-repair-plan.md.
+- `docs_updated`: docs/decision_log.md, docs/bridge-serial-repair-plan.md
+- `related`: INC-048, DEC-079, DEC-133, DEC-148, OUT-003
+
+### OUT-003: Drive 01 identity evidence prevents approving the current Fill proposal
+- `id`: OUT-003
+- `date`: 2026-09-12
+- `status`: open
+- `severity`: Medium
+- `triggered_by`: INC-065
+- `summary`: Operator cannot approve the current exact placement proposal. Duration remains open; the portal is available and Fill is idle. No archive loss was observed, and post-upgrade verification found all 18 catalog tables unchanged before the operator created this new draft.
+- `remediation`: Pending the reviewed explicit repair and physical Drive 01 qualification, followed by a fresh preview and operator approval. Do not bypass fencing or restore an older catalog over the new draft.
+- `detail`: docs/bridge-serial-repair-plan.md
+- `docs_updated`: docs/decision_log.md, docs/bridge-serial-repair-plan.md
+- `related`: INC-065, DEC-153
+
+### DEC-153: Guard bridge-serial repair with explicit evidence and consistent consumers
+- `id`: DEC-153
+- `date`: 2026-09-12
+- `status`: accepted
+- `triggered_by`: Operator approved the scoped repair following INC-065 diagnosis.
+- `decision`: Permit an explicit repair only for the exact supported historical encoding relationship with matching historical proofs, a current clean anchor and fresh attached filesystem/annex UUID and capacity evidence. Preserve registered serial, raw observations, old evidence and archive bytes. Retain backup/rehearsal, inventory, controller/physical fences, final observation and atomic approval invalidation. Require one consistent post-repair matching boundary across approval, reconciliation and reads; generic hexadecimal serial equivalence is not authorized. Report the affected drive and an actionable guarded recovery path.
+- `rationale`: Neither a manual hash rewrite nor global serial normalization repairs the complete contract. Canonical identity and physical readout are different representations; accepting their relationship must remain evidence-bound and must not silently enlarge existing Slice approval authority.
+- `impact`: Proof recognition, repair workflow, shared consumer matching and operator diagnostics. The precise Slice evidence-binding design remains subject to review; a necessary new serialized authority format requires separate scope confirmation. Implement in a fresh PR with the approved bounded local Grok/cloud Codex review cycle, no Greptile. Physical repair follows reviewed merge, fresh backup and Drive 01 reconnection; never automatically approve or start Fill.
+- `docs_updated`: docs/decision_log.md, docs/bridge-serial-repair-plan.md, docs/archive-serial-repair.md
+- `related`: INC-065, OUT-003, DEC-133, DEC-148
+
+### DEC-154: Keep bridge compatibility optional and preserve ordinary observation evidence
+- `id`: DEC-154
+- `date`: 2026-09-12
+- `status`: accepted
+- `triggered_by`: Operator approved the bounded correction and one additional local review after DEC-153's three-round stop; final Grok findings and baseline/branch regression tests exposed an optional-match boundary error.
+- `decision`: Missing, stale, malformed or ambiguous bridge proof grants no encoded-serial matching permission; it must not introduce a new refusal for ordinary literal/serial-less source reads. Apply exact sealed generation/anchor checks only before granting bridge compatibility. Preserve raw observed fingerprints when optional matching fails, retaining unproven identity and all existing admission/fence checks. Catalog access errors remain errors, not permission to assume a match.
+- `rationale`: Failure to establish an optional compatibility relationship is different from failure to observe hardware or satisfy ordinary identity rules. Keeping these outcomes separate avoids both broader serial acceptance and accidental refusal of unaffected reads.
+- `impact`: Shared evidence resolver, bootstrap diagnostic preservation and regressions for ordinary reads plus unchanged stale-plan refusal. No new Slice fields, schema, alias registry or live-data changes. Authorize exactly one additional local Grok correction review, not a reset of the default three-round policy; the already-approved cloud Codex cycle remains capped at three rounds, with no Greptile.
+- `docs_updated`: docs/decision_log.md, docs/bridge-serial-repair-plan.md, docs/archive-serial-repair.md
+- `related`: DEC-153, INC-065

--- a/modelark/drive_bootstrap.py
+++ b/modelark/drive_bootstrap.py
@@ -50,7 +50,7 @@ from modelark.core import db
 from modelark.catalog_versions import SUPPORTED_CATALOG_VERSIONS, SERIAL_REPAIR_CATALOG_VERSION
 from modelark.serial_identity import (
     recognize_legacy_anchor, SerialIdentityUnproven, is_legacy_serial_mismatch,
-    serialless_anchor_serial,
+    serialless_anchor_serial, recognize_bridge_anchor,
 )
 
 # Re-export the typed refusal so operator entry points (the `drive reconcile` CLI) can translate it to a
@@ -83,7 +83,9 @@ class _LiveEvidence:
     disagree within a decision): the stable identifiers, capacity/free, allocation unit, and the
     composite identity fingerprint. ``serial`` remains the actual disk readout;
     ``serial_in_identity`` records whether the catalog binds serial as identity.
-    Successful discovery never silently enriches a serial-less registration."""
+    ``identity_serial`` can be canonical while ``serial`` retains a separately
+    proven bridge readout. Successful discovery never silently enriches a
+    serial-less registration."""
     path: str | None
     fs_uuid: str | None
     annex_uuid: str | None
@@ -94,10 +96,11 @@ class _LiveEvidence:
     fingerprint: str | None
     proven: bool
     serial_in_identity: bool = True
+    identity_serial: str | None = None
 
     def observation(self) -> dm.Observation:
         proof = json.dumps({"v": 1, "fs_uuid": self.fs_uuid, "annex_uuid": self.annex_uuid,
-                            "serial": self.serial if self.serial_in_identity else None},
+                            "serial": (self.identity_serial or self.serial) if self.serial_in_identity else None},
                            sort_keys=True, separators=(",", ":"))
         observed = json.dumps({"v": 1, "fs_uuid": self.fs_uuid, "annex_uuid": self.annex_uuid,
                                "serial": self.serial}, sort_keys=True, separators=(",", ":"))
@@ -166,15 +169,24 @@ def _live_evidence(con, label: str) -> _LiveEvidence:
     from modelark.serial_identity import serial_for_identity
     try:
         identity_serial = serial_for_identity(saved[0] if saved else None, serial)
-    except SerialIdentityUnproven:
+        if saved and saved[0] and saved[0] != serial:
+            from modelark.serial_evidence import bridge_serial_for_observation
+            try:
+                identity_serial = bridge_serial_for_observation(
+                    con, label, fs_uuid, annex_uuid, serial, capacity)
+            except (SerialIdentityUnproven, sqlite3.Error):
+                # Failed optional matching is not a failed observation. Retain
+                # the raw fingerprint and let known_serial_matches refuse it.
+                pass
+    except (SerialIdentityUnproven, sqlite3.Error):
         return _LiveEvidence(str(path), fs_uuid, annex_uuid, serial, capacity,
                              volume.free_bytes, volume.alloc_unit_bytes, None, False)
     fingerprint = capacity_evidence.identity_fingerprint_v1(
         fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=identity_serial, filesystem_capacity_bytes=capacity)
-    known_serial_matches = saved is not None and (not saved[0] or saved[0] == serial)
+    known_serial_matches = saved is not None and (not saved[0] or saved[0] == identity_serial)
     return _LiveEvidence(str(path), fs_uuid, annex_uuid, serial, capacity,
                          volume.free_bytes, volume.alloc_unit_bytes, fingerprint, known_serial_matches,
-                         serial_in_identity=bool(saved and saved[0]))
+                         serial_in_identity=bool(saved and saved[0]), identity_serial=identity_serial)
 
 
 def _annex_keys_present(dest, keys, *, target_uuid) -> set[str]:
@@ -397,10 +409,30 @@ def _serial_repair_state_snapshot(con, label):
                 anchor_capacity_bytes=proof["filesystem_capacity_bytes"],
                 anchor_authority=proof["write_authority"])
         except SerialIdentityUnproven as exc:
-            raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label, reason=str(exc)) from exc
-        status = "legacy_clean" if clean else "legacy_dirty"
+            if not clean or current_anchor is None:
+                raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label, reason=str(exc)) from exc
+            try:
+                correction = recognize_bridge_anchor(
+                    fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=serial, fingerprint=fingerprint,
+                    filesystem_capacity_bytes=capacity, anchor_identity_proof=proof['identity_proof'],
+                    anchor_fence_proof=proof['fence_proof'], anchor_fingerprint=proof['identity_fingerprint'],
+                    anchor_capacity_bytes=proof['filesystem_capacity_bytes'], anchor_authority=proof['write_authority'])
+            except SerialIdentityUnproven as bridge_exc:
+                raise dm.DriveMutationRefused('DRIVE_SERIAL_REPAIR_UNPROVEN', drive=label,
+                                             reason=str(bridge_exc)) from bridge_exc
+            if con.execute("SELECT 1 FROM drive_dirty_generations WHERE drive_label=? AND identity_epoch=? "
+                           "AND operation_code='serial_identity_repair'", [label, epoch]).fetchone():
+                raise dm.DriveMutationRefused('DRIVE_SERIAL_REPAIR_UNPROVEN', drive=label,
+                                             reason='bridge repair requires a unique transition in this epoch')
+            required_serial = correction.observed_serial
+            status = 'bridge_encoded_clean'
+        else:
+            status = "legacy_clean" if clean else "legacy_dirty"
     try:
         keys = FenceIdentity(fs_uuid, annex_uuid, required_serial, capacity, epoch, fingerprint).lock_keys()
+        if status == 'bridge_encoded_clean':
+            keys = tuple(sorted(set(keys) | set(
+                FenceIdentity(fs_uuid, annex_uuid, serial, capacity, epoch, canonical).lock_keys())))
     except UnprovenFenceIdentity as exc:
         raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label, reason=str(exc)) from exc
     return {"catalog_version": version, "drive_label": label, "facts": facts, "metadata": metadata,
@@ -436,11 +468,39 @@ def inspect_serial_identity(con, label: str) -> dict:
             con.execute("ROLLBACK")
 
 
+def bridge_repair_required(con, label):
+    """Diagnostic only; never authorize repair from a refusal message."""
+    try:
+        return inspect_serial_identity(con, label)['status'] == 'bridge_encoded_clean'
+    except (dm.DriveMutationRefused, sqlite3.Error):
+        return False
+
+
 def _serial_live(con, label, state):
-    ev = _live_evidence(con, label)
     facts = state["facts"]
+    if state['status'] == 'bridge_encoded_clean':
+        # This exceptional observation is confined to the explicit guarded
+        # repair. Normal observation cannot use historical proof as admission.
+        path = register.archive_path(con, label)
+        try:
+            volume = register.observe_archive_volume(path) if path is not None else None
+        except BlockObservationError as exc:
+            raise dm.DriveMutationRefused('DRIVE_SERIAL_REPAIR_LIVE_MISMATCH', drive=label) from exc
+        if volume is None:
+            raise dm.DriveMutationRefused('DRIVE_SERIAL_REPAIR_LIVE_MISMATCH', drive=label)
+        ev = _LiveEvidence(str(path), volume.fs_uuid, volume.annex_uuid, volume.serial,
+                           volume.capacity_bytes, volume.free_bytes, volume.alloc_unit_bytes,
+                           capacity_evidence.identity_fingerprint_v1(
+                               fs_uuid=volume.fs_uuid, annex_uuid=volume.annex_uuid, serial=facts[7],
+                               filesystem_capacity_bytes=volume.capacity_bytes),
+                           volume.serial == state['required_live_serial'], identity_serial=facts[7])
+    else:
+        ev = _live_evidence(con, label)
+    required_observation = ev.serial
+    if facts[7] is not None and state['status'] != 'bridge_encoded_clean':
+        required_observation = ev.identity_serial or ev.serial
     if (not ev.proven or not ev.path or ev.fs_uuid != facts[5] or ev.annex_uuid != facts[6]
-            or (state["required_live_serial"] is not None and ev.serial != state["required_live_serial"])
+            or (state["required_live_serial"] is not None and required_observation != state["required_live_serial"])
             or ev.capacity != facts[3]
             or ev.fingerprint != state["canonical_fingerprint"]
             or type(ev.free) is not int or not 0 <= ev.free <= facts[3]):
@@ -484,7 +544,7 @@ def _serial_enrich_locked(con, label, state, final, now):
     """One composite transaction: old clean -> new generation -> new identity -> anchor."""
     from modelark.proposal import bump_revision, supersede_serial_repair_approvals
     _serial_guard(con, label, state)
-    if state["status"] not in {"legacy_clean", "observed_serial_clean"}:
+    if state["status"] not in {"legacy_clean", "observed_serial_clean", "bridge_encoded_clean"}:
         raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label)
     facts = state["facts"]
     generation = dm._advance_one(con, label, "serial_identity_repair", captured=facts)
@@ -574,7 +634,7 @@ def repair_serial_identity(con, label: str, *, expected_binding: str, now,
                 first = _serial_live(con, label, state)
                 if state["status"] == "already_correct":
                     return {**inspect_serial_identity(con, label), "observed_serial": first.serial}
-                if state["status"] not in {"legacy_clean", "legacy_dirty", "observed_serial_clean"}:
+                if state["status"] not in {"legacy_clean", "legacy_dirty", "observed_serial_clean", "bridge_encoded_clean"}:
                     raise dm.DriveMutationRefused("DRIVE_SERIAL_REPAIR_UNPROVEN", drive=label)
                 owner = _capture_recovery_owner(con, label, facts)
                 inventory = _require_complete_inventory(con, label, first.path, progress=progress)
@@ -721,6 +781,9 @@ def reconcile_drive(con, label: str, *, now, dedicated: bool = False, accept_dri
             require_no_live_session(con)
             facts = _persisted(con, label)
             metadata = _reconcile_metadata(con, label)
+            if bridge_repair_required(con, label):
+                raise dm.DriveMutationRefused('DRIVE_SERIAL_REPAIR_REQUIRED', drive=label,
+                                             reason='inspect and explicitly repair the recorded bridge serial first')
             p_epoch, p_gen, p_fp, p_cap, p_auth, p_fs, p_annex, p_serial = facts
             owner = _capture_recovery_owner(con, label, facts)
             ev = _live_evidence(con, label)

--- a/modelark/fetch.py
+++ b/modelark/fetch.py
@@ -721,6 +721,13 @@ def _observe_drive(con, label: str) -> drive_mutation.Observation:
     from modelark.serial_identity import serial_for_identity, SerialIdentityUnproven
     try:
         identity_serial = serial_for_identity(saved[2] if saved else None, ev["serial"])
+        if saved and saved[2] and saved[2] != ev['serial']:
+            from modelark.serial_evidence import bridge_serial_for_observation
+            try:
+                identity_serial = bridge_serial_for_observation(
+                    con, label, ev['fs_uuid'], ev['annex_uuid'], ev['serial'], ev['filesystem_capacity_bytes'])
+            except SerialIdentityUnproven:
+                pass  # Keep the raw mismatch; never fall back to canonical serial.
     except SerialIdentityUnproven:
         return drive_mutation.Observation(
             False, ev["free_bytes"], ev["filesystem_capacity_bytes"], None, "", "",
@@ -737,7 +744,7 @@ def _observe_drive(con, label: str) -> drive_mutation.Observation:
     refusal_code = None
     if saved is None:
         refusal_code = "DRIVE_IDENTITY_UNPROVEN"
-    elif saved[2] and saved[2] != ev["serial"]:
+    elif saved[2] and saved[2] != identity_serial:
         # In particular, the old null-serial fingerprint must not turn failure
         # to confirm a KNOWN physical serial into an accepted identity.
         refusal_code = "DRIVE_IDENTITY_MISMATCH"

--- a/modelark/proposal.py
+++ b/modelark/proposal.py
@@ -1340,6 +1340,14 @@ def _fence_facts(con, labels: Sequence[str]):
             identity = FenceIdentity(*row)
             identity.lock_keys()
         except UnprovenFenceIdentity as exc:
+            from modelark.drive_bootstrap import bridge_repair_required
+            if bridge_repair_required(con, label):
+                raise Refusal(
+                    'DRIVE_SERIAL_REPAIR_REQUIRED',
+                    {'drive': label, 'reason': 'Historical USB-bridge serial evidence needs explicit repair. '
+                     'Attach this drive, inspect serial identity, then use the guarded repair; preview again afterward.'},
+                    ('inspect_serial_identity', 'repair_serial_identity', 'preview_again'),
+                ) from exc
             raise Refusal(
                 "DRIVE_IDENTITY_UNPROVEN",
                 {"drive": label, "reason": str(exc)},

--- a/modelark/serial_evidence.py
+++ b/modelark/serial_evidence.py
@@ -1,0 +1,118 @@
+"""Read-only resolution of the one explicit bridge repair in a drive epoch.
+
+The catalog is trusted append-only evidence, not live hardware proof. A binding
+is ephemeral: consumers must still prove the current attachment and retain their
+normal physical fences. Slice additionally supplies its exact sealed source.
+"""
+from dataclasses import dataclass
+
+from modelark.serial_identity import (
+    SerialIdentityUnproven, _identity_proof, recognize_bridge_anchor,
+)
+
+
+@dataclass(frozen=True)
+class BridgeBinding:
+    fs_uuid: str
+    annex_uuid: str
+    serial: str
+    observed_serial: str
+    capacity: int
+
+    def match(self, fs_uuid, annex_uuid, serial, capacity):
+        if ((fs_uuid, annex_uuid, capacity) != (self.fs_uuid, self.annex_uuid, self.capacity)
+                or type(capacity) is not int or serial not in (self.serial, self.observed_serial)):
+            raise SerialIdentityUnproven('live attachment does not match proven bridge repair')
+        return self.serial
+
+
+def _anchor(con, label, epoch, generation):
+    row = con.execute(
+        'SELECT anchor_id,identity_fingerprint,filesystem_capacity_bytes,write_authority,'
+        'identity_proof,fence_proof FROM drive_clean_anchors '
+        'WHERE drive_label=? AND identity_epoch=? AND generation=?',
+        [label, epoch, generation]).fetchone()
+    if row is None:
+        raise SerialIdentityUnproven('repair or sealed clean anchor missing')
+    return row
+
+
+def load_bridge_binding(con, label, *, sealed_source=None):
+    """Return a proven transition or None; never select an arbitrary old serial.
+
+    Call within a consistent catalog transaction and the consumer's physical
+    fence. Literal matching does not require this optional compatibility proof.
+    A missing/invalid/ambiguous bridge transition must never produce a binding.
+    Such absence is not a refusal of the ordinary literal/serial-less path.
+    """
+    try:
+        return _load_bridge_binding(con, label, sealed_source=sealed_source)
+    except SerialIdentityUnproven:
+        return None
+
+
+def _load_bridge_binding(con, label, *, sealed_source):
+    row = con.execute(
+        'SELECT fs_uuid,annex_uuid,serial,filesystem_capacity_bytes,identity_epoch,'
+        'write_generation,identity_fingerprint,write_authority,lifecycle '
+        'FROM drives WHERE drive_label=?', [label]).fetchone()
+    if row is None:
+        return None
+    fs, annex, serial, capacity, epoch, generation, fingerprint, authority, lifecycle = row
+    if (type(epoch) is not int or epoch < 1 or type(generation) is not int or generation < 1
+            or type(capacity) is not int or capacity <= 0
+            or authority != 'dedicated_local' or lifecycle != 'active'):
+        return None
+    transitions = con.execute(
+        "SELECT generation FROM drive_dirty_generations WHERE drive_label=? "
+        "AND identity_epoch=? AND operation_code='serial_identity_repair' ORDER BY generation",
+        [label, epoch]).fetchall()
+    if len(transitions) != 1:
+        return None
+    repaired = transitions[0][0]
+    if type(repaired) is not int or not 1 < repaired <= generation:
+        return None
+    old = _anchor(con, label, epoch, repaired - 1)
+    new = _anchor(con, label, epoch, repaired)
+    correction = recognize_bridge_anchor(
+        fs_uuid=fs, annex_uuid=annex, serial=serial, fingerprint=old[1],
+        filesystem_capacity_bytes=capacity, anchor_identity_proof=old[4],
+        anchor_fence_proof=old[5], anchor_fingerprint=old[1], anchor_capacity_bytes=old[2],
+        anchor_authority=old[3])
+    canonical = dict(v=1, fs_uuid=fs, annex_uuid=annex, serial=serial)
+    raw = dict(canonical, serial=correction.observed_serial)
+    if (new[1:4] != (correction.new_fingerprint, capacity, authority)
+            or fingerprint != correction.new_fingerprint
+            or _identity_proof(new[4]) != canonical or _identity_proof(new[5]) != raw):
+        raise SerialIdentityUnproven('repair transition does not bind canonical identity and raw observation')
+    # This is an additional condition for GRANTING encoded-serial matching,
+    # not an additional gate on ordinary reads. No binding means literal only.
+    if sealed_source is not None:
+        d, a = sealed_source.drive, sealed_source.anchor
+        if ((label, fs, annex, serial, capacity, epoch, generation, fingerprint, authority, lifecycle)
+                != (d.drive_label, d.fs_uuid, d.annex_uuid, d.serial, d.filesystem_capacity_bytes,
+                    d.identity_epoch, d.write_generation, d.identity_fingerprint,
+                    d.write_authority, d.lifecycle)):
+            raise SerialIdentityUnproven('current drive differs from sealed source')
+        current = _anchor(con, label, epoch, generation)
+        if ((label, epoch, generation, fingerprint, capacity, authority, str(current[0]))
+                != (a.drive_label, a.identity_epoch, a.generation, a.identity_fingerprint,
+                    a.filesystem_capacity_bytes, a.write_authority, a.anchor_id)
+                or current[1:4] != (fingerprint, capacity, authority)):
+            raise SerialIdentityUnproven('exact sealed clean anchor changed')
+    return BridgeBinding(fs, annex, serial, correction.observed_serial, capacity)
+
+
+def bridge_serial_for_observation(con, label, fs_uuid, annex_uuid, serial, capacity):
+    """Resolve an exact registered/observed mismatch without implicit enrichment."""
+    own = not con.in_transaction
+    if own:
+        con.execute('BEGIN')
+    try:
+        binding = load_bridge_binding(con, label)
+        if binding is None:
+            raise SerialIdentityUnproven('no unique proven bridge repair')
+        return binding.match(fs_uuid, annex_uuid, serial, capacity)
+    finally:
+        if own:
+            con.execute('ROLLBACK')

--- a/modelark/serial_identity.py
+++ b/modelark/serial_identity.py
@@ -1,4 +1,4 @@
-"""Pure recognition of the narrowly repairable v1 null-serial anchor (DEC-133).
+"""Pure recognition of narrowly repairable v1 serial anchors (DEC-133/148/153).
 
 Recognition is only one prerequisite for repair. The workflow must independently
 bind the anchor to the exact epoch/generation, prove live media and cleanliness,
@@ -19,6 +19,11 @@ class SerialIdentityUnproven(ValueError):
 class SerialCorrection:
     old_fingerprint: str
     new_fingerprint: str
+
+
+@dataclass(frozen=True)
+class BridgeSerialCorrection(SerialCorrection):
+    observed_serial: str
 
 
 def _normalized_string(value, name, *, optional=False):
@@ -100,6 +105,43 @@ def _identity_proof(text):
     for key in ('fs_uuid', 'annex_uuid', 'serial'):
         _normalized_string(proof[key], 'proof ' + key, optional=True)
     return proof
+
+
+def recognize_bridge_anchor(
+    *, fs_uuid, annex_uuid, serial, fingerprint, filesystem_capacity_bytes,
+    anchor_identity_proof, anchor_fence_proof, anchor_fingerprint,
+    anchor_capacity_bytes, anchor_authority,
+) -> BridgeSerialCorrection:
+    """Recognize one historical ASCII-hex bridge observation, never admit IO.
+
+    Both UUIDs, the exact raw spelling and both strict proofs are required. The
+    workflow must additionally prove the CURRENT clean generation and fresh
+    attachment, hold compatible fences, and revalidate before committing. This
+    is not a general serial-equivalence rule or an authorized observation alias.
+    """
+    _normalized_string(fs_uuid, 'fs_uuid')
+    _normalized_string(annex_uuid, 'annex_uuid')
+    _normalized_string(serial, 'serial')
+    if len(serial) > 128 or any(not 33 <= ord(char) <= 126 for char in serial):
+        raise SerialIdentityUnproven('bridge repair requires bounded printable ASCII serial')
+    _capacity(filesystem_capacity_bytes, 'filesystem_capacity_bytes')
+    _capacity(anchor_capacity_bytes, 'anchor_capacity_bytes')
+    if anchor_capacity_bytes != filesystem_capacity_bytes or anchor_authority != 'dedicated_local':
+        raise SerialIdentityUnproven('anchor capacity or authority disagrees')
+    proof = _identity_proof(anchor_identity_proof)
+    fence = _identity_proof(anchor_fence_proof)
+    if proof != fence or proof['fs_uuid'] != fs_uuid or proof['annex_uuid'] != annex_uuid:
+        raise SerialIdentityUnproven('bridge identity and fence proofs disagree with saved UUIDs')
+    raw = proof['serial']
+    if not isinstance(raw, str) or raw.lower() != serial.encode('ascii').hex():
+        raise SerialIdentityUnproven('proof is not the exact ASCII-hex encoding of registered serial')
+    old = identity_fingerprint_v1(fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=raw,
+                                  filesystem_capacity_bytes=filesystem_capacity_bytes)
+    if fingerprint != old or anchor_fingerprint != old:
+        raise SerialIdentityUnproven('bridge anchor does not reproduce the exact saved identity')
+    new = identity_fingerprint_v1(fs_uuid=fs_uuid, annex_uuid=annex_uuid, serial=serial,
+                                  filesystem_capacity_bytes=filesystem_capacity_bytes)
+    return BridgeSerialCorrection(old, new, raw)
 
 
 def serialless_anchor_serial(*, fs_uuid, annex_uuid, fingerprint,

--- a/modelark/slice/local_source.py
+++ b/modelark/slice/local_source.py
@@ -145,6 +145,8 @@ def _open_content(tree, candidate):
 class LocalArchiveReader:
     """Internal reader with full per-artifact and lightweight per-read attachment proofs."""
 
+    supports_serial_evidence = True
+
     def __init__(self, attachments, *, observer, max_decode_bytes=64 << 20, policy=None):
         self.attachments = {label: canonical_attachment(path)
                             for label, path in attachments.items()}
@@ -153,7 +155,7 @@ class LocalArchiveReader:
         self.policy = policy
 
     @contextmanager
-    def _stored(self, candidate, boundary):
+    def _stored(self, candidate, boundary, serial_evidence=None):
         from .linux import BoundTree
         label = candidate.drive.drive_label
         if label not in self.attachments:
@@ -180,13 +182,15 @@ class LocalArchiveReader:
                 from modelark.serial_identity import serial_for_identity, SerialIdentityUnproven
                 try:
                     identity_serial = serial_for_identity(drive.serial, expected[1])
+                    if drive.serial and expected[1] != drive.serial and serial_evidence is not None:
+                        identity_serial = serial_evidence.match(expected[0], annex, expected[1], expected[2])
                 except SerialIdentityUnproven as exc:
                     raise TransferRefusal("SOURCE_IDENTITY_UNPROVEN", label) from exc
                 fingerprint = identity_fingerprint_v1(
                     fs_uuid=expected[0], annex_uuid=annex, serial=identity_serial,
                     filesystem_capacity_bytes=expected[2])
                 if ((expected[0], expected[2]) != (drive.fs_uuid, drive.filesystem_capacity_bytes)
-                        or (bool(drive.serial) and expected[1] != drive.serial)
+                        or (bool(drive.serial) and identity_serial != drive.serial)
                         or annex != drive.annex_uuid or fingerprint != drive.identity_fingerprint):
                     raise TransferRefusal("SOURCE_CHANGED", label)
                 stream = stack.enter_context(os.fdopen(_open_content(tree, candidate), "rb"))
@@ -222,8 +226,8 @@ class LocalArchiveReader:
             yield _SourceErrors(stream, label, recheck), check
 
     @contextmanager
-    def open(self, candidate, *, check=lambda: None):
-        with self._stored(candidate, check) as (stream, attachment_check):
+    def open(self, candidate, *, check=lambda: None, _serial_evidence=None):
+        with self._stored(candidate, check, _serial_evidence) as (stream, attachment_check):
             decoded = original_stream(stream, compressed=candidate.copy.compressed,
                                       expected_bytes=candidate.copy.orig_bytes,
                                       max_decode_bytes=self.max_decode_bytes,
@@ -236,11 +240,11 @@ class LocalArchiveReader:
                 decoded.close()
 
     @contextmanager
-    def inspect(self, candidate, *, check=lambda: None):
+    def inspect(self, candidate, *, check=lambda: None, _serial_evidence=None):
         from modelark.artifact_preflight import inspect_original
         from modelark.artifact_io import DecodeError
         from modelark.codec_resources import CodecResourceRefusal
-        with self._stored(candidate, check) as (stream, attachment_check):
+        with self._stored(candidate, check, _serial_evidence) as (stream, attachment_check):
             try:
                 inspect_original(stream, compressed=candidate.copy.compressed,
                                  expected_bytes=candidate.copy.orig_bytes,

--- a/modelark/slice/sources.py
+++ b/modelark/slice/sources.py
@@ -1,6 +1,8 @@
 """Read-only source-use gate sharing the archive writer's nonblocking drive fence."""
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, closing, contextmanager
 import json
+from pathlib import Path
+import sqlite3
 
 from modelark import drive_fence
 from modelark.drive_identity import FenceIdentity, UnprovenFenceIdentity
@@ -76,15 +78,31 @@ class FencedSources:
                               if drive.drive_label == candidate.drive.drive_label), None)
                 if fresh is None or identity(fresh) != captured:
                     raise TransferRefusal("SOURCE_EVIDENCE_UNAVAILABLE", "source identity changed")
+                serial_args = {}
+                if getattr(self.reader, 'supports_serial_evidence', False):
+                    from modelark.serial_evidence import load_bridge_binding
+                    from modelark.serial_identity import SerialIdentityUnproven
+                    # No caller-provided alias or serialized extension. Resolve
+                    # only against the exact source anchor already in the seal,
+                    # under these same physical fences and one read transaction.
+                    try:
+                        with closing(sqlite3.connect(
+                                Path(self.catalog_path).resolve().as_uri() + '?mode=ro', uri=True)) as con:
+                            con.execute('BEGIN')
+                            binding = load_bridge_binding(con, candidate.drive.drive_label,
+                                                          sealed_source=candidate)
+                    except (sqlite3.Error, SerialIdentityUnproven) as exc:
+                        raise TransferRefusal('SOURCE_EVIDENCE_UNAVAILABLE', str(exc)) from exc
+                    serial_args['_serial_evidence'] = binding
                 if inspect:
                     from .transaction import _same_source
                     if artifact is None or not _same_source(artifact, candidate, snapshot):
                         raise TransferRefusal("SOURCE_CHANGED", candidate.drive.drive_label)
-                    stream = stack.enter_context(self.reader.inspect(candidate, check=check))
+                    stream = stack.enter_context(self.reader.inspect(candidate, check=check, **serial_args))
                 elif check is not None and getattr(self.reader, "policy", None) is not None:
-                    stream = stack.enter_context(self.reader.open(candidate, check=check))
+                    stream = stack.enter_context(self.reader.open(candidate, check=check, **serial_args))
                 else:
-                    stream = stack.enter_context(self.reader.open(candidate))
+                    stream = stack.enter_context(self.reader.open(candidate, **serial_args))
             except UnprovenFenceIdentity as exc:
                 raise TransferRefusal("SOURCE_EVIDENCE_UNAVAILABLE", str(exc)) from exc
             except drive_fence.FenceUnavailable as exc:

--- a/modelark/web/static/proposal.js
+++ b/modelark/web/static/proposal.js
@@ -13,6 +13,8 @@
   function refusalText(result) {
     if (!result) return "The proposal request failed.";
     const bits = [result.code || result.error || "PROPOSAL_REFUSED"];
+    if (result.evidence && typeof result.evidence.drive === "string") bits.push(result.evidence.drive);
+    if (result.evidence && typeof result.evidence.reason === "string") bits.push(result.evidence.reason);
     if (result.actions && result.actions.length) bits.push(`next: ${result.actions.join(" · ")}`);
     return bits.join(" — ");
   }

--- a/tests/test_bridge_serial_optional.py
+++ b/tests/test_bridge_serial_optional.py
@@ -1,0 +1,50 @@
+"""Optional bridge evidence cannot become a new admission rule for ordinary reads."""
+import pytest
+
+from modelark import drive_bootstrap as bootstrap, drive_mutation as dm
+from modelark.serial_evidence import load_bridge_binding
+from modelark.slice import catalog, domain
+from modelark.slice.transaction import _same_source
+from test_serial_repair_public_slice import (
+    workflow as _workflow, hardware as _hardware, native as _native,
+    _candidate, _sources, PAYLOAD, REPO,
+)
+
+workflow, hardware, native = _workflow, _hardware, _native
+
+
+@pytest.mark.parametrize('workflow', ['canonical', 'serialless'], indirect=True)
+@pytest.mark.parametrize('clean', [False, True])
+def test_ordinary_source_gate_unchanged_without_bridge_permission(workflow, clean):
+    case = workflow
+    candidate = _candidate(case)
+    spec = domain.SliceSpec((REPO,), 'qualification', 'delivery')
+    old = domain.preview(spec, catalog.read_catalog(case.path, spec))
+    generation = dm.begin_generation(case.con, 'drive-00', 'ordinary-write')
+    if clean:
+        observed = bootstrap._live_evidence(case.con, 'drive-00').observation()
+        dm._publish_anchor_locked(case.con, 'drive-00', 1, generation, observed, '2026-09-12')
+    before = tuple(case.con.iterdump())
+    assert load_bridge_binding(case.con, 'drive-00', sealed_source=candidate) is None
+    with _sources(case).open(candidate) as (_, stream):
+        assert stream.read(len(PAYLOAD)) == PAYLOAD
+    # Preserve the separate transaction admission rule: an old plan is still
+    # stale. Restoring ordinary read behavior is not permission to execute it.
+    fresh = catalog.read_catalog(case.path, spec)
+    assert not _same_source(old.closure[0], candidate, fresh)
+    assert tuple(case.con.iterdump()) == before
+
+
+@pytest.mark.parametrize('workflow', ['legacy'], indirect=True)
+def test_other_serial_repair_is_not_bridge_permission_or_read_refusal(workflow):
+    case = workflow
+    intent = bootstrap.inspect_serial_identity(case.con, 'drive-00')
+    bootstrap.repair_serial_identity(case.con, 'drive-00', expected_binding=intent['binding'],
+                                    now='2026-09-12', writers_stopped=True)
+    candidate = _candidate(case)
+    generation = dm.begin_generation(case.con, 'drive-00', 'ordinary-write')
+    observed = bootstrap._live_evidence(case.con, 'drive-00').observation()
+    dm._publish_anchor_locked(case.con, 'drive-00', 1, generation, observed, '2026-09-12')
+    assert load_bridge_binding(case.con, 'drive-00', sealed_source=candidate) is None
+    with _sources(case).open(candidate) as (_, stream):
+        assert stream.read(len(PAYLOAD)) == PAYLOAD

--- a/tests/test_bridge_serial_proof.py
+++ b/tests/test_bridge_serial_proof.py
@@ -1,0 +1,83 @@
+"""Historical encoding recognition is proof-only, not runtime serial equality."""
+import json
+
+import pytest
+
+from modelark.capacity_evidence import identity_fingerprint_v1
+from modelark.serial_identity import (
+    SerialIdentityUnproven, recognize_bridge_anchor, serial_for_identity,
+)
+
+
+SERIAL = 'VR1KV4LK'
+RAW = '5652314B56344C4B'
+
+
+def facts(raw=RAW):
+    proof = json.dumps(dict(v=1, fs_uuid='fs-1', annex_uuid='annex-1', serial=raw))
+    fingerprint = identity_fingerprint_v1(fs_uuid='fs-1', annex_uuid='annex-1',
+                                          serial=raw, filesystem_capacity_bytes=1000)
+    return dict(fs_uuid='fs-1', annex_uuid='annex-1', serial=SERIAL, fingerprint=fingerprint,
+                filesystem_capacity_bytes=1000, anchor_identity_proof=proof,
+                anchor_fence_proof=proof, anchor_fingerprint=fingerprint,
+                anchor_capacity_bytes=1000, anchor_authority='dedicated_local')
+
+
+@pytest.mark.parametrize('raw', [RAW, RAW.lower()])
+def test_exact_pair_recognized_with_raw_spelling_preserved(raw):
+    original = facts(raw)
+    result = recognize_bridge_anchor(**original)
+    assert result.observed_serial == raw
+    assert result.old_fingerprint == original['fingerprint']
+    assert result.new_fingerprint == identity_fingerprint_v1(
+        fs_uuid='fs-1', annex_uuid='annex-1', serial=SERIAL, filesystem_capacity_bytes=1000)
+    assert original == facts(raw)
+    # No standing equality rule: an ordinary observation still carries raw E.
+    assert serial_for_identity(SERIAL, raw) == raw
+
+
+@pytest.mark.parametrize('key,value', [
+    ('fs_uuid', None), ('annex_uuid', None), ('fs_uuid', 'other'), ('annex_uuid', 'other'),
+    ('serial', None), ('serial', ''), ('serial', 'other'), ('serial', RAW),
+    ('serial', 'é'), ('serial', 'a' * 129), ('serial', 'a b'), ('serial', '\ud800'),
+    ('filesystem_capacity_bytes', True), ('filesystem_capacity_bytes', 1000.0),
+    ('filesystem_capacity_bytes', 1001), ('anchor_capacity_bytes', 1001),
+    ('anchor_authority', 'unknown'), ('fingerprint', 'a' * 64),
+    ('anchor_fingerprint', 'b' * 64),
+])
+def test_saved_facts_cannot_be_inferred_or_weakened(key, value):
+    with pytest.raises(SerialIdentityUnproven):
+        recognize_bridge_anchor(**(facts() | {key: value}))
+
+
+@pytest.mark.parametrize('key', ['anchor_identity_proof', 'anchor_fence_proof'])
+@pytest.mark.parametrize('value', [None, '{}', 'null', '[]', '{',
+    '{"v":1,"v":1,"fs_uuid":"fs-1","annex_uuid":"annex-1","serial":"5652314B56344C4B"}',
+    '{"v":NaN,"fs_uuid":"fs-1","annex_uuid":"annex-1","serial":"5652314B56344C4B"}',
+    '[' * 2000 + 'null' + ']' * 2000,
+])
+def test_invalid_proof_refuses(key, value):
+    with pytest.raises(SerialIdentityUnproven):
+        recognize_bridge_anchor(**(facts() | {key: value}))
+
+
+@pytest.mark.parametrize('key', ['anchor_identity_proof', 'anchor_fence_proof'])
+@pytest.mark.parametrize('field,value', [
+    ('v', True), ('v', 1.0), ('v', 2), ('serial', None), ('serial', SERIAL),
+    ('serial', RAW.lower()), ('serial', RAW + '00'), ('serial', ' ' + RAW),
+    ('serial', RAW.encode().hex()), ('serial', 123), ('fs_uuid', 'other'),
+    ('annex_uuid', None), ('extra', True),
+])
+def test_either_proof_mismatch_refuses(key, field, value):
+    changed = facts()
+    proof = json.loads(changed[key])
+    proof[field] = value
+    changed[key] = json.dumps(proof)
+    with pytest.raises(SerialIdentityUnproven):
+        recognize_bridge_anchor(**changed)
+
+
+@pytest.mark.parametrize('raw', [SERIAL, RAW + '00', RAW.encode().hex(), '0x' + RAW])
+def test_two_agreeing_proofs_and_a_matching_hash_do_not_authorize_other_encodings(raw):
+    with pytest.raises(SerialIdentityUnproven):
+        recognize_bridge_anchor(**facts(raw))

--- a/tests/test_bridge_serial_ui.py
+++ b/tests/test_bridge_serial_ui.py
@@ -1,0 +1,27 @@
+"""The actual browser refusal formatter exposes the affected drive safely."""
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+def test_refusal_formatter_reports_drive_and_reason_as_text():
+    node = shutil.which('node')
+    if node is None:
+        pytest.skip('node needed for actual JavaScript formatter test')
+    source = (Path(__file__).resolve().parents[1] / 'modelark/web/static/proposal.js').read_text()
+    function = source[source.index('  function refusalText('):source.index('  function setStartGate(')]
+    result = dict(code='DRIVE_SERIAL_REPAIR_REQUIRED',
+                  evidence=dict(drive='drive-01', reason='<script>historical bridge proof</script>'),
+                  actions=['inspect_serial_identity', 'repair_serial_identity', 'preview_again'])
+    output = subprocess.run([node, '-e', function + '\nconsole.log(refusalText(' + json.dumps(result) + '));'],
+                            capture_output=True, text=True, check=True).stdout
+    assert 'drive-01' in output
+    assert '<script>historical bridge proof</script>' in output
+    assert 'inspect_serial_identity' in output
+    assert 'repair_serial_identity' in output
+    # The formatter returns text, not HTML. Review errors use the text sink.
+    assert 'state.textContent = refusalText(status)' in source
+    assert 'innerHTML = refusalText' not in source

--- a/tests/test_bridge_serial_workflow.py
+++ b/tests/test_bridge_serial_workflow.py
@@ -1,0 +1,218 @@
+"""Real repair and consumers on disposable archives with synthetic host inventory."""
+from dataclasses import replace
+import json
+import sqlite3
+
+import pytest
+
+from modelark import drive_bootstrap as bootstrap, fetch, plan, proposal, register
+from modelark.serial_evidence import load_bridge_binding
+from modelark.slice.local_source import LocalArchiveReader
+from modelark.slice.transaction import TransferRefusal
+from test_serial_repair_public_slice import (
+    workflow as _workflow, hardware as _hardware, native as _native,
+    _candidate, _preview, _complete, _sources, REPO, PAYLOAD,
+)
+
+workflow, hardware, native = _workflow, _hardware, _native
+pytestmark = pytest.mark.parametrize('workflow', ['bridge'], indirect=True)
+
+
+@pytest.fixture
+def bridge(workflow, hardware):
+    case = workflow
+    case.raw = hardware[3]['serial']
+    case.encoded_fp = case.con.execute('SELECT identity_fingerprint FROM drives').fetchone()[0]
+    return case
+
+
+def repair(case):
+    intent = bootstrap.inspect_serial_identity(case.con, 'drive-00')
+    assert intent['status'] == 'bridge_encoded_clean'
+    return bootstrap.repair_serial_identity(case.con, 'drive-00', expected_binding=intent['binding'],
+                                           now='2026-09-12', writers_stopped=True)
+
+
+def corrupt(con, statement):
+    # Deliberately damaged disposable evidence only. Normal fixtures/production
+    # retain these guards; successful repair is tested with append-only triggers.
+    con.execute('DROP TRIGGER drive_clean_anchors_no_update')
+    con.execute('DROP TRIGGER drive_clean_anchors_no_delete')
+    con.execute('DROP TRIGGER drive_dirty_generations_no_update')
+    con.execute(statement)
+
+
+def test_bridge_repair_preserves_history_then_public_slice_completes(bridge):
+    case = bridge
+    before = tuple(case.con.iterdump())
+    old_anchor = case.con.execute('SELECT * FROM drive_clean_anchors').fetchone()
+    assert not bootstrap._live_evidence(case.con, 'drive-00').proven
+    assert not fetch._observe_drive(case.con, 'drive-00').identity_proven
+    with pytest.raises(proposal.Refusal) as refused:
+        proposal._fence_facts(case.con, ['drive-00'])
+    assert refused.value.code == 'DRIVE_SERIAL_REPAIR_REQUIRED'
+    assert refused.value.evidence['drive'] == 'drive-00'
+    assert 'reconcile_drive' not in refused.value.actions
+    with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_REQUIRED'):
+        bootstrap.reconcile_drive(case.con, 'drive-00', now='2026-09-12', dedicated=True)
+    assert tuple(case.con.iterdump()) == before
+
+    result = repair(case)
+
+    assert result['canonical_fingerprint'] == case.canonical
+    assert result['observed_serial'] == case.raw
+    assert result['generation'] == 2
+    assert result['legacy_recovered'] is False
+    assert case.con.execute('SELECT serial FROM drives').fetchone() == (case.serial,)
+    assert case.con.execute('SELECT * FROM drive_clean_anchors WHERE generation=1').fetchone() == old_anchor
+    with sqlite3.connect(result['backup']) as backup:
+        assert tuple(backup.iterdump()) == before
+    identity, fence = case.con.execute(
+        'SELECT identity_proof,fence_proof FROM drive_clean_anchors WHERE generation=2').fetchone()
+    assert json.loads(identity)['serial'] == case.serial
+    assert json.loads(fence)['serial'] == case.raw
+    assert proposal._fence_facts(case.con, ['drive-00'])
+    for observation in (bootstrap._live_evidence(case.con, 'drive-00').observation(),
+                        fetch._observe_drive(case.con, 'drive-00')):
+        assert observation.identity_proven
+        assert observation.fingerprint == case.canonical
+        assert json.loads(observation.identity_proof)['serial'] == case.serial
+        assert json.loads(observation.fence_proof)['serial'] == case.raw
+
+    # Standalone readers have no repair authority. The fenced gate must resolve
+    # the unique transition against the exact source anchor in this new seal.
+    candidate = _candidate(case)
+    with pytest.raises(TransferRefusal, match='SOURCE_CHANGED'):
+        with LocalArchiveReader({'drive-00': case.archive}, observer=case.observer).open(candidate):
+            pytest.fail('unbound reader admitted an encoded serial')
+    with _sources(case).open(candidate) as (_, stream):
+        assert stream.read(len(PAYLOAD)) == PAYLOAD
+    preview = _preview(case, 'bridge-delivery')
+    _complete(case, preview, case.parent / 'bridge-delivery')
+    assert {str(p.relative_to(case.archive)): p.read_bytes()
+            for p in case.archive.rglob('*') if p.is_file()} == case.archive_bytes
+    fresh = bootstrap.inspect_serial_identity(case.con, 'drive-00')
+    assert bootstrap.repair_serial_identity(case.con, 'drive-00', expected_binding=fresh['binding'],
+                                           now='2026-09-12', writers_stopped=True)['status'] == 'already_correct'
+
+
+def test_same_bridge_reconciliation_and_public_fill_approval(bridge):
+    case = bridge
+    repair(case)
+    result = bootstrap.reconcile_drive(case.con, 'drive-00', now='2026-09-12',
+                                       dedicated=True, accept_drift=True)
+    assert result.outcome in {'refreshed', 'drift_accepted'}
+    plan.create(case.con, 'ark', name='Bridge qualification')
+    plan.add_drive(case.con, 'ark', 'drive-00')
+    plan.set_active(case.con, 'ark')
+    case.con.execute('UPDATE models SET numcopies=1')
+    case.con.execute("INSERT INTO selection(repo_id,finalized_at) VALUES(?,'2026-09-12')", [REPO])
+    preview = proposal.preview_pure(case.con, 'ark')
+    assert preview['header']['gate_b_code'] == 'FEASIBLE'
+    draft = proposal.publish_draft(case.con, preview)
+    proposal.approve(case.con, draft['proposal_id'], services=proposal._DefaultServices())
+    assert proposal.load_proposal(case.con, draft['proposal_id'])['lifecycle'] == 'approved'
+
+
+@pytest.mark.parametrize('change', ['dirty', 'other-uuid', 'missing-anchor', 'prior-repair'])
+def test_unsupported_historical_case_refuses_without_changes(bridge, change):
+    case = bridge
+    if change == 'dirty':
+        case.con.execute("INSERT INTO drive_dirty_generations(drive_label,identity_epoch,generation,operation_code) "
+                         "VALUES('drive-00',1,2,'test')")
+        case.con.execute('UPDATE drives SET write_generation=2')
+    elif change == 'other-uuid':
+        case.con.execute("UPDATE drives SET fs_uuid='other'")
+    elif change == 'missing-anchor':
+        corrupt(case.con, 'DELETE FROM drive_clean_anchors')
+    else:
+        corrupt(case.con, "UPDATE drive_dirty_generations SET operation_code='serial_identity_repair'")
+    before = tuple(case.con.iterdump())
+    with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_UNPROVEN'):
+        bootstrap.inspect_serial_identity(case.con, 'drive-00')
+    assert tuple(case.con.iterdump()) == before
+
+
+@pytest.mark.parametrize('field,value', [('serial', 'different'), ('fs_uuid', 'other'),
+                                      ('annex_uuid', 'other'), ('capacity_bytes', 1000)])
+def test_changed_final_attachment_refuses_after_backup(bridge, monkeypatch, field, value):
+    case = bridge
+    original = register.observe_archive_volume
+    calls = []
+
+    def observe(path):
+        calls.append(path)
+        observed = original(path)
+        return replace(observed, **{field: value}) if len(calls) >= 3 else observed
+
+    monkeypatch.setattr(register, 'observe_archive_volume', observe)
+    before = tuple(case.con.iterdump())
+    with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_SERIAL_REPAIR_LIVE_MISMATCH'):
+        repair(case)
+    assert len(calls) >= 3
+    assert tuple(case.con.iterdump()) == before
+
+
+@pytest.mark.parametrize('mutation', [
+    "UPDATE drive_clean_anchors SET anchor_id=anchor_id+20 WHERE generation=2",
+    "UPDATE drive_clean_anchors SET identity_proof='{}' WHERE generation=1",
+    "UPDATE drive_clean_anchors SET fence_proof='{}' WHERE generation=2",
+    "UPDATE drive_dirty_generations SET operation_code='not-a-repair' WHERE generation=2",
+    "INSERT INTO drive_dirty_generations(drive_label,identity_epoch,generation,operation_code) "
+    "VALUES('drive-00',1,3,'serial_identity_repair')",
+])
+def test_sealed_source_cannot_use_changed_or_ambiguous_authority(bridge, mutation):
+    case = bridge
+    repair(case)
+    candidate = _candidate(case)
+    corrupt(case.con, mutation)
+    with pytest.raises(TransferRefusal):
+        with _sources(case).open(candidate):
+            pytest.fail('changed proof admitted source')
+
+
+def test_later_generation_keeps_one_transition_but_old_seal_does_not_rebind(bridge):
+    case = bridge
+    repair(case)
+    old_candidate = _candidate(case)
+    from modelark import drive_mutation as dm
+    generation = dm.begin_generation(case.con, 'drive-00', 'test-later-write')
+    observation = bootstrap._live_evidence(case.con, 'drive-00').observation()
+    assert observation.identity_proven
+    dm._publish_anchor_locked(case.con, 'drive-00', 1, generation, observation, '2026-09-12')
+    assert load_bridge_binding(case.con, 'drive-00', sealed_source=old_candidate) is None
+    with pytest.raises(TransferRefusal):
+        with _sources(case).open(old_candidate):
+            pytest.fail('old sealed generation was rebound')
+    with _sources(case).open(_candidate(case)) as (_, stream):
+        assert stream.read(len(PAYLOAD)) == PAYLOAD
+
+
+@pytest.mark.parametrize('key', ['encoded_fp', 'canonical', 'old'])
+def test_repair_holds_old_canonical_and_null_exclusion_keys(bridge, key):
+    from modelark import drive_fence
+    before = tuple(bridge.con.iterdump())
+    with drive_fence.hold_drives_sorted([(getattr(bridge, key), 1)], blocking=False):
+        with pytest.raises(bootstrap.DriveMutationRefused, match='DRIVE_FENCE_UNAVAILABLE'):
+            repair(bridge)
+    assert tuple(bridge.con.iterdump()) == before
+
+
+def test_literal_bridge_readout_is_recorded_literally_after_repair(bridge, hardware):
+    repair(bridge)
+    hardware[3]['serial'] = bridge.serial
+    observed = bootstrap._live_evidence(bridge.con, 'drive-00').observation()
+    assert observed.identity_proven
+    assert json.loads(observed.fence_proof)['serial'] == bridge.serial
+    assert json.loads(observed.identity_proof)['serial'] == bridge.serial
+    hardware[3]['serial'] = bridge.raw.lower()
+    # Hex-digit case is recognized only in the initial historical proof.
+    # A different fresh spelling is not an automatically authorized alias.
+    if bridge.raw.lower() != bridge.raw:
+        assert not bootstrap._live_evidence(bridge.con, 'drive-00').proven
+
+
+def test_hash_rewrite_without_repair_does_not_authorize_matching(bridge):
+    bridge.con.execute('UPDATE drives SET identity_fingerprint=?', [bridge.canonical])
+    assert not bootstrap._live_evidence(bridge.con, 'drive-00').proven
+    assert not fetch._observe_drive(bridge.con, 'drive-00').identity_proven

--- a/tests/test_serial_repair_public_slice.py
+++ b/tests/test_serial_repair_public_slice.py
@@ -95,8 +95,12 @@ def workflow(tmp_path, monkeypatch, hardware, native, request):
     mode = getattr(request, "param", "legacy")
     stored_serial = None if mode in {"serialless", "observed_serial"} else disk["serial"]
     stored_fp = canonical if mode in {"canonical", "observed_serial"} else old
+    if mode == 'bridge':
+        disk['serial'] = stored_serial.encode('ascii').hex().upper()
+        stored_fp = identity_fingerprint_v1(fs_uuid=leaf['uuid'], annex_uuid=ANNEX,
+                                            serial=disk['serial'], filesystem_capacity_bytes=capacity)
     proof = json.dumps({"v": 1, "fs_uuid": leaf["uuid"], "annex_uuid": ANNEX,
-                        "serial": disk["serial"] if mode in {"canonical", "observed_serial"} else None})
+                        "serial": disk["serial"] if mode in {"canonical", "observed_serial", "bridge"} else None})
     con = sqlite3.connect(db.DB_PATH, isolation_level=None)
     con.executescript(db.SCHEMA_PATH.read_text())
     con.execute("PRAGMA user_version=7")
@@ -120,7 +124,7 @@ def workflow(tmp_path, monkeypatch, hardware, native, request):
     try:
         yield SimpleNamespace(con=con, path=db.DB_PATH, archive=archive, source=source,
                               parent=parent, observer=source_observer, old=old, canonical=canonical,
-                              commands=commands, serial=disk["serial"],
+                              commands=commands, serial=stored_serial if mode == 'bridge' else disk["serial"],
                               archive_bytes={str(p.relative_to(archive)): p.read_bytes()
                                              for p in archive.rglob("*") if p.is_file()})
     finally:


### PR DESCRIPTION
## Summary

Fix the evidence mismatch behind Drive 01's placement-approval refusal: its registered serial is literal text, but its historical clean anchor records the exact ASCII-hex string observed through a USB bridge.

- Extend the existing attended serial repair with strict historical proof, fresh matching hardware, backup/rehearsal, compatible physical locks, and an append-only repair transition.
- Preserve the registered serial, historical anchors, archive bytes, and honest raw fence observations. Do not introduce general hex equivalence or an alias registry.
- Resolve the single proven transition through one shared adapter for reconciliation, Fill, and Slice. Exact Slice sealed evidence gates encoded-serial permission only; ordinary literal/serial-less behavior and separate stale-plan checks remain intact.
- Show the affected drive and guarded repair action in placement refusals instead of an unhelpful reconciliation loop.
- Document the bounded contract, attended recovery, incident, and decisions in the authoritative ledger.

## Verification

- 638 regression tests passed across serial repair, bridge proof/workflow, drive bootstrap/mutation/identity/observation, proposal approval, Slice source/catalog compatibility, and UI behavior.
- Repository-wide `ruff check modelark scripts tests` passed; `git diff --check` passed.
- Built the source archive and wheel from it with `python -m build --no-isolation`; confirmed the new adapter and documentation/tests are packaged.
- Two existing Torch deprecation warnings. Tests used disposable archives and test-only singleton isolation; the live portal stayed running.
- Ordinary-source regression reproduced against the released baseline before correction, then covered alongside encoded-serial refusal and stale-plan checks.

## Safety / rollout

No live catalog or drive changes, no deployment, no automatic approval or Fill start. Physical qualification is still pending. After reviewed merge, use an attended maintenance window, fresh backup, Drive 01 attachment, guarded inspection/repair, and a fresh placement preview. Existing draft/history must not be discarded by restoring an old backup.

## Review process

Local Grok review reached the original three-round cap and stopped on an optional-proof adapter regression. The operator explicitly authorized the bounded correction and exactly one additional local review; this was not a budget reset. Cloud Codex is limited to three rounds. No Greptile. The operator retains merge authority.

The authorized extra Grok pass returned **ACCEPT**, with no blocking correctness/security findings. Its non-blocking runbook sequencing wording was aligned with the reviewed implementation; no code changed after that verdict. Complete local review evidence is retained in `/tmp/modelark-bridge-review.5wGm7t/extra-1-review.md`.
